### PR TITLE
pulse synths default cutoff is a lamda

### DIFF
--- a/app/server/sonicpi/lib/sonicpi/synthinfo.rb
+++ b/app/server/sonicpi/lib/sonicpi/synthinfo.rb
@@ -614,7 +614,7 @@ module SonicPi
         :sustain_level => 1,
         :env_curve => 2,
 
-        :cutoff => lambda{rrand(95, 105)},
+        :cutoff => 100,
         :cutoff_slide => 0,
         :cutoff_slide_shape => 5,
         :cutoff_slide_curve => 0,


### PR DESCRIPTION
This messes up the documentation of the default value. 
The synth defines cutoff default as a 100 as setting to that.
