### PR TITLE
I18n rebased

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ app/gui/qt/qrc_SonicPi.cpp
 app/gui/qt/ruby_help.h
 app/gui/qt/help/*.html
 app/gui/qt/help_files.qrc
+app/gui/qt/lang/*.qm
 app/gui/qt/qrc_help_files.cpp
 app/gui/qt/Sonic-Pi.app
 app/gui/qt/Sonic Pi.app

--- a/TRANSLATION.md
+++ b/TRANSLATION.md
@@ -1,0 +1,57 @@
+# Translating Sonic Pi
+
+At present, you can translate the tutorial and the Qt GUI, only.
+
+Translations for the tutorial are located in
+[`etc/doc/tutorial`](./etc/doc/tutorial/).
+
+Translations for the Qt GUI are located in
+[`app/gui/qt/lang/sonic-pi_<LANG>.ts`](./app/gui/qt/lang/).
+
+## Translating the tutorial
+
+- Sign up with [github](https://help.github.com/categories/bootcamp/)
+- Fork the [Sonic Pi repo](https://github.com/samaaron/sonic-pi)
+  to your own github repo, `git clone` it to your computer
+- `cd etc/doc/tutorial`
+- Want to add a new language to the tutorial? Then copy the `en/`
+  folder and add the new files to your repo with `git add <NEWLANG>/*.md`
+- When you're happy, `git commit`, `git push` to your github repo.
+- [Send a pull request](https://help.github.com/articles/creating-a-pull-request/) to the Sonic Pi repo.
+
+## Translating the Qt GUI
+
+- Sign up with [github](https://help.github.com/categories/bootcamp/)
+- Fork the [Sonic Pi repo](https://github.com/samaaron/sonic-pi)
+  to your own github repo, `git clone` it to your computer
+- [Build Sonic Pi](./INSTALL.md),
+  first the server extensions, then the Qt GUI.
+- `cd app/gui/qt`
+- Want to add a new language to the Qt GUI? Then first add a reference
+  to the new language file to `SonicPi.Pro` and `SonicPi.qrc`, then run
+  `lupdate` to have the new .ts file created for you.
+- Edit the translation with Qt Linguist,
+  `linguist lang/sonic-pi_<LANG>.ts`.
+- Build a new binary, test it.
+- When you're happy, `git add` if you added a new language, then
+  `git commit`, `git push` to your github repo.
+- [Send a pull request](https://help.github.com/articles/creating-a-pull-request/) to the Sonic Pi repo.
+
+## Adding a new translation string to the Qt GUI
+
+Messages you want to have translated need to be marked with `tr()`
+in the source.
+
+If you added or changed a translation string during development,
+don't forget to run `lupdate --pro SonicPi.pro` afterwards to update
+the `.ts` files.
+
+Then push them back to github and ask the translators to pull and
+translate them.
+
+(The translation workflow will hopefully become much easier once
+Transifex is integrated.)
+
+## To-Do
+
+- Transifex integration

--- a/app/gui/qt/SonicPi.pro
+++ b/app/gui/qt/SonicPi.pro
@@ -29,6 +29,9 @@ TARGET = 'Sonic Pi'
 QT += macextras
 }
 
+CODECFORSRC = UTF-8
+CODECFORTR = UTF-8
+
 TEMPLATE = app
 
 SOURCES += main.cpp \
@@ -46,7 +49,10 @@ HEADERS  += mainwindow.h \
             sonicpiapis.h \
             sonicpiscintilla.h \
             oschandler.h \
-            sonicpiudpserver.h
+            sonicpiudpserver.h \
+            ruby_help.h
+
+TRANSLATIONS = lang/sonic-pi_de.ts
 
 OTHER_FILES += \
     images/copy.png \
@@ -59,7 +65,7 @@ OTHER_FILES += \
 
 RESOURCES += \
     SonicPi.qrc \
-    help_files.qrc  \
+    help_files.qrc \
     info_files.qrc
 
 RC_FILE = SonicPi.rc

--- a/app/gui/qt/SonicPi.qrc
+++ b/app/gui/qt/SonicPi.qrc
@@ -33,9 +33,11 @@
         <file>images/coreteam/samaaron.png</file>
         <file>images/coreteam/josephwilk.png</file>
         <file>images/coreteam/xavierriley.png</file>
-	<file>images/coreteam/jweather.png</file>
+        <file>images/coreteam/jweather.png</file>
 
-	<file>html/info.html</file>
-	<file>html/startup.html</file>
+        <file>html/info.html</file>
+        <file>html/startup.html</file>
+
+        <file>lang/sonic-pi_de.qm</file>
     </qresource>
 </RCC>

--- a/app/gui/qt/lang/sonic-pi_de.ts
+++ b/app/gui/qt/lang/sonic-pi_de.ts
@@ -1,0 +1,469 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.0" language="de_DE">
+<defaultcodec>UTF-8</defaultcodec>
+<context>
+    <name>MainWindow</name>
+    <message>
+        <location filename="../mainwindow.cpp" line="177"/>
+        <source>Preferences</source>
+        <translation>Einstellungen</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="186"/>
+        <source>Log</source>
+        <translation>Protokoll</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="255"/>
+        <location filename="../mainwindow.cpp" line="1277"/>
+        <location filename="../mainwindow.cpp" line="1295"/>
+        <source>Sonic Pi</source>
+        <translation>Sonic Pi</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="327"/>
+        <source>ruby could not be started, is it installed and in your PATH?</source>
+        <translation>Konnte ruby nicht starten - ist es korrekt installiert?</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="346"/>
+        <source>Failed to start server, please check %1.</source>
+        <oldsource>Failed to start server, please check </oldsource>
+        <translation>Konnte Server nicht starten, bitte in %1 nachsehen.</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="403"/>
+        <source>Raspberry Pi System Volume</source>
+        <translation>Raspberry Pi Lautstärke</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="406"/>
+        <source>Studio Settings</source>
+        <translation>Studio-Einstellungen</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="423"/>
+        <source>Raspberry Pi Audio Output</source>
+        <translation>Raspberry Pi Audio-Ausgabe</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="425"/>
+        <source>&amp;Default</source>
+        <translation>&amp;Standard</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="426"/>
+        <source>&amp;Headphones</source>
+        <translation>&amp;Kopfhörerbuchse</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="427"/>
+        <source>&amp;HDMI</source>
+        <translation>&amp;HDMI</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="621"/>
+        <source>Save Current Workspace</source>
+        <translation>Arbeitsbereich speichern</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="660"/>
+        <source>Running Code...</source>
+        <oldsource>Running Code....</oldsource>
+        <translation>Führe Programm aus...</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="703"/>
+        <source>Beautifying...</source>
+        <oldsource>Beautifying....</oldsource>
+        <translation>Textausrichtung...</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="714"/>
+        <source>Reloading...</source>
+        <oldsource>Reloading....</oldsource>
+        <translation>Neu laden...</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="721"/>
+        <source>Enabling Mixer HPF...</source>
+        <oldsource>Enabling Mixer HPF....</oldsource>
+        <translation>Mixer-Hochpassfilter aktiv...</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="729"/>
+        <source>Disabling Mixer HPF...</source>
+        <oldsource>Disabling Mixer HPF....</oldsource>
+        <translation>Mixer-Hochpassfilter inaktiv...</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="143"/>
+        <location filename="../mainwindow.cpp" line="682"/>
+        <source>Workspace %1</source>
+        <translation>Arbeitsbereich %1</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="404"/>
+        <source>Use this slider to change the system volume of your Raspberry Pi.</source>
+        <oldsource>Use this slider to change the system volume of your Raspberry Pi</oldsource>
+        <translation>Hier veränderst du die Systemlautstärke deines Raspberry Pi.</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="407"/>
+        <source>Advanced audio settings for working with
+external PA systems when performing with Sonic Pi.</source>
+        <oldsource>Advanced audio settings for working with external PA systems when performing with Sonic Pi.</oldsource>
+        <translation>Erweiterte Audio-Einstellungen, die man beim Einsatz
+an einem externen Verstärker gut gebrauchen kann.</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="408"/>
+        <source>Invert Stereo</source>
+        <translation>Stereokanäle tauschen</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="410"/>
+        <source>Force Mono</source>
+        <translation>Mono-Ton erzwingen</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="424"/>
+        <source>Your Raspberry Pi has two forms of audio output.
+Firstly, there is the headphone jack of the Raspberry Pi itself.
+Secondly, some HDMI monitors/TVs support audio through the HDMI port.
+Use these buttons to force the output to the one you want.</source>
+        <oldsource>Your Raspberry Pi has two forms of audio output. 
+Firstly, there is the headphone jack of the Raspberry Pi itself. 
+Secondly, some HDMI monitors/TVs support audio through the HDMI port. 
+Use these buttons to force the output to the one you want. 
+For example, if you have headphones connected to your Raspberry Pi, choose &apos;Headphones&apos;. </oldsource>
+        <translation>Dein Raspberry Pi hat zwei verschiedene Anschlüsse für die Tonausgabe.
+Erstens: Die analoge Kopfhörerbuchse am Raspberry Pi selbst.
+Zweitens: Der digitale HDMI-Monitoranschluss, der den Ton zum Monitor/Fernseher überträgt.
+Hier wählst du aus, über welchen davon die Tonausgabe gehen soll.</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="447"/>
+        <source>Debug Options</source>
+        <translation>Debug-Einstellungen</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="448"/>
+        <source>Print output</source>
+        <translation>Ausgabe anzeigen</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="449"/>
+        <source>Check synth args</source>
+        <translation>Synth-Parameter prüfen</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="450"/>
+        <source>Clear output on run</source>
+        <translation>Vorm Ausführen Ausgabe leeren</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="515"/>
+        <source>We&apos;re sorry, but Sonic Pi was unable to start...</source>
+        <translation>Sonic Pi konnte nicht starten. Das tut uns leid...</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="736"/>
+        <source>Enabling Mixer LPF...</source>
+        <oldsource>Enabling Mixer LPF....</oldsource>
+        <translation>Mixer-Tiefpassfilter aktiv...</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="744"/>
+        <source>Disabling Mixer LPF...</source>
+        <oldsource>Disabling Mixer LPF....</oldsource>
+        <translation>Mixer-Tiefpassfilter inaktiv...</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="751"/>
+        <source>Enabling Inverted Stereo...</source>
+        <oldsource>Enabling Inverted Stereo....</oldsource>
+        <translation>Stereo-Kanaltausch aktiv...</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="758"/>
+        <source>Enabling Standard Stereo...</source>
+        <oldsource>Enabling Standard Stereo....</oldsource>
+        <translation>Stereo-Kanaltausch inaktiv...</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="765"/>
+        <source>Mono Mode...</source>
+        <oldsource>Mono Mode....</oldsource>
+        <translation>Mono-Ton aktiv...</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="772"/>
+        <source>Stereo Mode...</source>
+        <oldsource>Stereo Mode....</oldsource>
+        <translation>Stereo-Ton aktiv...</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="780"/>
+        <source>Stopping...</source>
+        <translation>Stopp...</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="844"/>
+        <location filename="../mainwindow.cpp" line="860"/>
+        <source>Updating System Volume.</source>
+        <oldsource>Updating system volume.</oldsource>
+        <translation>Setze System-Lautstärke.</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="873"/>
+        <location filename="../mainwindow.cpp" line="879"/>
+        <source>Switching To Headphone Audio Output.</source>
+        <oldsource>Switching To Headphone Audio Output .</oldsource>
+        <translation>Umschalten auf Kopfhörerbuchse.</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="892"/>
+        <location filename="../mainwindow.cpp" line="898"/>
+        <source>Switching To HDMI Audio Output.</source>
+        <oldsource>Switching To HDMI Audio Output .</oldsource>
+        <translation>Umschalten auf HDMI-Anschluss.</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="911"/>
+        <location filename="../mainwindow.cpp" line="917"/>
+        <source>Switching To Default Audio Output.</source>
+        <oldsource>Switching To Default Audio Output .</oldsource>
+        <translation>Umschalten auf Standard-Tonausgabe.</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1041"/>
+        <source>Run</source>
+        <translation>Ausführen</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1042"/>
+        <source>Run the code in the current workspace</source>
+        <translation>Das Programm im aktuellen Arbeitsbereich ausführen</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1046"/>
+        <source>Stop</source>
+        <translation>Stopp</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1047"/>
+        <source>Stop all running code</source>
+        <translation>Alle laufenden Programme beenden</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1050"/>
+        <source>Save As...</source>
+        <translation>Speichern als...</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1051"/>
+        <source>Save current workspace as an external file</source>
+        <translation>Den aktuellen Arbeitsbereich als Datei speichern</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1054"/>
+        <source>Info</source>
+        <translation>Info</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1055"/>
+        <source>See information about Sonic Pi</source>
+        <translation>Einige Informationen über Sonic Pi</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="230"/>
+        <location filename="../mainwindow.cpp" line="1059"/>
+        <source>Help</source>
+        <translation>Hilfe</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1060"/>
+        <source>Toggle help pane</source>
+        <translation>Hilfetexte anzeigen</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1063"/>
+        <source>Prefs</source>
+        <translation>Einstellungen</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1064"/>
+        <source>Toggle preferences pane</source>
+        <translation>Einstellungen anzeigen</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1068"/>
+        <location filename="../mainwindow.cpp" line="1069"/>
+        <location filename="../mainwindow.cpp" line="1179"/>
+        <location filename="../mainwindow.cpp" line="1180"/>
+        <source>Start Recording</source>
+        <translation>Aufnahme starten</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1073"/>
+        <source>Auto-Align Text</source>
+        <oldsource>Auto Align Text</oldsource>
+        <translation>Text automatisch ausrichten</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1074"/>
+        <source>Auto-align text</source>
+        <translation>Text automatisch ausrichten</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1078"/>
+        <source>Increase Text Size</source>
+        <translation>Text vergrößern</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1079"/>
+        <source>Make text bigger</source>
+        <translation>Text vergrößern</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1084"/>
+        <source>Decrease Text Size</source>
+        <translation>Text verkleinern</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1085"/>
+        <source>Make text smaller</source>
+        <translation>Text verkleinern</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1091"/>
+        <source>Tools</source>
+        <translation>Werkzeuge</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1131"/>
+        <source>About</source>
+        <translation>Über Sonic Pi</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1131"/>
+        <source>Core Team</source>
+        <translation>Kern-Team</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1131"/>
+        <source>Contributors</source>
+        <translation>Mitwirkende</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1132"/>
+        <source>Community</source>
+        <translation>Gemeinschaft</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1132"/>
+        <source>License</source>
+        <translation>Lizenz</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1132"/>
+        <source>History</source>
+        <translation>Änderungen</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1152"/>
+        <source>Sonic Pi - Info</source>
+        <translation>Über Sonic Pi</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1172"/>
+        <location filename="../mainwindow.cpp" line="1173"/>
+        <source>Stop Recording</source>
+        <translation>Aufnahme stoppen</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1184"/>
+        <source>Save Recording</source>
+        <translation>Aufnahme speichern</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1199"/>
+        <source>Ready</source>
+        <translation>Bereit</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1278"/>
+        <source>Cannot read file %1:
+%2.</source>
+        <translation>Kann Datei %1 nicht laden:
+%2.</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1288"/>
+        <source>File loaded</source>
+        <translation>Datei geladen</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1296"/>
+        <source>Cannot write file %1:
+%2.</source>
+        <translation>Kann Datei %1 nicht schreiben:
+%2.</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1312"/>
+        <source>File saved</source>
+        <translation>Datei geschrieben</translation>
+    </message>
+    <message>
+        <location filename="../ruby_help.h" line="32"/>
+        <location filename="../ruby_help.h" line="41"/>
+        <location filename="../ruby_help.h" line="96"/>
+        <source>Tutorial</source>
+        <translation>Tutorial</translation>
+    </message>
+    <message>
+        <location filename="../ruby_help.h" line="123"/>
+        <source>Examples</source>
+        <translation>Beispiele</translation>
+    </message>
+    <message>
+        <location filename="../ruby_help.h" line="156"/>
+        <source>Synths</source>
+        <translation>Synths</translation>
+    </message>
+    <message>
+        <location filename="../ruby_help.h" line="188"/>
+        <source>Fx</source>
+        <translation>Fx</translation>
+    </message>
+    <message>
+        <location filename="../ruby_help.h" line="205"/>
+        <source>Samples</source>
+        <translation>Samples</translation>
+    </message>
+    <message>
+        <location filename="../ruby_help.h" line="313"/>
+        <source>Lang</source>
+        <translation>Lang</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../main.cpp" line="44"/>
+        <source>Sonic Pi</source>
+        <translation>Sonic Pi</translation>
+    </message>
+</context>
+<context>
+    <name>SonicPiUDPServer</name>
+    <message>
+        <location filename="../sonicpiudpserver.cpp" line="40"/>
+        <source>Is Sonic Pi already running?  Can&apos;t open UDP port 4558.</source>
+        <translation>Läuft Sonic Pi bereits?  Konnte UDP-Port 4558 nicht öffnen.</translation>
+    </message>
+</context>
+</TS>

--- a/app/gui/qt/mac-build-app
+++ b/app/gui/qt/mac-build-app
@@ -37,6 +37,9 @@ mkdir build
 cp -f ruby_help.tmpl ruby_help.h
 ../../server/bin/qt-doc.rb -o ruby_help.h
 
+# Generate i18n files
+lrelease SonicPi.pro
+
 # Build app
 $QMAKE -o Makefile SonicPi.pro
 make

--- a/app/gui/qt/main.cpp
+++ b/app/gui/qt/main.cpp
@@ -16,16 +16,35 @@
 #include <QPixmap>
 #include <QBitmap>
 #include <QLabel>
+#include <QTranslator>
+#include <QLibraryInfo>
 
 #include "mainwindow.h"
 int main(int argc, char *argv[])
 {
-
-#if defined(Q_OS_MAC)
+#ifndef Q_OS_MAC
+  Q_INIT_RESOURCE(SonicPi);
+#endif
 
   QApplication app(argc, argv);
-  app.setApplicationName("Sonic Pi");
+
+  QString systemLocale = QLocale::system().name();
+
+  QTranslator qtTranslator;
+  qtTranslator.load("qt_" + systemLocale, QLibraryInfo::location(QLibraryInfo::TranslationsPath));
+  app.installTranslator(&qtTranslator);
+  
+  QTranslator translator;
+  if (!translator.load("sonic-pi_" + systemLocale, ":/lang/") && (!systemLocale.startsWith("en")) && (systemLocale != "C")) {
+    std::cout << "No translation found for your locale \"" + systemLocale.toStdString() + "\"." << std::endl;
+    std::cout << "Please contact us if you want to translate Sonic Pi to your language." << std::endl;
+  }
+  app.installTranslator(&translator);
+  
+  app.setApplicationName(QObject::tr("Sonic Pi"));
   app.setStyle("gtk");
+
+#ifdef Q_OS_MAC
   app.setAttribute( Qt::AA_UseHighDpiPixmaps );
   QMainWindow* splashWindow = new QMainWindow(0, Qt::FramelessWindowHint);
   QLabel* imageLabel = new QLabel();
@@ -43,22 +62,15 @@ int main(int argc, char *argv[])
 
   MainWindow mainWin(app, splashWindow);
   return app.exec();
-
 #else
-
-  Q_INIT_RESOURCE(SonicPi);
-  QApplication app(argc, argv);
-  app.setApplicationName("Sonic Pi");
-  app.setStyle("gtk");
   QPixmap pixmap(":/images/splash.png");
   QSplashScreen *splash = new QSplashScreen(pixmap);
   splash->setMask(pixmap.mask());
   splash->show();
   splash->repaint();
+
   MainWindow mainWin(app, splash);
   return app.exec();
-
-#endif
-
+#endif  
 
 }

--- a/app/gui/qt/mainwindow.cpp
+++ b/app/gui/qt/mainwindow.cpp
@@ -140,7 +140,7 @@ MainWindow::MainWindow(QApplication &app, QSplashScreen* splash)
     std::string s;
 
     workspaces[ws] = new SonicPiScintilla(lexer);
-    QString w = QString("Workspace %1").arg(QString::number(ws + 1));
+    QString w = QString(tr("Workspace %1")).arg(QString::number(ws + 1));
     tabs->addTab(workspaces[ws], w);
   }
 
@@ -227,7 +227,7 @@ MainWindow::MainWindow(QApplication &app, QSplashScreen* splash)
   QWidget *docW = new QWidget();
   docW->setLayout(docLayout);
 
-  docWidget = new QDockWidget("Help", this);
+  docWidget = new QDockWidget(tr("Help"), this);
   docWidget->setAllowedAreas(Qt::BottomDockWidgetArea);
   docWidget->setWidget(docW);
   docWidget->setObjectName("help");
@@ -343,7 +343,7 @@ void MainWindow::waitForServiceSync() {
 
   if (!sonicPiServer->isServerStarted()) {
     if (!startup_error_reported) {
-      invokeStartupError(tr("Failed to start server, please check ") + log_path);
+      invokeStartupError(QString(tr("Failed to start server, please check %1.").arg(log_path)));
     }
     return;
   }
@@ -369,13 +369,13 @@ void MainWindow::serverStarted() {
 
 void MainWindow::serverError(QProcess::ProcessError error) {
   sonicPiServer->stopServer();
-  std::cout << "SERVER ERROR" << error <<std::endl;
+  std::cout << "Server Error: " << error <<std::endl;
   std::cout << serverProcess->readAllStandardError().data() << std::endl;
   std::cout << serverProcess->readAllStandardOutput().data() << std::endl;
 }
 
 void MainWindow::serverFinished(int exitCode, QProcess::ExitStatus exitStatus) {
-  std::cout << "SERVER Finished: " << exitCode << ", " << exitStatus << std::endl;
+  std::cout << "Server Finished: " << exitCode << ", " << exitStatus << std::endl;
   std::cout << serverProcess->readAllStandardError().data() << std::endl;
   std::cout << serverProcess->readAllStandardOutput().data() << std::endl;
 }
@@ -401,13 +401,13 @@ void MainWindow::initPrefsWindow() {
   QGridLayout *grid = new QGridLayout;
 
   QGroupBox *volBox = new QGroupBox(tr("Raspberry Pi System Volume"));
-  volBox->setToolTip("Use this slider to change the system volume of your Raspberry Pi");
+  volBox->setToolTip(tr("Use this slider to change the system volume of your Raspberry Pi."));
 
   QGroupBox *advancedAudioBox = new QGroupBox(tr("Studio Settings"));
-  advancedAudioBox->setToolTip("Advanced audio settings for working with external PA systems when performing with Sonic Pi");
-  mixer_invert_stereo = new QCheckBox("Invert Stereo");
+  advancedAudioBox->setToolTip(tr("Advanced audio settings for working with\nexternal PA systems when performing with Sonic Pi."));
+  mixer_invert_stereo = new QCheckBox(tr("Invert Stereo"));
   connect(mixer_invert_stereo, SIGNAL(clicked()), this, SLOT(update_mixer_invert_stereo()));
-  mixer_force_mono = new QCheckBox("Force Mono");
+  mixer_force_mono = new QCheckBox(tr("Force Mono"));
   connect(mixer_force_mono, SIGNAL(clicked()), this, SLOT(update_mixer_force_mono()));
 
 
@@ -421,7 +421,7 @@ void MainWindow::initPrefsWindow() {
 
 
   QGroupBox *audioOutputBox = new QGroupBox(tr("Raspberry Pi Audio Output"));
-  audioOutputBox->setToolTip("Your Raspberry Pi has two forms of audio output. \nFirstly, there is the headphone jack of the Raspberry Pi itself. \nSecondly, some HDMI monitors/TVs support audio through the HDMI port. \nUse these buttons to force the output to the one you want. \nFor example, if you have headphones connected to your Raspberry Pi, choose 'Headphones'. ");
+  audioOutputBox->setToolTip(tr("Your Raspberry Pi has two forms of audio output.\nFirstly, there is the headphone jack of the Raspberry Pi itself.\nSecondly, some HDMI monitors/TVs support audio through the HDMI port.\nUse these buttons to force the output to the one you want."));
   rp_force_audio_default = new QRadioButton(tr("&Default"));
   rp_force_audio_headphones = new QRadioButton(tr("&Headphones"));
   rp_force_audio_hdmi = new QRadioButton(tr("&HDMI"));
@@ -444,10 +444,10 @@ void MainWindow::initPrefsWindow() {
   vol_box->addWidget(rp_system_vol);
   volBox->setLayout(vol_box);
 
-  QGroupBox *debug_box = new QGroupBox("Debug Options");
-  print_output = new QCheckBox("Print output");
-  check_args = new QCheckBox("Check synth args");
-  clear_output_on_run = new QCheckBox("Clear output on run");
+  QGroupBox *debug_box = new QGroupBox(tr("Debug Options"));
+  print_output = new QCheckBox(tr("Print output"));
+  check_args = new QCheckBox(tr("Check synth args"));
+  clear_output_on_run = new QCheckBox(tr("Clear output on run"));
 
   QVBoxLayout *debug_box_layout = new QVBoxLayout;
   debug_box_layout->addWidget(print_output);
@@ -512,7 +512,7 @@ void MainWindow::startupError(QString msg) {
 
   QString logtext = readFile(log_path + QDir::separator() + "output.log");
   QMessageBox *box = new QMessageBox(QMessageBox::Warning,
-				     "We're sorry, but Sonic Pi was unable to start...", msg);
+				     tr("We're sorry, but Sonic Pi was unable to start..."), msg);
   box->setDetailedText(logtext);
 
   QGridLayout* layout = (QGridLayout*)box->layout();
@@ -576,7 +576,7 @@ std::string MainWindow::workspaceFilename(SonicPiScintilla* text)
 
 void MainWindow::loadWorkspaces()
 {
-  std::cout << "loading workspaces" << std::endl;;
+  std::cout << "loading workspaces" << std::endl;
 
   for(int i = 0; i < workspace_max; i++) {
     Message msg("/load-buffer");
@@ -588,7 +588,7 @@ void MainWindow::loadWorkspaces()
 
 void MainWindow::saveWorkspaces()
 {
-  std::cout << "saving workspaces" << std::endl;;
+  std::cout << "saving workspaces" << std::endl;
 
   for(int i = 0; i < workspace_max; i++) {
     std::string code = workspaces[i]->text().toStdString();
@@ -657,7 +657,7 @@ void MainWindow::runCode()
   ws->setReadOnly(true);
   ws->selectAll();
   resetErrorPane();
-  statusBar()->showMessage(tr("Running Code...."), 1000);
+  statusBar()->showMessage(tr("Running Code..."), 1000);
   std::string code = ((SonicPiScintilla*)tabs->currentWidget())->text().toStdString();
   Message msg("/save-and-run-buffer");
   std::string filename = workspaceFilename( (SonicPiScintilla*)tabs->currentWidget());
@@ -679,7 +679,7 @@ void MainWindow::runCode()
   }
 
   msg.pushStr(code);
-  msg.pushStr(QString("Workspace %1").arg(tabs->currentIndex()+1).toStdString());
+  msg.pushStr(QString(tr("Workspace %1")).arg(tabs->currentIndex()+1).toStdString());
   sendOSC(msg);
 
   QTimer::singleShot(500, this, SLOT(unhighlightCode()));
@@ -700,7 +700,7 @@ void MainWindow::unhighlightCode()
 
 void MainWindow::beautifyCode()
 {
-  statusBar()->showMessage(tr("Beautifying...."), 2000);
+  statusBar()->showMessage(tr("Beautifying..."), 2000);
   std::string code = ((SonicPiScintilla*)tabs->currentWidget())->text().toStdString();
   Message msg("/beautify-buffer");
   std::string filename = workspaceFilename( (SonicPiScintilla*)tabs->currentWidget());
@@ -711,14 +711,14 @@ void MainWindow::beautifyCode()
 
 void MainWindow::reloadServerCode()
 {
-  statusBar()->showMessage(tr("reloading...."), 2000);
+  statusBar()->showMessage(tr("Reloading..."), 2000);
   Message msg("/reload");
   sendOSC(msg);
 }
 
 void MainWindow::mixerHpfEnable(float freq)
 {
-  statusBar()->showMessage(tr("enabling mixer HPF...."), 2000);
+  statusBar()->showMessage(tr("Enabling Mixer HPF..."), 2000);
   Message msg("/mixer-hpf-enable");
   msg.pushFloat(freq);
   sendOSC(msg);
@@ -726,14 +726,14 @@ void MainWindow::mixerHpfEnable(float freq)
 
 void MainWindow::mixerHpfDisable()
 {
-  statusBar()->showMessage(tr("disabling mixer HPF...."), 2000);
+  statusBar()->showMessage(tr("Disabling Mixer HPF..."), 2000);
   Message msg("/mixer-hpf-disable");
   sendOSC(msg);
 }
 
 void MainWindow::mixerLpfEnable(float freq)
 {
-  statusBar()->showMessage(tr("enabling Mixer HPF...."), 2000);
+  statusBar()->showMessage(tr("Enabling Mixer LPF..."), 2000);
   Message msg("/mixer-lpf-enable");
   msg.pushFloat(freq);
   sendOSC(msg);
@@ -741,35 +741,35 @@ void MainWindow::mixerLpfEnable(float freq)
 
 void MainWindow::mixerLpfDisable()
 {
-  statusBar()->showMessage(tr("disabling mixer LPF...."), 2000);
+  statusBar()->showMessage(tr("Disabling Mixer LPF..."), 2000);
   Message msg("/mixer-lpf-disable");
   sendOSC(msg);
 }
 
 void MainWindow::mixerInvertStereo()
 {
-  statusBar()->showMessage(tr("enabling inverted stereo...."), 2000);
+  statusBar()->showMessage(tr("Enabling Inverted Stereo..."), 2000);
   Message msg("/mixer-invert-stereo");
   sendOSC(msg);
 }
 
 void MainWindow::mixerStandardStereo()
 {
-  statusBar()->showMessage(tr("enabling standard stereo...."), 2000);
+  statusBar()->showMessage(tr("Enabling Standard Stereo..."), 2000);
   Message msg("/mixer-standard-stereo");
   sendOSC(msg);
 }
 
 void MainWindow::mixerMonoMode()
 {
-  statusBar()->showMessage(tr("mono mode...."), 2000);
+  statusBar()->showMessage(tr("Mono Mode..."), 2000);
   Message msg("/mixer-mono-mode");
   sendOSC(msg);
 }
 
 void MainWindow::mixerStereoMode()
 {
-  statusBar()->showMessage(tr("stereo mode...."), 2000);
+  statusBar()->showMessage(tr("Stereo Mode..."), 2000);
   Message msg("/mixer-stereo-mode");
   sendOSC(msg);
 }
@@ -841,7 +841,7 @@ void MainWindow::changeRPSystemVol(int val)
   //do nothing
   val = val;
 #elif defined(Q_OS_MAC)
-  statusBar()->showMessage(tr("Updating system volume."), 2000);
+  statusBar()->showMessage(tr("Updating System Volume."), 2000);
   //do nothing, just print out what it would do on RPi
   float v = (float) val;
   float vol_float = pow(v/100.0, (float)1./3.) * 100.0;
@@ -857,7 +857,7 @@ void MainWindow::changeRPSystemVol(int val)
   float vol_float = std::pow(v/100.0, (float)1./3.) * 100.0;
   std::ostringstream ss;
   ss << vol_float;
-  statusBar()->showMessage(tr("Updating system volume."), 2000);
+  statusBar()->showMessage(tr("Updating System Volume."), 2000);
   QString prog = "amixer cset numid=1 " + QString::fromStdString(ss.str()) + '%';
   p->start(prog);
 #endif
@@ -870,13 +870,13 @@ void MainWindow::setRPSystemAudioHeadphones()
 #if defined(Q_OS_WIN)
   //do nothing
 #elif defined(Q_OS_MAC)
-  statusBar()->showMessage(tr("Switching to headphone audio output ."), 2000);
+  statusBar()->showMessage(tr("Switching To Headphone Audio Output."), 2000);
   //do nothing, just print out what it would do on RPi
   QString prog = "amixer cset numid=3 1";
   std::cout << prog.toStdString() << std::endl;
 #else
   //assuming Raspberry Pi
-  statusBar()->showMessage(tr("Switching to headphone audio output ."), 2000);
+  statusBar()->showMessage(tr("Switching To Headphone Audio Output."), 2000);
   QProcess *p = new QProcess();
   QString prog = "amixer cset numid=3 1";
   p->start(prog);
@@ -889,13 +889,13 @@ void MainWindow::setRPSystemAudioHDMI()
 #if defined(Q_OS_WIN)
   //do nothing
 #elif defined(Q_OS_MAC)
-  statusBar()->showMessage(tr("Switching to HDMI audio output ."), 2000);
+  statusBar()->showMessage(tr("Switching To HDMI Audio Output."), 2000);
   //do nothing, just print out what it would do on RPi
   QString prog = "amixer cset numid=3 2";
   std::cout << prog.toStdString() << std::endl;
 #else
   //assuming Raspberry Pi
-  statusBar()->showMessage(tr("Switching to HDMI audio output ."), 2000);
+  statusBar()->showMessage(tr("Switching To HDMI Audio Output."), 2000);
   QProcess *p = new QProcess();
   QString prog = "amixer cset numid=3 2";
   p->start(prog);
@@ -908,13 +908,13 @@ void MainWindow::setRPSystemAudioAuto()
   //do nothing
 
 #elif defined(Q_OS_MAC)
-  statusBar()->showMessage(tr("Switching to default audio output ."), 2000);
+  statusBar()->showMessage(tr("Switching To Default Audio Output."), 2000);
   //do nothing, just print out what it would do on RPi
   QString prog = "amixer cset numid=3 0";
   std::cout << prog.toStdString() << std::endl;
 #else
   //assuming Raspberry Pi
-  statusBar()->showMessage(tr("Switching to default audio output ."), 2000);
+  statusBar()->showMessage(tr("Switching To Default Audio Output."), 2000);
   QProcess *p = new QProcess();
   QString prog = "amixer cset numid=3 0";
   p->start(prog);
@@ -1070,7 +1070,7 @@ void MainWindow::createToolBar()
 
   // Align
   QAction *textAlignAct = new QAction(QIcon(":/images/align.png"),
-			     tr("Auto Align Text"), this);
+			     tr("Auto-Align Text"), this);
   setupAction(textAlignAct, 'M', tr("Auto-align text"), SLOT(beautifyCode()));
 
   // Font Size Increase
@@ -1128,8 +1128,8 @@ void MainWindow::createInfoPane() {
   QStringList files, tabs;
   files << ":/html/info.html" << ":/info/CORETEAM.html" << ":/info/CONTRIBUTORS.html" <<
     ":/info/COMMUNITY.html" << ":/info/LICENSE.html" <<":/info/CHANGELOG.html";
-  tabs << "About" << "Core Team" << "Contributors" <<
-    "Community" << "License" << "History";
+  tabs << tr("About") << tr("Core Team") << tr("Contributors") <<
+    tr("Community") << tr("License") << tr("History");
 
   for (int t=0; t < files.size(); t++) {
     QTextBrowser *pane = new QTextBrowser;
@@ -1149,7 +1149,7 @@ void MainWindow::createInfoPane() {
   infoWidg->setWindowIcon(QIcon(":images/icon-smaller.png"));
   infoWidg->setLayout(infoLayout);
   infoWidg->setWindowFlags(Qt::Tool | Qt::WindowTitleHint | Qt::WindowCloseButtonHint | Qt::CustomizeWindowHint);
-  infoWidg->setWindowTitle("Sonic Pi - Info");
+  infoWidg->setWindowTitle(tr("Sonic Pi - Info"));
 
   QAction *closeInfoAct = new QAction(this);
   closeInfoAct->setShortcut(QKeySequence(Qt::CTRL + Qt::Key_W));
@@ -1379,20 +1379,22 @@ void MainWindow::addHelpPage(QListWidget *nameList,
     item->setSizeHint(QSize(item->sizeHint().width(), 25));
     nameList->addItem(item);
     entry.entryIndex = nameList->count()-1;
-    helpKeywords.insert(helpPages[i].keyword.toLower(), entry);
 
-    // magic numbers ahoy
-    // to be revamped along with the help system
-    switch (entry.pageIndex) {
-    case 2:
-      autocomplete->addSymbol(SonicPiAPIs::Synth, helpPages[i].keyword);
-      break;
-    case 3:
-      autocomplete->addSymbol(SonicPiAPIs::FX, helpPages[i].keyword);
-      break;
-    case 5:
-      autocomplete->addKeyword(SonicPiAPIs::Func, helpPages[i].keyword);
-      break;
+    if (helpPages[i].keyword != NULL) {
+      helpKeywords.insert(helpPages[i].keyword, entry);
+      // magic numbers ahoy
+      // to be revamped along with the help system
+      switch (entry.pageIndex) {
+      case 2:
+        autocomplete->addSymbol(SonicPiAPIs::Synth, helpPages[i].keyword);
+        break;
+      case 3:
+        autocomplete->addSymbol(SonicPiAPIs::FX, helpPages[i].keyword);
+        break;
+      case 5:
+        autocomplete->addKeyword(SonicPiAPIs::Func, helpPages[i].keyword);
+        break;
+      }
     }
   }
 }

--- a/app/gui/qt/rp-build-app
+++ b/app/gui/qt/rp-build-app
@@ -6,6 +6,7 @@ cd $(dirname $0)
 
 cp -f ruby_help.tmpl ruby_help.h
 ../../server/bin/qt-doc.rb -o ruby_help.h
+lrelease SonicPi.pro
 qmake -o Makefile SonicPi.pro || qmake-qt4 -o Makefile SonicPi.pro
 set +x
 make

--- a/app/gui/qt/win-build-app.bat
+++ b/app/gui/qt/win-build-app.bat
@@ -4,6 +4,9 @@ copy /Y ruby_help.tmpl ruby_help.h
 ruby ../../server/bin/qt-doc.rb -o ruby_help.h
 @IF ERRORLEVEL==9009 goto :noruby
 
+lrelease SonicPi.pro
+@IF ERRORLEVEL==9009 goto :noqt
+
 qmake -o Makefile SonicPi.pro
 @IF ERRORLEVEL==9009 goto :noqt
 

--- a/etc/doc/tutorial/README.md
+++ b/etc/doc/tutorial/README.md
@@ -1,0 +1,14 @@
+This subdirectory contains the tutorial and its translations.
+
+Please refer to [TRANSLATION](../../../TRANSLATION.md) to learn
+more about how you can translate Sonic Pi to your language.
+
+# File Format
+
+The first line of each tutorial file is used as the title for the
+Qt GUI's help browser.
+
+The remainder is converted from markdown to HTML.
+
+Conversion to the Qt GUI help browser is done by `qt-doc.rb` during
+the build process.

--- a/etc/doc/tutorial/de/01-Welcome-to-Sonic-Pi.md
+++ b/etc/doc/tutorial/de/01-Welcome-to-Sonic-Pi.md
@@ -1,3 +1,5 @@
+1 Willkommen bei Sonic Pi
+
 # Hallo zusammen :-)
 
 Willkommen bei Sonic Pi! Ich hoffe, Du bist genauso aufgeregt, verrückte Sounds zu machen, wie ich es bin, dir zu zeigen, wie das geht. Wir werden viel Spaß dabei haben, alles über Musik, Synthese, Coding, Komposition, Aufführung und andere Dinge zu lernen.

--- a/etc/doc/tutorial/de/01.1-Your-First-Beeps.md
+++ b/etc/doc/tutorial/de/01.1-Your-First-Beeps.md
@@ -1,3 +1,5 @@
+1.1 Eure ersten Klänge
+
 # Eure ersten Klänge
 
 Seht Euch den folgenden Code an:

--- a/etc/doc/tutorial/de/01.2-Exploring-the-Interface.md
+++ b/etc/doc/tutorial/de/01.2-Exploring-the-Interface.md
@@ -1,3 +1,5 @@
+1.2 Die Programmoberfläche von Sonic Pi
+
 # Die Programmoberfläche von Sonic Pi
 
 Sonic PI hat eine sehr einfache Oberfläche zum Coden von Musik. Schauen wir uns das einmal genauer an.

--- a/etc/doc/tutorial/de/01.3-Learning-through-Play.md
+++ b/etc/doc/tutorial/de/01.3-Learning-through-Play.md
@@ -1,3 +1,5 @@
+1.3 Spielend lernen
+
 # Spielend lernen
 
 Sonic Pi soll dich dazu animieren etwas über Computer und Musik zu lernen - und zwar auf eine spielerische Weise und über das Experimentieren. Das allerwichtigste ist, dass du Spaß hast, und bevor du es überhaupt bemerkt hast, wirst du zufällig gelernt haben, Code zu schreiben, zu komponieren und Musik aufzuführen.

--- a/etc/doc/tutorial/de/02-Synths.md
+++ b/etc/doc/tutorial/de/02-Synths.md
@@ -1,3 +1,5 @@
+2 Synths
+
 # Synths
 
 Ok, genug der Einführung - laßt uns Klänge machen.

--- a/etc/doc/tutorial/de/02.1-Synth-Params.md
+++ b/etc/doc/tutorial/de/02.1-Synth-Params.md
@@ -1,3 +1,5 @@
+2.1 Synth Parameter
+
 # Parameters: Amp and Pan
 
 So, wie du bestimmen kannst, welche Note oder welcher Sample gespielt wird, bietet Sonic Pi auch eine Reihe von Paramtern, um Klänge zu gestalten und zu kontrollieren. Wir werden viele davon in diesem Tutorial behandeln, und es gibt für jeden Parameter ausführlich Informationen in der Hilfe. Jetzt sehen wir uns aber erstmal den nützlichsten an: *amplitude*. Lass uns zunächst ansehen, was Parameter eigentlich sind.

--- a/etc/doc/tutorial/de/02.2-Switching-Synths.md
+++ b/etc/doc/tutorial/de/02.2-Switching-Synths.md
@@ -1,3 +1,5 @@
+2.2 Synths wechseln
+
 # Synths wechseln
 
 Bis jetzt hatten wir viel Spaß mit Tönen und Samples. Aber wahrscheinlich wird dir langsam langweilig, immer denselben Klang zu hören. Ist das alles, was Sonic Pi anzubieten hat? Besteht das Live Coding nicht aus mehr als Pieptönen? Aber klar doch, und in diesem Abschnitt sehen wir uns die spannende Auswahl an Sounds an, die Sonic Pi mitbringt.

--- a/etc/doc/tutorial/de/02.3-Duration-with-Envelopes.md
+++ b/etc/doc/tutorial/de/02.3-Duration-with-Envelopes.md
@@ -1,3 +1,5 @@
+2.3 Dauern und Hüllkurven
+
 # Dauern und Hüllkurven
 
 Wie wir schon vorher gesehen haben, können wir mit dem `sleep`-Kommando steuern, wann ein Klang anfängt zu spielen. Bislang konnten wir aber noch nicht die Dauer eines Klangs steuern (außer bei Samplen, die wir strecken oder verdichten können).

--- a/etc/doc/tutorial/de/03-Samples.md
+++ b/etc/doc/tutorial/de/03-Samples.md
@@ -1,3 +1,5 @@
+3 Samples
+
 # Samples
 
 Du kannst deine Musik auch prima mit aufgenommenen Sounds erweitern. In der großen Tradition des Hip-hop nennen wir diese aufgenommenen Sounds auch *Samples*. Also, wenn du ein Mikrophon mit nach draußen nimmst und den zarten Klang der Regentropfen auf einem Zeltdach aufnimmst, dann hast du einen Sample erzeugt.

--- a/etc/doc/tutorial/de/03.1-Triggering-Samples.md
+++ b/etc/doc/tutorial/de/03.1-Triggering-Samples.md
@@ -1,3 +1,5 @@
+3.1 Samples ansteuern
+
 # Samples ansteuern
 
 Pieptöne zu spielen ist erst der Anfang. Mit aufgenommenen Samples hat man noch viel mehr Spaß. Versuche es:

--- a/etc/doc/tutorial/de/03.2-Sample-Params.md
+++ b/etc/doc/tutorial/de/03.2-Sample-Params.md
@@ -1,3 +1,5 @@
+3.2 Sample Parameter
+
 # Sample Parameter: Amp und Pan
 
 Genauso wie mit den Synths können wir auch unsere Sounds mit Parametern steuern. Samples funktionieren mit demselben Parameter-Mechanismus. Besuchen wir unsere Freunde `amp:` and `pan:` nocheinmal.

--- a/etc/doc/tutorial/de/03.3-Stretching-Samples.md
+++ b/etc/doc/tutorial/de/03.3-Stretching-Samples.md
@@ -1,3 +1,5 @@
+3.3 Samples ausdehnen
+
 # Samples ausdehnen
 
 Jetzt, wo wir eine ganze Menge Synths und Samples spielen können, um damit Musik zu machen, wird es Zeit zu lernen, wie wir diese Synths und Samples verändern könnten, um unsere Musik einzigartiger und spannender zu machen. Als erstes sehen wir uns an, wie wir Samples *strecken* und *stauchen* können.

--- a/etc/doc/tutorial/de/10-Essential-Knowledge.md
+++ b/etc/doc/tutorial/de/10-Essential-Knowledge.md
@@ -1,3 +1,5 @@
+10 Unentbehrliche Kenntnisse
+
 # Unentbehrliche Kenntnisse
 
 Dieses Kapitel behandelt sehr nützliches - nein, *unentbehrliches* - Wissen, welches Dir hilft,  das Bestmögliche aus Deinem Sonic Pi herauszuholen.

--- a/etc/doc/tutorial/de/10.1-Using-Shortcuts.md
+++ b/etc/doc/tutorial/de/10.1-Using-Shortcuts.md
@@ -1,3 +1,5 @@
+10.1 Tastaturkürzel
+
 # Tastaturkürzel
 
 Sonic Pi ist zu gleichen Teilen Musikinstrument und Programmierumgebung. Tastaturkürzel helfen Dir dabei, Sonic Pi viel *effizienter und natürlicher* zu spielen - insbesondere wenn Du live vor Publikum spielst. 

--- a/etc/doc/tutorial/de/10.2-Shortcut-Cheatsheet.md
+++ b/etc/doc/tutorial/de/10.2-Shortcut-Cheatsheet.md
@@ -1,3 +1,5 @@
+10.2 Cheatsheet für Tastaturkürzel
+
 # Cheatsheet für Tastaturkürzel
 
 Der folgende Abschnitt ist eine Zusammenfassung der wichtígsten Tastenkürzel, die in Sonic Pi verfügbar sind.

--- a/etc/doc/tutorial/de/10.3-Sharing.md
+++ b/etc/doc/tutorial/de/10.3-Sharing.md
@@ -1,3 +1,5 @@
+10.3 Teilen
+
 # Teilen
 
 In Sonic Pi geht es vor allen Dingen um das Teilen und gemeinsame Lernen.

--- a/etc/doc/tutorial/de/10.4-Performing.md
+++ b/etc/doc/tutorial/de/10.4-Performing.md
@@ -1,3 +1,5 @@
+10.4 Auftritte
+
 # Auftritte
 
 Einer der aufregendsten Aspekte von Sonic Pi ist, dass es Dir erlaubt, Code als *Musikinstrument* zu verwenden. Das bedeutet, dass live programmieren jetzt als neuer Weg gesehen werden kann, Musik auzuführen.

--- a/etc/doc/tutorial/de/11-Conclusions.md
+++ b/etc/doc/tutorial/de/11-Conclusions.md
@@ -1,3 +1,5 @@
+11 Abschluss
+
 # Abschluss
 
 Das ist das Ende der Sonic Pi Einführung. Hoffentlich hast Du etwas dabei gelernt. Keine Angst, falls Du das Gefühl hast, nicht alles verstanden zu haben - spiele einfach weiter und hab Spaß dabei. Dann wird immer mehr hängenbleiben.Und komm einfach auf das Tutorial zurück, wenn Du eine Frage hast, die in einem der vorhergegangenen Kapitel behandelt worden sein könnte.  

--- a/etc/doc/tutorial/en/01-Welcome-to-Sonic-Pi.md
+++ b/etc/doc/tutorial/en/01-Welcome-to-Sonic-Pi.md
@@ -1,3 +1,5 @@
+1 Welcome to Sonic Pi
+
 # Welcome friend :-)
 
 Welcome to Sonic Pi. Hopefully you're as excited to get started making

--- a/etc/doc/tutorial/en/01.1-Live-Coding.md
+++ b/etc/doc/tutorial/en/01.1-Live-Coding.md
@@ -1,1 +1,3 @@
+1.1 Live Coding
+
 # Live Coding

--- a/etc/doc/tutorial/en/01.2-Exploring-the-Interface.md
+++ b/etc/doc/tutorial/en/01.2-Exploring-the-Interface.md
@@ -1,3 +1,5 @@
+1.2 Exploring the Interface
+
 # The Sonic Pi Interface
 
 Sonic Pi has a very simple interface for coding music. Let's spend a

--- a/etc/doc/tutorial/en/01.3-Learning-through-Play.md
+++ b/etc/doc/tutorial/en/01.3-Learning-through-Play.md
@@ -1,3 +1,5 @@
+1.3 Learning through Play
+
 # Learning through Play
 
 Sonic Pi encourages you to learn about both computing and music through

--- a/etc/doc/tutorial/en/02-Synths.md
+++ b/etc/doc/tutorial/en/02-Synths.md
@@ -1,3 +1,5 @@
+2 Synths
+
 # Synths
 
 OK, enough of the intros - let's get into some sound.

--- a/etc/doc/tutorial/en/02.1-Your-First-Beeps.md
+++ b/etc/doc/tutorial/en/02.1-Your-First-Beeps.md
@@ -1,3 +1,5 @@
+2.1 Your First Beeps
+
 # Your First Beeps
 
 Take a look at the following code:

--- a/etc/doc/tutorial/en/02.2-Synth-Params.md
+++ b/etc/doc/tutorial/en/02.2-Synth-Params.md
@@ -1,3 +1,5 @@
+2.2 Synth Parameters
+
 # Synth Parameters: Amp and Pan
 
 As well as allowing you to control which note to play or which sample to

--- a/etc/doc/tutorial/en/02.3-Switching-Synths.md
+++ b/etc/doc/tutorial/en/02.3-Switching-Synths.md
@@ -1,3 +1,5 @@
+2.3 Switching Synths
+
 # Switching Synths
 
 So far we've had quite a lot of fun making beeps. However, you're

--- a/etc/doc/tutorial/en/02.4-Durations-with-Envelopes.md
+++ b/etc/doc/tutorial/en/02.4-Durations-with-Envelopes.md
@@ -1,3 +1,5 @@
+2.4 Duration with Envelopes
+
 # Duration with Envelopes
 
 In an earlier section, we looked at how we can use the `sleep` command

--- a/etc/doc/tutorial/en/03-Samples.md
+++ b/etc/doc/tutorial/en/03-Samples.md
@@ -1,3 +1,5 @@
+3 Samples
+
 # Samples
 
 Another great way to develop your music is to use pre-recorded

--- a/etc/doc/tutorial/en/03.1-Triggering-Samples.md
+++ b/etc/doc/tutorial/en/03.1-Triggering-Samples.md
@@ -1,3 +1,5 @@
+3.1 Triggering Samples
+
 # Triggering Samples
 
 Playing beeps is only the beginning. Something that's a lot of fun is

--- a/etc/doc/tutorial/en/03.2-Sample-Params.md
+++ b/etc/doc/tutorial/en/03.2-Sample-Params.md
@@ -1,3 +1,5 @@
+3.2 Sample Parameters
+
 # Sample Parameters: Amp and Pan
 
 As we saw with synths, we can easily control our sounds with

--- a/etc/doc/tutorial/en/03.3-Stretching-Samples.md
+++ b/etc/doc/tutorial/en/03.3-Stretching-Samples.md
@@ -1,3 +1,5 @@
+3.3 Stretching Samples
+
 # Stretching Samples
 
 Now that we can play a variety of synths and samples to create some music,

--- a/etc/doc/tutorial/en/03.4-Enveloped-Samples.md
+++ b/etc/doc/tutorial/en/03.4-Enveloped-Samples.md
@@ -1,3 +1,5 @@
+3.4 Enveloped Samples
+
 # Enveloped Samples
 
 It is also possible to modify the *duration* and *amplitude* of a sample

--- a/etc/doc/tutorial/en/03.5-Partial-Samples.md
+++ b/etc/doc/tutorial/en/03.5-Partial-Samples.md
@@ -1,3 +1,5 @@
+3.5 Partial Samples
+
 # Partial Samples
 
 This section will conclude our exploration of Sonic Pi's sample

--- a/etc/doc/tutorial/en/03.6-External-Samples.md
+++ b/etc/doc/tutorial/en/03.6-External-Samples.md
@@ -1,3 +1,5 @@
+3.6 External Samples
+
 # External Samples
 
 Whilst the built-in samples can get you up and started quickly, you

--- a/etc/doc/tutorial/en/04-Randomisation.md
+++ b/etc/doc/tutorial/en/04-Randomisation.md
@@ -1,3 +1,5 @@
+4 Randomisation
+
 # Randomisation
 
 A great way to add some interest into your music is using some random

--- a/etc/doc/tutorial/en/05-Programming-Structures.md
+++ b/etc/doc/tutorial/en/05-Programming-Structures.md
@@ -1,3 +1,5 @@
+5 Programming Structures
+
 # Programming Structures
 
 Now that you've learned the basics of creating sounds with `play` and

--- a/etc/doc/tutorial/en/05.1-Blocks.md
+++ b/etc/doc/tutorial/en/05.1-Blocks.md
@@ -1,3 +1,5 @@
+5.1 Blocks
+
 # Blocks
 
 A structure you'll see a lot in Sonic Pi is the block. Blocks allow us

--- a/etc/doc/tutorial/en/05.2-Iteration-and-Loops.md
+++ b/etc/doc/tutorial/en/05.2-Iteration-and-Loops.md
@@ -1,3 +1,5 @@
+5.2 Iteration and Loops
+
 # Iteration and Loops
 
 So far we've spent a lot of time looking at the different sounds you

--- a/etc/doc/tutorial/en/05.3-Conditionals.md
+++ b/etc/doc/tutorial/en/05.3-Conditionals.md
@@ -1,3 +1,5 @@
+5.3 Conditionals
+
 # Conditionals
 
 A common thing you'll likely find yourself wanting to do is to not only

--- a/etc/doc/tutorial/en/05.4-Threads.md
+++ b/etc/doc/tutorial/en/05.4-Threads.md
@@ -1,3 +1,5 @@
+5.4 Threads
+
 # Threads
 
 So you've made your killer bassline and a phat beat. How do you play

--- a/etc/doc/tutorial/en/05.5-Functions.md
+++ b/etc/doc/tutorial/en/05.5-Functions.md
@@ -1,3 +1,5 @@
+5.5 Functions
+
 # Functions
 
 Once you start writing lots of code, you may wish to find a way to

--- a/etc/doc/tutorial/en/05.6-Variables.md
+++ b/etc/doc/tutorial/en/05.6-Variables.md
@@ -1,3 +1,5 @@
+5.6 Variables
+
 # Variables
 
 A useful thing to do in your code is to create names for things. Sonic

--- a/etc/doc/tutorial/en/05.7-Thread-Synchronisation.md
+++ b/etc/doc/tutorial/en/05.7-Thread-Synchronisation.md
@@ -1,3 +1,5 @@
+5.7 Thread Synchronisation
+
 # Thread Synchronisation
 
 Once you have become sufficiently advanced live coding with a number of

--- a/etc/doc/tutorial/en/06-FX.md
+++ b/etc/doc/tutorial/en/06-FX.md
@@ -1,3 +1,5 @@
+6 FX
+
 # Studio FX
 
 One of the most rewarding and fun aspects of Sonic Pi is the ability to

--- a/etc/doc/tutorial/en/06.1-Adding-FX.md
+++ b/etc/doc/tutorial/en/06.1-Adding-FX.md
@@ -1,3 +1,5 @@
+6.1 Adding FX
+
 # Adding FX
 
 In this section we'll look at a couple of FX: reverb and echo. We'll

--- a/etc/doc/tutorial/en/06.2-FX-in-Practice.md
+++ b/etc/doc/tutorial/en/06.2-FX-in-Practice.md
@@ -1,3 +1,5 @@
+6.2 FX in Practice
+
 # FX in Practice
 
 Although they look deceptively simple on the outside, FX are actually

--- a/etc/doc/tutorial/en/07-Control.md
+++ b/etc/doc/tutorial/en/07-Control.md
@@ -1,3 +1,5 @@
+7 Control
+
 # Controlling running sounds
 
 So far we've looked at how you can trigger synths and samples, and

--- a/etc/doc/tutorial/en/07.1-Controlling-Running-Synths.md
+++ b/etc/doc/tutorial/en/07.1-Controlling-Running-Synths.md
@@ -1,3 +1,5 @@
+7.1 Controlling Running Synths
+
 # Controlling Running Synths
 
 So far we've only concerned ourselves with triggering new sounds and

--- a/etc/doc/tutorial/en/07.2-Controlling-FX.md
+++ b/etc/doc/tutorial/en/07.2-Controlling-FX.md
@@ -1,3 +1,5 @@
+7.2 Controlling FX
+
 # Controlling FX
 
 It is also possible to control FX, although this is achieved in a

--- a/etc/doc/tutorial/en/07.3-Sliding-Parameters.md
+++ b/etc/doc/tutorial/en/07.3-Sliding-Parameters.md
@@ -1,3 +1,5 @@
+7.3 Sliding Parameters
+
 # Sliding Parameters
 
 Whilst exploring the synth and FX args, you might have noticed that

--- a/etc/doc/tutorial/en/08-Data-Structures.md
+++ b/etc/doc/tutorial/en/08-Data-Structures.md
@@ -1,3 +1,5 @@
+8 Data Structures
+
 # Data Structures
 
 A very useful tool in a programmer's toolkit is a data structure.

--- a/etc/doc/tutorial/en/08.1-Lists.md
+++ b/etc/doc/tutorial/en/08.1-Lists.md
@@ -1,3 +1,5 @@
+8.1 Lists
+
 # Lists
 
 In this section we'll take a look at a data structure which is very

--- a/etc/doc/tutorial/en/08.2-Chords.md
+++ b/etc/doc/tutorial/en/08.2-Chords.md
@@ -1,3 +1,5 @@
+8.2 Chords
+
 # Chords
 
 Sonic Pi has built-in support for chord names which will return

--- a/etc/doc/tutorial/en/08.3-Scales.md
+++ b/etc/doc/tutorial/en/08.3-Scales.md
@@ -1,3 +1,5 @@
+8.3 Scales
+
 # Scales
 
 Sonic Pi has support for a wide range of scales. How about

--- a/etc/doc/tutorial/en/08.4-Rings.md
+++ b/etc/doc/tutorial/en/08.4-Rings.md
@@ -1,3 +1,5 @@
+8.4 Rings
+
 # Rings
 
 An interesting spin on standard lists are rings. If you know some

--- a/etc/doc/tutorial/en/09-Live-Coding.md
+++ b/etc/doc/tutorial/en/09-Live-Coding.md
@@ -1,3 +1,5 @@
+9 Live Coding
+
 # Live Coding
 
 One of the most exciting aspects of Sonic Pi is that it enables you to

--- a/etc/doc/tutorial/en/09.1-Live-Coding-Fundamentals.md
+++ b/etc/doc/tutorial/en/09.1-Live-Coding-Fundamentals.md
@@ -1,3 +1,5 @@
+9.1 Live Coding Fundamentals
+
 # Live Coding
 
 Now we've learned enough to really start having some fun. In this

--- a/etc/doc/tutorial/en/09.2-Live-Loops.md
+++ b/etc/doc/tutorial/en/09.2-Live-Loops.md
@@ -1,3 +1,5 @@
+9.2 Live Loops
+
 # Live Loops
 
 Ok, so this section of the tutorial is the real gem. If you only read

--- a/etc/doc/tutorial/en/09.3-Multiple-Live-Loops.md
+++ b/etc/doc/tutorial/en/09.3-Multiple-Live-Loops.md
@@ -1,3 +1,5 @@
+9.3 Multiple Live Loops
+
 # Multiple Live Loops
 
 Consider the following live loop:

--- a/etc/doc/tutorial/en/10-Essential-Knowledge.md
+++ b/etc/doc/tutorial/en/10-Essential-Knowledge.md
@@ -1,3 +1,5 @@
+10 Essential Knowledge
+
 # Essential Knowledge
 
 This section will cover some very useful - in fact *essential* - knowledge

--- a/etc/doc/tutorial/en/10.1-Using-Shortcuts.md
+++ b/etc/doc/tutorial/en/10.1-Using-Shortcuts.md
@@ -1,3 +1,5 @@
+10.1 Using Shortcuts
+
 # Using Shortcuts
 
 Sonic Pi is as much an instrument as a coding environment. Shortcuts can

--- a/etc/doc/tutorial/en/10.2-Shortcut-Cheatsheet.md
+++ b/etc/doc/tutorial/en/10.2-Shortcut-Cheatsheet.md
@@ -1,3 +1,5 @@
+10.2 Shortcut Cheatsheet
+
 # Shortcut Cheatsheet
 
 The following is a summary of the main shortcuts available within Sonic

--- a/etc/doc/tutorial/en/10.3-Sharing.md
+++ b/etc/doc/tutorial/en/10.3-Sharing.md
@@ -1,3 +1,5 @@
+10.3 Sharing
+
 # Sharing
 
 Sonic Pi is all about sharing and learning with each other. 

--- a/etc/doc/tutorial/en/10.4-Performing.md
+++ b/etc/doc/tutorial/en/10.4-Performing.md
@@ -1,3 +1,5 @@
+10.4 Performing
+
 # Performing
 
 One of the most exciting aspects of Sonic Pi is that it enables you to

--- a/etc/doc/tutorial/en/11-Conclusions.md
+++ b/etc/doc/tutorial/en/11-Conclusions.md
@@ -1,3 +1,5 @@
+11 Conclusions
+
 # Conclusions
 
 This concludes the Sonic Pi introductory tutorial. Hopefully you've


### PR DESCRIPTION
This replaces
https://github.com/samaaron/sonic-pi/pull/314
and
https://github.com/samaaron/sonic-pi/pull/302

This makes it possible to translate the Qt GUI using Qt Linguist.

The patch comes with a quick German translation which needs proofreading by someone who knows the synth terminology (since the goal was to make translation possible, not to translate).

Problems:

- This was developed and tested with Linux, only.
- The Qt Linguist translation workflow sucks with github. Transifex integration is planned, that should make things much smoother.
- The Sonic Pi main UI buttons are graphical elements that contain bitmapped text. These are not translatable, so it needs to be discussed if/how these need to be replaced, maybe in favor of a good old MDI-style UI.
- The build scripts for Win and Mac have not been tested.

Also, this makes translation of the tutorial possible

The approach used here is using qt-doc.rb to match the locale against a list of possible languages, which looks roughly like this:

    if ...
      { lang1 }
    else if ...
      { lang2 }
    else
      { default lang }

This patched qt-doc.rb uses the filenames of the tutorial markdown sources only to sort them. The chapter title is not extracted from the filename, anymore, but from the first line of text of each markdown file. The filenames now don't matter anymore, but I request that translators use the same filenames as in the `en/` directory.

Problems:

- `lupdate` should be run with an existing `ruby_help.h`, because there are `tr()` calls in there.
- This patch doesn't clean up the help system as such. `qt-doc.rb` is still quite hacky.
- I'm new to ruby. Please proofread / fix the programming style, thanks.

