### PR TITLE
Fix encoding error while building documentation

### DIFF
--- a/app/server/bin/qt-doc.rb
+++ b/app/server/bin/qt-doc.rb
@@ -219,7 +219,7 @@ info_sources.each do |src|
   bn = m[1]
   ext = m[2]
 
-  input = IO.read(input_path)
+  input = IO.read(input_path, :encoding => 'utf-8')
   if ext == "md"
     html = MarkdownConverter.convert(input)
   else


### PR DESCRIPTION
While building on Ubuntu 14.04, the `qt-doc.rb` script fails with:
```
../../server/bin/qt-doc.rb:34:in `gsub!': invalid byte sequence in US-ASCII (ArgumentError)
	from ../../server/bin/qt-doc.rb:34:in `convert'
	from ../../server/bin/qt-doc.rb:224:in `block in <main>'
	from ../../server/bin/qt-doc.rb:214:in `each'
	from ../../server/bin/qt-doc.rb:214:in `<main>'
```