### PR TITLE
pull _slide* args out of doc arg table

### DIFF
--- a/app/server/sonicpi/lib/sonicpi/synthinfo.rb
+++ b/app/server/sonicpi/lib/sonicpi/synthinfo.rb
@@ -3480,8 +3480,8 @@ Choose a lower cutoff to keep more of the bass/mid and a higher cutoff to make t
           doc << "Any parameter that is slidable has three additional parameters named _slide, _slide_curve, and _slide_shape.  For example, 'amp' is slidable, so you can also set amp_slide, amp_slide_curve, and amp_slide_shape with the following effects:"
           slide_args = {
             :_slide => {:default => 0, :doc=>v.generic_slide_doc('parameter')},
-            :_slide_shape => {:default=>0, :doc=>v.generic_slide_shape_doc('parameter')},
-            :_slide_curve => {:default=>5, :doc=>v.generic_slide_curve_doc('parameter')}
+            :_slide_shape => {:default=>5, :doc=>v.generic_slide_shape_doc('parameter')},
+            :_slide_curve => {:default=>0, :doc=>v.generic_slide_curve_doc('parameter')}
           }
 
           # table for slide parameters


### PR DESCRIPTION
Rather than crowding the arg table at the top of each synth/FX with the _slide, _slide_curve, and _slide_shape args, each "slidable" argument now has a note at the bottom with a clickable link to the generic slide documentation.

I would like to add pictures of each of the curves, but I don't think I understand them.  For instance, how many steps does the step curve have?  From my own testing, it seems to just jump to the target value instantly.
