### PR TITLE
Added QtConcurrent for QtConcurrentRun

### DIFF
--- a/app/gui/qt/SonicPi.pro
+++ b/app/gui/qt/SonicPi.pro
@@ -17,7 +17,7 @@
 #
 #-------------------------------------------------
 
-QT       += core gui
+QT       += core gui concurrent
 
 greaterThan(QT_MAJOR_VERSION, 4): QT += widgets
 


### PR DESCRIPTION
This fixes compilation errors on Ubuntu 14.04.1 (required by mainwindow.cpp)
