### PR TITLE
Add support for chords by degrees

### DIFF
--- a/app/server/sonicpi/lib/sonicpi/chord.rb
+++ b/app/server/sonicpi/lib/sonicpi/chord.rb
@@ -82,6 +82,13 @@ module SonicPi
 
     attr_reader :name, :tonic, :notes
 
+    def self.resolve_degree(degree, tonic, name, no_of_notes)
+      name = name.to_s
+      degree_int = Scale.resolve_degree_index(degree)
+      scale = Scale.new(tonic, name, 2)
+      scale.notes.drop(degree_int).select.with_index{|_, i| i % 2 == 0}.take(no_of_notes)
+    end
+
     def initialize(tonic, name)
       name = name.to_s
       intervals = CHORD[name]

--- a/app/server/sonicpi/lib/sonicpi/mods/sound.rb
+++ b/app/server/sonicpi/lib/sonicpi/mods/sound.rb
@@ -1901,6 +1901,25 @@ play_pattern scale(:C, :lydian_minor)
 
 
 
+       def chord_degree(degree, tonic, scale=:major, number_of_notes=4)
+         Chord.resolve_degree(degree, tonic, scale, number_of_notes)
+       end
+       doc name:          :chord_degree,
+           introduced:    Version.new(2,1,0),
+           summary:       "Construct chords based on scale degrees",
+           doc:           "A helper method that returns a list of midi note numbers when given a degree (a symbol :i,:ii,:iii,:iv,:v :vi, :vii or a number 1-7), tonic, scale and number of notes",
+           args:          [[:degree, :symbol_or_number], [:tonic, :symbol], [:scale, :symbol], [:number_of_notes, :number]],
+           opts:          nil,
+           accepts_block: false,
+           examples:      ["
+puts chord_degree(:i, :A3, :major) # returns a list of midi notes - [69 73 76 80]
+",
+"play chord_degree(:i, :A3, :major)"
+]
+
+
+
+
        def chord(tonic, name=:major, *opts)
          return [] unless tonic
          if tonic.is_a? Array

--- a/app/server/sonicpi/test/test_chord.rb
+++ b/app/server/sonicpi/test/test_chord.rb
@@ -21,5 +21,15 @@ module SonicPi
       assert_equal(Chord.new(:C4, :major), [60, 64, 67])
       assert_equal(Chord.new(60, :major), [60, 64, 67])
     end
+
+    def test_resolution_of_chord_degrees
+      assert_equal(Chord.resolve_degree(:i,   :C4, :major, 3),  [60, 64, 67])
+      assert_equal(Chord.resolve_degree(:ii,  :C4, :major, 3),  [62, 65, 69])
+      assert_equal(Chord.resolve_degree(5,    :D4, :major, 4),  [69, 73, 76,79])
+
+      assert_equal(Chord.resolve_degree(:vii, :D4, :major, 4),  [73, 76,79, 83])
+      assert_equal(Chord.resolve_degree(:vii, :F4, :ionian, 4), [76, 79, 82, 86])
+    end
+
   end
 end


### PR DESCRIPTION
## What

``` ruby
chord_degree(:ii, :A3, :major)
```
## Why?

For those who find it easier to think in scale degrees.
