### PR TITLE
Get current directory with `Dir.getwd`.

### DIFF
--- a/app/server/sonicpi/lib/sonicpi/util.rb
+++ b/app/server/sonicpi/lib/sonicpi/util.rb
@@ -67,7 +67,7 @@ module SonicPi
     end
 
     def root_path
-      File.absolute_path("#{File.dirname(__FILE__)}/../../../")
+      File.absolute_path("#{Dir.getwd}/../../../")
     end
 
     def etc_path


### PR DESCRIPTION
Closes #76.

Fixes #root_path approach of getting the current directory name.
