### PR TITLE
silence other functions

### DIFF
--- a/app/server/sonicpi/lib/sonicpi/spiderapi.rb
+++ b/app/server/sonicpi/lib/sonicpi/spiderapi.rb
@@ -33,6 +33,23 @@ module SonicPi
 
 
 
+
+
+
+    def silence(name)
+      raise "could not find #{name} to silence" unless @user_methods.method_defined?(name)
+
+      __info "Silencing #{name}"
+      define(name) do |*args|
+        sleep 1
+      end
+    end
+
+
+
+
+
+
     def after(times, params=nil, &block)
       raise "after must be called with a code block" unless block
 


### PR DESCRIPTION
As discussed in #131 a function to silence other functions.

Simply replaces function definition with a sleep. Must occur after function definition.

It would be possible to remove the ordering dependency by registering a sleep and then using this is scheduling. Maybe thats a nicer approach...
