### PR TITLE
set maxThreadCount for RPi

### DIFF
--- a/app/gui/qt/mainwindow.cpp
+++ b/app/gui/qt/mainwindow.cpp
@@ -106,7 +106,6 @@ MainWindow::MainWindow(QApplication &app, QSplashScreen* splash)
   connect(rec_flash_timer, SIGNAL(timeout()), this, SLOT(toggleRecordingOnIcon()));
 
   QThreadPool::globalInstance()->setMaxThreadCount(3);
-  std::cout << "maxThreadCount" << QThreadPool::globalInstance()->maxThreadCount() << std::endl;
 
   osc_thread = QtConcurrent::run(this, &MainWindow::startOSCListener);
   server_thread = QtConcurrent::run(this, &MainWindow::startServer);


### PR DESCRIPTION
Allows server and OSC threads to run at the same time.

Closes #250 
