### PR TITLE
Ruby server fails to send large packets to GUI

### DIFF
--- a/app/server/bin/sonic-pi-server.rb
+++ b/app/server/bin/sonic-pi-server.rb
@@ -142,7 +142,7 @@ osc_server.add_method("/ping") do |payload|
   #  puts "ping!"
   begin
     id = payload.to_a[0]
-    m = encoder.encode_single_message("/ack", id)
+    m = encoder.encode_single_message("/ack", [id])
     proxy.send_raw(m)
   rescue Exception => e
     puts "Received Exception when attempting to send ack!"
@@ -303,10 +303,10 @@ out_t = Thread.new do
       else
         case message[:type]
         when :multi_message
-          m = encoder.encode_single_message("/multi_message", message[:jobid], message[:thread_name].to_s, message[:runtime].to_s, message[:val].size, *message[:val].flatten)
+          m = encoder.encode_single_message("/multi_message", [message[:jobid], message[:thread_name].to_s, message[:runtime].to_s, message[:val].size, *message[:val].flatten])
           proxy.send_raw(m)
         when :info
-          m = encoder.encode_single_message("/info", message[:val])
+          m = encoder.encode_single_message("/info", [message[:val]])
           proxy.send_raw(m)
         when :error
           desc = message[:val] || ""
@@ -315,13 +315,13 @@ out_t = Thread.new do
           desc = CGI.escapeHTML(desc)
           trace = CGI.escapeHTML(trace)
           # puts "sending: /error #{desc}, #{trace}"
-          m = encoder.encode_single_message("/error", message[:jobid], desc, trace)
+          m = encoder.encode_single_message("/error", [message[:jobid], desc, trace])
           proxy.send_raw(m)
         when "replace-buffer"
           buf_id = message[:buffer_id]
           content = message[:val]
 #          puts "replacing buffer #{buf_id}, #{content}"
-          m = encoder.encode_single_message("/replace-buffer", buf_id, content)
+          m = encoder.encode_single_message("/replace-buffer", [buf_id, content])
           proxy.send_raw(m)
         else
 #          puts "ignoring #{message}"

--- a/app/server/sonicpi/lib/sonicpi/oscencode.rb
+++ b/app/server/sonicpi/lib/sonicpi/oscencode.rb
@@ -19,7 +19,7 @@ module SonicPi
       @bundle_header = get_from_or_add_to_string_cache("#bundle")
     end
 
-    def encode_single_message(address, *args)
+    def encode_single_message(address, args=[])
       message = ""
       address = get_from_or_add_to_string_cache(address)
       tags = ","
@@ -32,8 +32,8 @@ module SonicPi
       message << address << tags_encoded << args_encoded
     end
 
-    def encode_single_bundle(ts, address, *args)
-      message = encode_single_message(address, *args)
+    def encode_single_bundle(ts, address, args=[])
+      message = encode_single_message(address, args)
       message_encoded = [message.size].pack('N') << message
 
       bundle = ""

--- a/app/server/sonicpi/lib/sonicpi/scsynthexternal.rb
+++ b/app/server/sonicpi/lib/sonicpi/scsynthexternal.rb
@@ -47,14 +47,14 @@ module SonicPi
           if out_job.first == :send
             address, *args = out_job[1]
             log "OSC      ~ #{address} #{args.inspect}" if osc_debug_mode
-            m = encoder.encode_single_message(address, *args)
+            m = encoder.encode_single_message(address, args)
             @client.send_raw(m, @hostname, @port)
           else
             vt = out_job[1]
             ts = out_job[2]
             address, *args = out_job[3]
             log "BDL      ~ [#{vt} : #{ts.to_i}] #{address} #{args.inspect}" if osc_debug_mode
-            b = encoder.encode_single_bundle(ts, address, *args)
+            b = encoder.encode_single_bundle(ts, address, args)
             @client.send_raw(b, @hostname, @port)
           end
         end


### PR DESCRIPTION
## Effect

Very large messages being sent back to the GUI failed with a stack overflow error.
## Fix

Relying on splatting an array into function arguments is limited by the maximum no of possible arguments to a function. Hence very large messages being sent back to the GUI would fail with a stack overflow error.
Making them arrays removes this limitation.
#### Notes

I discovered this while working on the TCP conversion since I've been using very large packet sizes to run tests.
