### PR TITLE
handle accented characters in Windows usernames

### DIFF
--- a/app/server/sonicpi/lib/sonicpi/gitsave.rb
+++ b/app/server/sonicpi/lib/sonicpi/gitsave.rb
@@ -17,6 +17,7 @@ module SonicPi
   class GitSave
 
     def initialize(path)
+      path = path.encode('utf-8')
       @path = path
       begin
         @repo = Rugged::Repository.new(path + '/.git')

--- a/app/server/sonicpi/lib/sonicpi/util.rb
+++ b/app/server/sonicpi/lib/sonicpi/util.rb
@@ -59,7 +59,7 @@ module SonicPi
     end
 
     def home_dir
-      File.expand_path(Dir.home + '/.sonic-pi/')
+      File.expand_path('~/.sonic-pi/')
     end
 
     def project_path


### PR DESCRIPTION
Send UTF-8 paths to Rugged so it can handle Windows usernames with accented characters.  Closes #281 
