### PR TITLE
Add better support for older or weirdly

### DIFF
--- a/app/gui/qt/mainwindow.cpp
+++ b/app/gui/qt/mainwindow.cpp
@@ -1038,7 +1038,7 @@ void MainWindow::setRPSystemAudioHeadphones(){
 #else
   //assuming Raspberry Pi
   QProcess *p = new QProcess();
-  QString prog = "amixer cset numid=3 1";
+  QString prog = "amixer -c 0 cset numid=3 1";
   p->start(prog);
 #endif
 }
@@ -1054,7 +1054,7 @@ void MainWindow::setRPSystemAudioHDMI(){
 #else
   //assuming Raspberry Pi
   QProcess *p = new QProcess();
-  QString prog = "amixer cset numid=3 2";
+  QString prog = "amixer -c 0 cset numid=3 2";
   p->start(prog);
 #endif
 }
@@ -1070,7 +1070,7 @@ void MainWindow::setRPSystemAudioAuto(){
 #else
   //assuming Raspberry Pi
   QProcess *p = new QProcess();
-  QString prog = "amixer cset numid=3 0";
+  QString prog = "amixer -c 0 cset numid=3 0";
   p->start(prog);
 #endif
 }


### PR DESCRIPTION
configured Pis.

By forcing the card number, allows Sonic Pi to better support older versions of Raspbian or other setups like Raspi-LTSP which currently (because of the slightly different soundcard setup) fails to work. This will make sure it uses the default BCM2835 card.
Method added is the exact same method used by Python-games
https://github.com/KenT2/python-games/blob/master/launcher.sh
