### PR TITLE
fix use_sample_path, report expanded path

### DIFF
--- a/app/server/sonicpi/lib/sonicpi/mods/sound.rb
+++ b/app/server/sonicpi/lib/sonicpi/mods/sound.rb
@@ -2265,9 +2265,10 @@ stop bar"]
            partial = path + "/" + sym.to_s
          end
 
-         find_sample_with_path(partial)
+         res = find_sample_with_path(partial)
 
-         raise "No sample exists called :#{sym} in sample pack #{path}"
+         raise "No sample exists called :#{sym} in sample pack #{path} (#{File.expand_path(path)})" unless res
+         res
        end
 
        def arg_h_pp(arg_h)


### PR DESCRIPTION
fix regression in use_sample_path and with_sample_path introduced by 047d4698626afe7ad6fe6eb7220ddce645c86d9b

also logs expanded path if a sample is not found for people trying to make relative sample packs work (they're relative to the Sonic-Pi executable, which may be quite deeply buried)
