### PR TITLE
GUI fixes: error message lines, help system, and more

### DIFF
--- a/app/gui/qt/mainwindow.h
+++ b/app/gui/qt/mainwindow.h
@@ -34,6 +34,7 @@ class QMenu;
 class QsciScintilla;
 class QProcess;
 class QTextEdit;
+class QTextBrowser;
 class SonicPiLexer;
 class QString;
 class QSlider;
@@ -87,7 +88,7 @@ private slots:
     void setRPSystemAudioHeadphones();
     void setRPSystemAudioHDMI();
     void showPrefsPane();
-    void updateDocPane(QListWidgetItem *cur, QListWidgetItem *prev);
+    void updateDocPane(QListWidgetItem *cur);
     void serverError(QProcess::ProcessError error);
     void serverFinished(int exitCode, QProcess::ExitStatus exitStatus);
     void replaceBuffer(QString id, QString content);
@@ -141,12 +142,12 @@ private:
     QDockWidget *outputWidget;
     QDockWidget *prefsWidget;
     QDockWidget *docWidget;
-    QTextEdit *tutorialDocPane;
-    QTextEdit *langDocPane;
-    QTextEdit *synthsDocPane;
-    QTextEdit *fxDocPane;
-    QTextEdit *samplesDocPane;
-    QTextEdit *examplesDocPane;
+    QTextBrowser *tutorialDocPane;
+    QTextBrowser *langDocPane;
+    QTextBrowser *synthsDocPane;
+    QTextBrowser *fxDocPane;
+    QTextBrowser *samplesDocPane;
+    QTextBrowser *examplesDocPane;
 
     QTabWidget *tabs;
 

--- a/app/server/sonicpi/lib/sonicpi/spider.rb
+++ b/app/server/sonicpi/lib/sonicpi/spider.rb
@@ -339,6 +339,11 @@ module SonicPi
 
     def __spider_eval(code, info={})
       id = @job_counter.next
+
+      # skip __nosave lines for error reporting
+      firstline = 1
+      firstline -= code.split(/\r?\n/).count{|l| l.include? "#__nosave__"}
+
       job = Thread.new do
         Thread.current.priority = 10
         begin
@@ -362,7 +367,7 @@ module SonicPi
           Thread.current.thread_variable_set :sonic_pi_spider_start_time, now
           @run_start_time = now if num_running_jobs == 1
           __info "Starting run #{id}"
-          eval(code)
+          eval(code, nil, 'eval', firstline)
           __schedule_delayed_blocks_and_messages!
         rescue Exception => e
           __no_kill_block do

--- a/app/server/sonicpi/lib/sonicpi/synthinfo.rb
+++ b/app/server/sonicpi/lib/sonicpi/synthinfo.rb
@@ -3056,6 +3056,7 @@ Choose a lower cutoff to keep more of the bass/mid and a higher cutoff to make t
 
         next if v.is_a? StudioInfo
         doc = ""
+
         doc << '<p> <span style="font-size:25px; color:white;background-color:deeppink;">'
         doc << "<font #{hv_face}>" << v.name << "</font></span></p>\n"
         if klass == SynthInfo
@@ -3077,7 +3078,7 @@ Choose a lower cutoff to keep more of the bass/mid and a higher cutoff to make t
           bg_colour = cnt.even? ? "#5e5e5e" : "#E8E8E8"
           fnt_colour = cnt.even? ? "white" : "#5e5e5e"
           cnt += 1
-          arglist << "<td bgcolor=\"#{bg_colour}\">\n  <pre><h4><font color=\"#{fnt_colour}\">#{ak}: </font></h4</pre>\n</td>\n<td bgcolor=\"#{bg_colour}\">\n  <pre><h4><font color=\"#{fnt_colour}\">#{av[:default]}</font></h4></pre>\n</td>\n"
+          arglist << "<td bgcolor=\"#{bg_colour}\">\n  <pre><h4><font color=\"#{fnt_colour}\"><a href=\"##{ak}\" style=\"text-decoration:none; color: #{fnt_colour};\">#{ak}:</a> </font></h4</pre>\n</td>\n<td bgcolor=\"#{bg_colour}\">\n  <pre><h4><font color=\"#{fnt_colour}\">#{av[:default]}</font></h4></pre>\n</td>\n"
         end
         arglist << "</tr></table>\n"
         doc << arglist
@@ -3098,6 +3099,7 @@ Choose a lower cutoff to keep more of the bass/mid and a higher cutoff to make t
           cnt += 1
           background_colour = cnt.even? ? "#F8F8F8" : "#E8E8E8"
           key_bg_colour = cnt.even? ? "#E6F0FF" : "#B2D1FF"
+          doc << " <a name=\"#{ak}\"></a>\n"
           doc << "  <tr bgcolor=\"#{background_colour}\">\n"
           doc << "    <td bgcolor=\"#{key_bg_colour}\"><h3><pre> #{ak}:</pre></h3></td>\n"
           doc << "      <td>\n"

--- a/etc/doc/tutorial/21-Conclusions.md
+++ b/etc/doc/tutorial/21-Conclusions.md
@@ -2,7 +2,7 @@
 
 This concludes the Sonic Pi introductory tutorial. Hopefully you've learned something along the way. Don't worry if you feel you didn't understand everything - just play and have fun and you'll pick things up along the way. Feel free to dive back in when you have a question that might be covered in one of the sections.
 
-If you have any questions that haven't been covered in the tutorial, then please jump onto the Sonic Pi forums http://groups.google.com/group/sonic-pi/ and ask your question there. You'll find someone friendly and willing to lend a hand. 
+If you have any questions that haven't been covered in the tutorial, then please jump onto the Sonic Pi forums <a href="http://groups.google.com/group/sonic-pi/">http://groups.google.com/group/sonic-pi/</a> and ask your question there. You'll find someone friendly and willing to lend a hand. 
 
 Finally, I also invite you to take a deeper look at the rest of the documentation in this help system. There are a number of features that haven't been covered in this tutorial that are waiting for your discovery. 
 


### PR DESCRIPTION
- fix line number offset in error messages
  - count number of #**nosave** lines and pass 1-count to eval as first
    line number
- CRLF line endings on Windows when saving file
- Make links in info clickable (Tutorial 21 Google Group link)
  - use QTextBrowser instead of QTextEdit, setOpenExternalLinks(true)
- Make synth arg table entries link to their anchor tags
  - add anchor tags and styling in synthinfo.rb
- allow reselecting help entry after switching tabs
  - use itemPressed instead of itemSelectionChanged
- don't select all when running a workspace
  - do select all, but also setReadOnly for half a second while
    highlighting
