### PR TITLE
Remove dependency on missing (not required) image files.

### DIFF
--- a/app/gui/qt/Makefile
+++ b/app/gui/qt/Makefile
@@ -195,12 +195,7 @@ compiler_rcc_make_all: qrc_application.cpp
 compiler_rcc_clean:
 	-$(DEL_FILE) qrc_application.cpp
 qrc_application.cpp: application.qrc \
-		images/new.png \
-		images/copy.png \
-		images/cut.png \
-		images/save.png \
-		images/paste.png \
-		images/open.png
+		images/save.png
 	/usr/bin/rcc -name application application.qrc -o qrc_application.cpp
 
 compiler_image_collection_make_all: qmake_image_collection.cpp


### PR DESCRIPTION
images/save.png is still there so I left it in but perhaps this can be removed as well.
