### PR TITLE
INSTALL.md libqscintilla2-dev appears twice in dependencies list

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -67,7 +67,6 @@ In addition, under Ubuntu 14.04 based distributions try these:
 * `libqscintilla2-l10n`
 * `qt4-qmake`
 * `libqt4-dev`
-* `libqscintilla2-dev`
 
 Fedora package dependency names:
 


### PR DESCRIPTION
In Debian dependencies and, as well..., under Ubuntu 14.04 additional packages. Remove the latter.