### PR TITLE
Added instruction for running under generic linux

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -76,7 +76,9 @@ Compile the server extensions by `cd`ing into the directory `app/server/bin` and
 
 ### Running
 
-Run the script `rb-app-bin` in the directory `app/gui/qt`.
+Start the jack sound server daemon `jackd`. This is easily done through [qjackctl](http://qjackctl.sourceforge.net/), available as `qjackctl` in Debian.
+
+Then run the script `rb-app-bin` in the directory `app/gui/qt`.
 
 ----
 


### PR DESCRIPTION
JACK doesn't start automatically when running the script. Added instructions for starting it manually. 

Configuring JACK for low-latency performance is not difficult, and there are several guides for how to do this online, but I didn't know a good up to date walk-through to point to. The jackaudio [wiki](https://github.com/jackaudio/jackaudio.github.com/wiki) might be a good choice?
