### PR TITLE
synth_name should be defined before reference

### DIFF
--- a/app/server/sonicpi/lib/sonicpi/mods/sound.rb
+++ b/app/server/sonicpi/lib/sonicpi/mods/sound.rb
@@ -656,6 +656,8 @@ synth :dsaw, note: 50 # Play note 50 of the :dsaw synth with a release of 5"]
 
          n = note(n)
 
+         synth_name = current_synth_name
+
          if n.nil?
            unless Thread.current.thread_variable_get(:sonic_pi_mod_sound_synth_silent)
              __delayed_message "synth #{synth_name.to_sym.inspect}, {note: :rest}"
@@ -663,8 +665,6 @@ synth :dsaw, note: 50 # Play note 50 of the :dsaw synth with a release of 5"]
 
            return nil
          end
-
-         synth_name = current_synth_name
 
          init_args_h = {}
          args_h = resolve_synth_opts_hash_or_array(args)


### PR DESCRIPTION
## What?

Likely due to my own messy Ruby api wrapping around live_loop function I got an error.

```
Error: Thread died: #<NameError: undefined local variable or method `synth_name' for #<SonicPiSpiderUser1:0x007f9f6b38fad8>>
```

I've not been able to replicate just using SonicPi's core functions.

But this still looks like good hygiene since we make a reference to something that is not yet defined.
