### PR TITLE
Add function `play_pattern_relative`

### DIFF
--- a/app/server/sonicpi/lib/sonicpi/mods/sound.rb
+++ b/app/server/sonicpi/lib/sonicpi/mods/sound.rb
@@ -934,7 +934,7 @@ play 44"]
                    sleep scaled_note_slide_time
                  else
                    sleep note_time - scaled_note_slide_time
-                   nt.control(note: next_note);
+                   nt.control(note: next_note) if nt
                    sleep scaled_note_slide_time
                  end
                }
@@ -954,7 +954,7 @@ play 44"]
 
                  nt = play(note, combined_args.merge(sustain: scaled_sustain_time, release: scaled_release_time))
                  sleep note_time - scaled_note_slide_time
-                 nt.control(note: next_note);
+                 nt.control(note: next_note) if nt
                  sleep scaled_note_slide_time
                  sleep legato_time
                }

--- a/app/server/sonicpi/lib/sonicpi/mods/sound.rb
+++ b/app/server/sonicpi/lib/sonicpi/mods/sound.rb
@@ -886,6 +886,183 @@ sleep 2
 play 44"]
 
 
+           def play_pattern_relative(notes, times, *args)
+             synth_name = current_synth_name
+
+             init_args_h = {}
+             args_h = resolve_synth_opts_hash_or_array(args)
+
+             sn = synth_name.to_sym
+             info = SynthInfo.get_info(sn)
+
+             defaults = info ? info.arg_defaults : {}
+             combined_args = defaults.merge(args_h)
+             #TODO: figure out a better way of working with lambdas in pattern
+             # e.g. allowing random for every note
+             normalise_args!(combined_args)
+
+             # Other ideas
+             # swing as a percentage of time (see notes below)
+             # degrade as a probability of note playing or not
+
+             nt = nil
+             times = Array(times)
+             notes_with_times = Array(notes.zip(times.cycle))
+             total_time = notes_with_times.map(&:last).reduce(&:+)
+
+             # scaling ADSR as percentages of time
+             #   - attack and decay should be relative to the shortest value to be consistent
+             scaled_attack = times.min.to_f * combined_args[:attack].to_f
+             scaled_decay = times.min.to_f * combined_args[:decay].to_f
+             combined_args[:attack] = scaled_attack
+             combined_args[:decay] = scaled_decay
+
+             if combined_args[:slur].to_f >= 0.5
+               # If user is specifying slur = true, give them a sensible default for note_slide
+               combined_args[:note_slide] ||= 0.2
+
+               notes_with_times.each_with_index {|(note, time), idx|
+                 # legato doesn't make sense when notes are slurred together
+                 note_time = time
+                 scaled_note_slide_time = (combined_args[:note_slide] * note_time)
+                 next_note = note(notes_with_times[(idx + 1) % notes_with_times.length].first)
+
+                 if idx == 0
+                   nt = play(note, combined_args.merge(sustain: total_time, release: 0))
+                   sleep note_time - scaled_note_slide_time
+                   nt.control(note: next_note);
+                   sleep scaled_note_slide_time
+                 else
+                   sleep note_time - scaled_note_slide_time
+                   nt.control(note: next_note);
+                   sleep scaled_note_slide_time
+                 end
+               }
+             elsif combined_args[:note_slide].to_f != 0.0
+               # If they haven't asked for portamento/slides, but have specified slides
+               # then we slide but re-articulate the next note
+               notes_with_times.each_with_index {|(note, time), idx|
+
+                 legato_time = (time - (combined_args[:legato] || 1) * time)
+                 note_time = time - legato_time
+                 time_less_ad = (note_time - combined_args[:attack] - combined_args[:decay])
+                 scaled_sustain_time = time_less_ad.to_f * combined_args[:sustain].to_f
+                 scaled_release_time = time_less_ad.to_f - scaled_sustain_time
+
+                 scaled_note_slide_time = (combined_args[:note_slide] * note_time)
+                 next_note = note(notes_with_times[(idx + 1) % notes_with_times.length].first)
+
+                 nt = play(note, combined_args.merge(sustain: scaled_sustain_time, release: scaled_release_time))
+                 sleep note_time - scaled_note_slide_time
+                 nt.control(note: next_note);
+                 sleep scaled_note_slide_time
+                 sleep legato_time
+               }
+             else
+               notes_with_times.each_with_index {|(note, time), idx|
+                 legato_time = (time - (combined_args[:legato] || 1) * time)
+                 # musical swing is problematic - this would only work for consistent lengths of
+                 # musical beats e.g. every time is 0.5. It won't work with complex rhythms unless
+                 # we develop an awareness of which beat we're currently on
+                 #
+                 # on_beat = ((idx % 2) == 0)
+                 # swing_time = ((combined_args[:swing] || 0) * time)
+                 note_time = time - legato_time
+
+                 time_less_ad = (note_time - combined_args[:attack] - combined_args[:decay])
+                 scaled_sustain_time = time_less_ad.to_f * combined_args[:sustain].to_f
+                 scaled_release_time = time_less_ad.to_f - scaled_sustain_time
+
+                 play(note, combined_args.merge(sustain: scaled_sustain_time, release: scaled_release_time))
+                 # If implementing swing...
+                 # sleep note_time + (on_beat ? swing_time : (swing_time * -1))
+                 # else
+                 sleep note_time
+                 # end
+                 sleep legato_time
+               }
+             end
+           end
+           doc name:          :play_pattern_relative,
+               introduced:    Version.new(2,2,0),
+               summary:       "Play pattern of notes with specific times, scaling their parameters accordingly",
+               doc:           "Play each note in a list of notes one after another with specified times between them. The behaviour is the same as play_pattern_timed but the parameters of each note are changed in the following ways.
+
+    attack and decay: These params are scaled relative to the shortest time in the pattern. This means that `attack: 0.1` makes the attack time 10% of the shortest note in the pattern. Similarly for the decay param. This is to make the attack and decay consistent across all of the notes in the pattern.
+
+    sustain and release: These params are scaled relative to the time of each note, once we've dealt with attack and decay. This means a sustain value of 1 will make the note last right to the end of the given time, but no longer than that. The release param is set to whatever is left of the remaining time that hasn't been used by AD or S.
+
+    legato: This is a new argument that says how long the note will last relative to the time. A value of 1 for legato means the notes will sound for the full time while a value of 0.8 will make the note sound for 80% of the given time. This allows you to create musical legato (values near 1) or staccato (values nearer 0.1) without having to calculate ADSR envelopes for each note length.
+
+    note_slide: if a value for note_slide other than 0.0 is given, play_pattern_relative will automatically slide the pitches between the notes. Again note_slide is scaled relative to the length of the note so note_slide: 0.9 means 90% of the note time is spent sliding to the next pitch in the sequence.
+
+    slur: if we provide a value greater than or equal to 0.5 for the slur param, we get a portamento effect where only the first note in the sequence is articulated and then it slides to the other pitch values. This is a popular effect on many VST synths for creating slippery sounding lines.
+
+    Accepts optional args for modification of the synth being played. See each synth's documentation for synth-specific opts.",
+               args:          [[:notes, :list], [:times, :list_or_number]],
+               opts:          DEFAULT_PLAY_OPTS,
+               accepts_block: false,
+               examples:      ["
+    play_pattern_relative [40, 42, 44, 46], [1, 2, 3], legato: 0.8
+
+    # same as:
+
+    play 40
+    sleep 0.8
+    sleep 0.2 # legato
+    play 42
+    sleep 1.6
+    sleep 0.4 # legato
+    play 44
+    sleep 2.4
+    sleep 0.6 # legato
+    play 46
+
+    #NOTE legato will not work if slur is switched on (>= 0.5)",
+
+      "play_pattern_timed [40, 42, 44, 46, 49], [1, 0.5], attack: 0.1, decay: 0.2, sustain: 0.8
+
+    # same as:
+
+    play 40, attack: 0.05, decay: 0.1, sustain: 0.68, release: 0.17
+    sleep 1
+    play 42, attack: 0.05, decay: 0.1, sustain: 0.28, release: 0.07
+    sleep 0.5
+    play 44, attack: 0.05, decay: 0.1, sustain: 0.68, release: 0.17
+    sleep 1
+    play 46, attack: 0.05, decay: 0.1, sustain: 0.28, release: 0.07
+    sleep 0.5
+    play 49, attack: 0.05, decay: 0.1, sustain: 0.68, release: 0.17",
+
+    "play_pattern_timed [40, 42, 55], [1], note_slide: 0.25
+
+    # same as:
+
+    nt = play 40
+    sleep 0.75
+    control(nt, note: 42)
+    sleep 0.25
+
+    nt = play 42
+    sleep 0.75
+    control(nt, note: 55)
+    sleep 0.25
+
+    play 55
+    sleep 1",
+
+    "play_pattern_timed [40, 42, 55], [1], note_slide: 0.25, slur: 1
+
+    # same as:
+
+    nt = play 40, sustain: 3, release: 0
+    sleep 0.75
+    control(nt, note: 42)
+    sleep 0.25
+
+    sleep 0.75
+    control(nt, note: 55)
+    sleep 0.25"]
 
 
        def play_chord(notes, *args)


### PR DESCRIPTION
This adds a new function that automatically scales and sets params on a
given pattern of notes. It is similar to play pattern timed but the
optional arguments take on slightly different behaviours in order to
give a more musical set of defaults
- `attack` and `decay`: These are scaled to the shortest time in the
  list. `0.1` becomes 10% of the shortest note time and so on. This is
  to maintain a consistent attack across the whole pattern which is
  the obvious choice from a musical perspective
- `sustain` and `release`: Whatever is left of a note length after the
  AD params have been set, `sustain` is again scaled to that length.
  Ergo `sustain: 0.4` would set the sustain to be 40% of the note
  length with the rest being set as release

This function has a few other tricks up its sleeve
- `legato`: a value of 1 means the note sounds for the full length
  (100%) of time specified in the pattern. However, lower values result in more
  staccato sounds by cutting the note short. This gives a lot of
  musical control over the feel of the pattern
- `note_slide`: if this is set, the function will slide the pitch to
  the next note in the pattern. Again this is scaled to the given time
  for a note from 0 to 1 meaning 0 to 100% of the time.
- `slur`: If the `slur` param is `>= 0.5` then the pattern will sound
  as one note that slides to each of the pitches in the given times.
  This is similar to the portamento effect found on many synths
