### PR TITLE
make links in Info pane clickable

### DIFF
--- a/COMMUNITY.md
+++ b/COMMUNITY.md
@@ -5,26 +5,26 @@ Sonic Pi is more than just software. It's a whole community of people sharing id
 You can find other members at the following locations:
 
 ## Raspberry Pi
-*http://raspberrypi.org*
+*<http://raspberrypi.org>*
 
 The best place to access the latest resources, lesson plans, starter tutorials and information about Sonic Pi.
 
 ## Google Groups
-*https://groups.google.com/forum/#!forum/sonic-pi*
+*<https://groups.google.com/forum/#!forum/sonic-pi>*
 
 A mailing list/forum for people to share thoughts, advice, knowledge with each other. An excellent place to go to ask any questions you might have.
 
 ## Twitter
-*http://twitter.com/sonic_pi*
+*<http://twitter.com/sonic_pi>*
 
 For bite-sized chunks of the latest Sonic Pi news and information.
 
 ## Facebook
-*https://www.facebook.com/SonicPi*
+*<https://www.facebook.com/SonicPi>*
 
 For those Facebook users out there.
 
 ## GitHub
-*http://github.com/samaaron/sonic-pi*
+*<http://github.com/samaaron/sonic-pi>*
 
 For developers interested in the full source code. The issue tracker is also hosted here.

--- a/app/gui/qt/mainwindow.cpp
+++ b/app/gui/qt/mainwindow.cpp
@@ -298,12 +298,12 @@ MainWindow::MainWindow(QApplication &app, QSplashScreen &splash) {
   initDocsWindow();
 
 
-  infoPane = new QTextEdit;
-  infoPane->setReadOnly(true);
+  infoPane = new QTextBrowser;
+  infoPane->setOpenExternalLinks(true);
   infoPane->setFixedSize(550, 650);
   QString html;
 
-  infoPane->setHtml("<center><img src=\":/images/logo.png\" height=\"298\" width=\"365\"><pre><font size=\"4\"><font color=\"DeepPink\">A Sound Synthesiser<br>for Live Coding</font><br><br>Designed and developed by Sam Aaron<br>in Cambridge, England<br><br><font color=\"DeepPink\">http://sonic-pi.net</font><br><br>For the latest updates follow<br><font color=\"DeepPink\">@sonic_pi<br></font></font></pre><h2><pre><font color=\"#3C3C3C\"><pre>music_as <font color=\"DeepPink\">:code</font><br>code_as <font color=\"DeepPink\">:art</font></pre></h2><pre><font size=\"4\"><br>v2.0.1</font></pre></center>");
+  infoPane->setHtml("<center><img src=\":/images/logo.png\" height=\"298\" width=\"365\"><pre><font size=\"4\"><font color=\"DeepPink\">A Sound Synthesiser<br>for Live Coding</font><br><br>Designed and developed by Sam Aaron<br>in Cambridge, England<br><br><font color=\"DeepPink\"><a href=\"http://sonic-pi.net\" style=\"text-decoration: none; color:DeepPink\">http://sonic-pi.net</a></font><br><br>For the latest updates follow<br><font color=\"DeepPink\"><a href=\"http://twitter.com/sonic_pi\" style=\"text-decoration: none; color:DeepPink;\">@sonic_pi</a><br></font></font></pre><h2><pre><font color=\"#3C3C3C\"><pre>music_as <font color=\"DeepPink\">:code</font><br>code_as <font color=\"DeepPink\">:art</font></pre></h2><pre><font size=\"4\"><br>v2.0.1</font></pre></center>");
 
 
 #if defined(Q_OS_MAC)
@@ -338,8 +338,8 @@ MainWindow::MainWindow(QApplication &app, QSplashScreen &splash) {
   QString s;
   QTextStream st(&file);
   s.append(st.readAll());
-  QTextEdit *historyT = new QTextEdit;
-  historyT->setReadOnly(true);
+  QTextBrowser *historyT = new QTextBrowser;
+  historyT->setOpenExternalLinks(true);
   historyT->setHtml(s);
 
   //Contributors
@@ -349,8 +349,8 @@ MainWindow::MainWindow(QApplication &app, QSplashScreen &splash) {
   QString s2;
   QTextStream st2(&file2);
   s2.append(st2.readAll());
-  QTextEdit *contributorsT = new QTextEdit;
-  contributorsT->setReadOnly(true);
+  QTextBrowser *contributorsT = new QTextBrowser;
+  contributorsT->setOpenExternalLinks(true);
   contributorsT->setHtml(s2);
 
   //Community
@@ -360,8 +360,8 @@ MainWindow::MainWindow(QApplication &app, QSplashScreen &splash) {
   QString s3;
   QTextStream st3(&file3);
   s3.append(st3.readAll());
-  QTextEdit *communityT = new QTextEdit;
-  communityT->setReadOnly(true);
+  QTextBrowser *communityT = new QTextBrowser;
+  communityT->setOpenExternalLinks(true);
   communityT->setHtml(s3);
 
 
@@ -925,6 +925,8 @@ void MainWindow::stopCode()
 
 void MainWindow::about()
 {
+  // todo: this is returning true even after the window disappears
+  // Qt::Tool windows get closed automatically when app loses focus
   if(infoWidg->isVisible()) {
     infoWidg->hide();
   } else {

--- a/app/gui/qt/mainwindow.h
+++ b/app/gui/qt/mainwindow.h
@@ -201,7 +201,7 @@ private:
     QAction *aboutQtAct;
     QMap<QString, QString> *map;
 
-    QTextEdit *infoPane;
+    QTextBrowser *infoPane;
     QWidget *infoWidg;
     QTextEdit *startupPane;
     QLabel *imageLabel;

--- a/app/server/bin/qt-doc.rb
+++ b/app/server/bin/qt-doc.rb
@@ -33,6 +33,7 @@ class MarkdownCoverter
     # into Kramdown syntax where necessary
     contents.gsub!(/\`\`\`\`*/, '~~~~')
 
+    # todo: CSS
     contents_html = Kramdown::Document.new(contents).to_html
     contents_html.gsub!(/<h1.*?>/, '<p> <span style="font-size:25px; color:white;background-color:deeppink;">')
     contents_html.gsub!(/<h2.*?>/, '<br><p><span style="font-size:20px; color:white; background-color:dodgerblue;">')
@@ -44,6 +45,7 @@ class MarkdownCoverter
     contents_html.gsub!(/<ul>/, '<ul style="font-size:15px;color:#5e5e5e;">')
 
     contents_html.gsub!(/<code>/, '<code style="font-size:15px; color:deeppink; background-color:white">')
+    contents_html.gsub!(/<a href/, '<a style="text-decoration: none; color:darkorange;" href')
     contents_html = "<font face=\"HelveticaNeue-Light,Helvetica Neue Light,Helvetica Neue\">\n\n" + contents_html + "</font>"
   end
 end


### PR DESCRIPTION
exposes one bug I haven't tracked down yet: the Info dialog disappears if the app loses focus, because it's set as a Tool window.  No problem there, but the Info button tries to toggle its state, and it reports isVisible() as true even after it disappears, so you have to hit Info twice after it disappears to get it back.  Pretty easy to trigger now that links take you to an external browser...
