### PR TITLE
Add `distribute` to ring functions for "Euclidean" arrays

### DIFF
--- a/app/server/sonicpi/lib/sonicpi/spiderapi.rb
+++ b/app/server/sonicpi/lib/sonicpi/spiderapi.rb
@@ -65,6 +65,42 @@ module SonicPi
       "(knit :e2, 2, :c2, 3) #=> (ring :e2, :e2, :c2, :c2, :c2)"
     ]
 
+    def distribute(accents, total_beats, beat_rotations=0)
+      res = []
+      # if someone requests 9 accents in a bar of 8 beats
+      # default to filling the output with accents
+      return total_beats.times.map { true } if accents > total_beats
+
+      total_beats.times do |i|
+        # makes a boolean based on the index
+        # true is an accent, false is a rest
+        res << ((i * accents % total_beats) < accents)
+      end
+
+      if beat_rotations && beat_rotations.is_a?(Numeric)
+        while beat_rotations.abs > 0 do
+          if res.rotate!.first == true
+            beat_rotations = beat_rotations.abs - 1
+          end
+        end
+
+        res.ring
+      else
+        res.ring
+      end
+    end
+    doc name:           :distribute,
+        introduced:     Version.new(2,4,0),
+        summary:        "Distribute a number of accents evenly across a number of beats",
+        args:           [[:accents, :number], [:total_beats, :number], [:beat_rotations, :number]],
+        opts:           nil,
+        accepts_block:  false,
+        doc:            "Create a new ring of booleans values which space a given number of accents as evenly as possible throughout a bar. This is an implementation of the process described in 'The Euclidean Algorithm Generates Traditional Musical Rhythms' (Toussaint 2005). An optional third argument allows the ring to be rotated to the next strong beat allowing for easy permutations of the orignal rhythmic grouping (see example).",
+        examples:       [
+      "(distribute 5, 13)    #=> (ring true, false, false, true, false, false, true, false, true, false, false, true, false) # groups of  33232",
+      "(distribute 5, 13, 1) #=> (ring true, false, true, false, false, true, false, false, true, false, true, false, false) # groups of 23323 which is the above groupings rotated by 1"
+    ]
+
     def range(start, finish, step_size=1)
       return [] if start == finish
       step_size = step_size.abs


### PR DESCRIPTION
This adds a `distribute` method to produce a ring of evenly spaced beats
in a bar of a given length. This is represented as a ring array of
boolean values. This comes into play mainly when you want a particular
kind of rhythmic pattern (called a Euclidean rhythm in some academic
papers).

To give an example, let's say we want a pattern of 5 bass drum hits in
the space of 16 beats and we'd like to space those as evenly as
possible. That's what `distribute` can do for us:

```ruby
distribute(5, 16) #=> [[true, false, false, false, true, false, false, true, false, false, true, false, false, true, false, false]]
```

That can also be represented like so:

```
x . . . x . . x . . x . . x . .

note 5 x's and 11 dots
5 + 11 = 16
```

or in groups of beats as

```
43333
```

This type of rhythm (evenly spaced through the bar) makes for interesting loops
and is found throughout all kinds of world music e.g.

```
distribute(3,8) #=> [ x . . x . . x . ] # Cuban clave + others
distribute(4,7) #=> [ x . . x . . x . ] # Bulgarian folk
```

This method of producing rhythms is covered at length in the paper ["The Euclidean
Algorithm Generates Traditional Musical Rhythms" (Toussaint
2005)](http://cgm.cs.mcgill.ca/~godfried/publications/banff.pdf)

One last aspect of the `distribute` function is the ability to rotate
the beats via a third optional argument. This works a lot like Ruby's
`Array#rotate` but acts on the groups that form a 'beat'.  This gives an
easy way to get the permutations of the clave rhythm above:

```
distribute(3,8) #=> [ x . . x . . x . ] or groups of 332
distribute(3,8,1) #=> [ x . x . . x . . ] rotate once for groups of 233
distribute(3,8,2) #=> [ x . . x . x . . ] rotate twice for groups of 323
```

This ring of booleans can easily be mapped to a beat like so:

```ruby
clave_beat = distribute(3, 8)
clave_beat.each do |beat|
    sample :drum_bass_hard if beat == true
    sleep 0.25
end
```