### PR TITLE
redock floating help window when it is closed

### DIFF
--- a/app/gui/qt/mainwindow.cpp
+++ b/app/gui/qt/mainwindow.cpp
@@ -782,6 +782,7 @@ void MainWindow::about()
 void MainWindow::help()
 {
   if(docWidget->isVisible()) {
+    hidingDocPane = true;
     docWidget->hide();
   } else {
     docWidget->show();
@@ -1428,7 +1429,9 @@ void MainWindow::docScrollDown() {
 void MainWindow::helpClosed(bool visible) {
   if (visible) return;
   // redock on close
-  docWidget->setFloating(false);
+  if (!hidingDocPane)
+    docWidget->setFloating(false);
+  hidingDocPane = false;
 }
 
 void MainWindow::tabNext() {

--- a/app/gui/qt/mainwindow.h
+++ b/app/gui/qt/mainwindow.h
@@ -182,6 +182,7 @@ private:
     QDockWidget *prefsWidget;
     QDockWidget *docWidget;
     QTextBrowser *docPane;
+    bool hidingDocPane;
 
     QTabWidget *tabs;
 


### PR DESCRIPTION
Closes #236 -- I'll leave it up to Sam to decide if this is desired behavior.  Close button on the floating help pane now also re-docks the window.  May be helpful for confused users who can't figure out how to re-dock it.  Advanced users can still use the Help toolbar button to hide/show a floating help window if they wish.
