### PR TITLE
kill zombie servers on startup for better crash recovery

### DIFF
--- a/app/gui/qt/mainwindow.cpp
+++ b/app/gui/qt/mainwindow.cpp
@@ -111,6 +111,14 @@ MainWindow::MainWindow(QApplication &app, QSplashScreen* splash)
 
   QThreadPool::globalInstance()->setMaxThreadCount(3);
 
+  // kill any zombie processes that may exist
+  // better: test to see if UDP ports are in use, only kill/sleep if so
+  // best: kill SCSynth directly if needed
+  Message msg("/exit");
+  sendOSC(msg);
+  sleep(2);
+
+
   server_thread = QtConcurrent::run(this, &MainWindow::startServer);
 
   OscHandler* handler = new OscHandler(this, this->outputPane, this->errorPane);


### PR DESCRIPTION
send an /exit message in case the Ruby server is still running.  Allows for a clean recovery after a crash.

Would be even better if it checked to see if the port is actually listening.