### PR TITLE
Merge the toolbars so the items can be spaced out

### DIFF
--- a/app/gui/qt/mainwindow.cpp
+++ b/app/gui/qt/mainwindow.cpp
@@ -276,7 +276,7 @@ MainWindow::MainWindow(QApplication &app, QSplashScreen &splash) {
   initWorkspace(workspace8);
 
   createActions();
-  createToolBars();
+  createToolBar();
   createStatusBar();
 
   readSettings();
@@ -824,40 +824,28 @@ void MainWindow::createActions()
 
 }
 
-void MainWindow::createToolBars()
+void MainWindow::createToolBar()
 {
 
   QWidget *spacer = new QWidget();
-  spacer->setSizePolicy(QSizePolicy::MinimumExpanding, QSizePolicy::Expanding);
-  spacer->setVisible(true);
+  spacer->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);
 
-  QWidget *spacer2 = new QWidget();
-  spacer2->setSizePolicy(QSizePolicy::MinimumExpanding, QSizePolicy::Expanding);
-  spacer2->setVisible(true);
+  toolBar = addToolBar(tr("Tools"));
 
-  fileToolBar = addToolBar(tr("Run"));
-  saveToolBar = addToolBar(tr("Save"));
-  textSizeToolBar = addToolBar(tr("Text Size"));
-  supportToolBar = addToolBar(tr("Support"));
+  toolBar->setIconSize(QSize(270/3, 111/3));
+  toolBar->addAction(runAct);
+  toolBar->addAction(stopAct);
 
-  fileToolBar->setIconSize(QSize(270/3, 111/3));
-  fileToolBar->addAction(runAct);
-  fileToolBar->addAction(stopAct);
+  toolBar->addAction(saveAsAct);
+  toolBar->addAction(recAct);
+  toolBar->addWidget(spacer);
 
-  saveToolBar->setIconSize(QSize(270/3, 111/3));
-  saveToolBar->addAction(saveAsAct);
-  saveToolBar->addAction(recAct);
-  saveToolBar->addWidget(spacer);
+  toolBar->addAction(textIncAct);
+  toolBar->addAction(textDecAct);
 
-  textSizeToolBar->addWidget(spacer2);
-  textSizeToolBar->setIconSize(QSize(270/3, 111/3));
-  textSizeToolBar->addAction(textIncAct);
-  textSizeToolBar->addAction(textDecAct);
-
-  supportToolBar->setIconSize(QSize(270/3, 111/3));
-  supportToolBar->addAction(infoAct);
-  supportToolBar->addAction(helpAct);
-  supportToolBar->addAction(prefsAct);
+  toolBar->addAction(infoAct);
+  toolBar->addAction(helpAct);
+  toolBar->addAction(prefsAct);
 
 }
 

--- a/app/gui/qt/mainwindow.h
+++ b/app/gui/qt/mainwindow.h
@@ -73,7 +73,7 @@ private:
     void startOSCListener();
     void clearOutputPanels();
     void createActions();
-    void createToolBars();
+    void createToolBar();
     void createStatusBar();
     void readSettings();
     void writeSettings();
@@ -128,11 +128,7 @@ private:
     QMenu *editMenu;
     QMenu *helpMenu;
 
-    QToolBar *fileToolBar;
-    QToolBar *supportToolBar;
-    QToolBar *editToolBar;
-    QToolBar *saveToolBar;
-    QToolBar *textSizeToolBar;
+    QToolBar *toolBar;
 
     QAction *runAct;
     QAction *stopAct;


### PR DESCRIPTION
Too many toolbars.  I merged the toolbars, add them back when you need to move them around.
The problem with multiple toolbars in one toolbar area is that the toolbar area layouting
gives them the minimum space they can work with, so Expanding size policies aren't demanding enough.
