### PR TITLE
Add reset! function

### DIFF
--- a/app/server/sonicpi/lib/sonicpi/spiderapi.rb
+++ b/app/server/sonicpi/lib/sonicpi/spiderapi.rb
@@ -22,6 +22,20 @@ module SonicPi
     include SonicPi::DocSystem
     include SonicPi::Util
 
+	def reset!
+	  set_sched_ahead_time! default_sched_ahead_time
+	  set_control_delta! default_control_delta
+	  set_volume! 1
+	end
+	doc name:		  :reset!,
+        introduced:   Version.new(2, 2, 0),
+        summary:      "Reset set_sched_ahead_time!, set_control_delta! and set_volume! to defaults",
+        args:           [],
+        opts:           {},
+        doc: "Resets set_sched_ahead_time!, set_control_delta_time! and set_volume! to default values for OS in use",
+        examples:     [
+      "reset!"]
+
     def inc(n)
       n + 1
     end


### PR DESCRIPTION
Resets set_sched_ahead_time!  set_delta_time! and set_volume! to their default values for the OS in use.

Useful to put at the start of a new workspace if you are using these commands in another workspace, as the vlaues persist otherwise until explicitly reset or until Sonic Pi is restarted.

(Hope I've got the documentation additions right)

Closes my issue #241
