### PR TITLE
update native extension build process on Windows

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -156,9 +156,13 @@ Packaging:
 * copy `C:\ruby193\*` into `app\server\native\windows`
   - there are some things that can be trimmed, such as docs
 * download a matching DevKit from http://rubyinstaller.org/downloads/
-* make sure CMake, DevKit\bin, and DevKit\mingw\bin are in your path (DevKit doesn't do this automatically since it's not a gem install)
-* Compile native extensions: `ruby app/server/bin/compile-extensions.rb`
-  - if you get a "no Makefiles" error for rugged, you may need to patch app\server\vendor\rugged\ext\rugged\extconf.rb, see https://github.com/jweather/rugged/commit/5fa0cb957ae20faddfa3e3504f122495bbd4e72f
+* `cd app\server\vendor\rugged`
+* `..\..\native\windows\bin\gem build rugged.gemspec`
+* `..\..\native\windows\bin\gem install rugged-0.19.0.gem`
+  - if "Could not create Makefile", check `mkmf.log` to see if it can't find CMake.  If so, try copying the subdirectories under `c:\Program Files (x86)\CMake` to your DevKit directory.  (I couldn't get it to find it using PATH, possibly because DevKit was rewriting it)
+* `cd app\server\vendor\ffi`
+* `..\..\native\windows\bin\gem build ffi.gemspec`
+* `..\..\native\windows\bin\gem install ffi-1.9.6.gem`
 * There is an Advanced Installer config file in `Sonic Pi.aip` for packaging to MSI: http://www.advancedinstaller.com/
 
 ## Unsupported development HTML Interface


### PR DESCRIPTION
Giving up on compile-native-extensions.rb for now... gem install seems to handle the compilation process much more graciously on Windows.  
