### PR TITLE
don't save workspaces that weren't successfully loaded

### DIFF
--- a/app/gui/qt/mainwindow.cpp
+++ b/app/gui/qt/mainwindow.cpp
@@ -769,6 +769,7 @@ void MainWindow::startOSCListener() {
             if (msg->arg().popStr(id).popStr(content).isOkNoMoreArgs()) {
 
               QMetaObject::invokeMethod( this, "replaceBuffer", Qt::QueuedConnection, Q_ARG(QString, QString::fromStdString(id)), Q_ARG(QString, QString::fromStdString(content)));
+	      loaded_workspaces = true;
             } else {
               std::cout << "Server: unhandled replace-buffer: "<< std::endl;
             }
@@ -1513,7 +1514,8 @@ void MainWindow::onExitCleanup()
     std::cout << "Server process is not running, something is up..." << std::endl;
     cont_listening_for_osc = false;
   } else {
-    saveWorkspaces();
+    if (loaded_workspaces)
+      saveWorkspaces();
     sleep(1);
     std::cout << "Asking server process to exit..." << std::endl;
     Message msg("/exit");

--- a/app/gui/qt/mainwindow.h
+++ b/app/gui/qt/mainwindow.h
@@ -149,6 +149,7 @@ private:
     bool osc_incoming_port_open;
     bool is_recording;
     bool show_rec_icon_a;
+    bool loaded_workspaces;
     QTimer *rec_flash_timer;
 
     SonicPiScintilla *textEdit;


### PR DESCRIPTION
I can't figure out how to trigger this, but it just happened to me today -- after a failed startup, all my workspaces contain "#loading".  This patch won't save the workspaces unless we received at least one /replace-buffer message from the server (ie, we loaded them succesfully)
