### PR TITLE
Startup errors

### DIFF
--- a/app/gui/qt/mainwindow.h
+++ b/app/gui/qt/mainwindow.h
@@ -107,6 +107,8 @@ private slots:
     void updateDocPane2(QListWidgetItem *cur, QListWidgetItem *prev);
     void serverError(QProcess::ProcessError error);
     void serverFinished(int exitCode, QProcess::ExitStatus exitStatus);
+    void invokeStartupError(QString msg);
+    void startupError(QString msg);
     void replaceBuffer(QString id, QString content);
     void tabNext();
     void tabPrev();
@@ -146,6 +148,7 @@ private:
 
     bool cont_listening_for_osc;
     bool server_started;
+    bool startup_error_reported;
     bool osc_incoming_port_open;
     bool is_recording;
     bool show_rec_icon_a;


### PR DESCRIPTION
- update server to send startup errors in an argument of the /exited message
- update GUI to report server errors, as well as inability to listen on the OSC port
- this covers several cases with more useful error messages: scsynth still running, ruby still running, Sonic Pi already running, scsynth failed to start
- note that parenting the QProcess to `this` apparently keeps us from shutting down scsynth cleanly on Windows, so that's not an improvement
- startup code should be rewritten for 2.2, especially the sleep(1) in the GUI thread (yuck)
