### PR TITLE
Fix 'Error: invalid argument - 0.0' error when rrand arguments have rang...

### DIFF
--- a/app/server/sonicpi/lib/sonicpi/docsystem.rb
+++ b/app/server/sonicpi/lib/sonicpi/docsystem.rb
@@ -12,6 +12,7 @@
 #++
 
 require 'cgi'
+require_relative 'util'
 
 module SonicPi
   module DocSystem

--- a/app/server/sonicpi/lib/sonicpi/spiderapi.rb
+++ b/app/server/sonicpi/lib/sonicpi/spiderapi.rb
@@ -311,6 +311,7 @@ one_in 100 # will return true with a probability of 1/100, false with a probabil
 
 
     def rrand(min, max)
+      return min if min == max
       range = (min - max).abs
       rgen = Thread.current.thread_variable_get :sonic_pi_spider_random_generator
       r = rgen.rand(range.to_f)
@@ -337,6 +338,7 @@ end"]
 
 
     def rrand_i(min, max)
+      return min if min == max
       range = (min - max).abs
       rgen = Thread.current.thread_variable_get :sonic_pi_spider_random_generator
       r = rgen.rand(range.to_i + 1)

--- a/app/server/sonicpi/lib/sonicpi/version.rb
+++ b/app/server/sonicpi/lib/sonicpi/version.rb
@@ -10,6 +10,7 @@
 # and distribution of modified versions of this work as long as this
 # notice is included.
 #++
+$:.unshift File.expand_path("../../../../vendor/osc-ruby/lib", __FILE__)
 require 'osc-ruby'
 
 module SonicPi

--- a/app/server/sonicpi/test/test_spiderapi.rb
+++ b/app/server/sonicpi/test/test_spiderapi.rb
@@ -1,0 +1,30 @@
+#--
+# This file is part of Sonic Pi: http://sonic-pi.net
+# Full project source: https://github.com/samaaron/sonic-pi
+# License: https://github.com/samaaron/sonic-pi/blob/master/LICENSE.md
+#
+# Copyright 2013, 2014 by Sam Aaron (http://sam.aaron.name).
+# All rights reserved.
+#
+# Permission is granted for use, copying, modification, distribution,
+# and distribution of modified versions of this work as long as this
+# notice is included.
+#++
+
+require 'test/unit'
+require_relative "../lib/sonicpi/spiderapi"
+
+module SonicPi
+
+  class SpiderApiTester < Test::Unit::TestCase
+    include SonicPi::SpiderAPI
+
+    def test_rrand_handles_0_range
+      assert_equal(1, rrand(1,1))
+    end
+
+    def test_rrand_i_handles_0_range
+      assert_equal(1, rrand_i(1,1))
+    end
+  end
+end


### PR DESCRIPTION
...e 0 (min == max)

@samaaron Handle cases like rrand(1,1)
