### PR TITLE
fix tutorial path after markdown files were moved to subdir

### DIFF
--- a/app/server/sonicpi/lib/sonicpi/util.rb
+++ b/app/server/sonicpi/lib/sonicpi/util.rb
@@ -100,7 +100,7 @@ module SonicPi
     end
 
     def tutorial_path
-      File.absolute_path("#{doc_path}/tutorial")
+      File.absolute_path("#{doc_path}/tutorial/en")
     end
 
     def tmp_path


### PR DESCRIPTION
The tutorial was moved to en/ in preparation for i18n.

Until then, qt-doc.rb still needs to find them.