### PR TITLE
bind Home and End

### DIFF
--- a/app/gui/qt/mainwindow.cpp
+++ b/app/gui/qt/mainwindow.cpp
@@ -545,7 +545,10 @@ void MainWindow::initPrefsWindow() {
   addOtherKeyBinding(settings, QsciCommand::DeleteBack, Qt::Key_Backspace);
 
   addKeyBinding(settings, QsciCommand::Home, Qt::Key_A | SPi_CTRL);
+  addKeyBinding(settings, QsciCommand::VCHome, Qt::Key_Home);
+
   addKeyBinding(settings, QsciCommand::LineEnd, Qt::Key_E | SPi_CTRL);
+  addOtherKeyBinding(settings, QsciCommand::LineEnd, Qt::Key_End);
 
   addKeyBinding(settings, QsciCommand::Delete, Qt::Key_D | SPi_CTRL);
   addKeyBinding(settings, QsciCommand::DeleteLineRight, Qt::Key_K | SPi_CTRL);


### PR DESCRIPTION
Home uses Scintilla's "VCHome" which goes to the first non-whitespace character, then to the beginning of the line if you hit it again.
