### PR TITLE
i18n de - reorder tutorial chapters

### DIFF
--- a/etc/doc/tutorial/de/02.1-Your-First-Beeps.md
+++ b/etc/doc/tutorial/de/02.1-Your-First-Beeps.md
@@ -1,4 +1,4 @@
-1.1 Eure ersten Klänge
+2.1 Eure ersten Klänge
 
 # Eure ersten Klänge
 

--- a/etc/doc/tutorial/de/02.2-Synth-Params.md
+++ b/etc/doc/tutorial/de/02.2-Synth-Params.md
@@ -1,4 +1,4 @@
-2.1 Synth Parameter
+2.2 Synth Parameter
 
 # Parameters: Amp and Pan
 

--- a/etc/doc/tutorial/de/02.3-Switching-Synths.md
+++ b/etc/doc/tutorial/de/02.3-Switching-Synths.md
@@ -1,4 +1,4 @@
-2.2 Synths wechseln
+2.3 Synths wechseln
 
 # Synths wechseln
 

--- a/etc/doc/tutorial/de/02.4-Durations-with-Envelopes.md
+++ b/etc/doc/tutorial/de/02.4-Durations-with-Envelopes.md
@@ -1,4 +1,4 @@
-2.3 Dauern und Hüllkurven
+2.4 Dauern und Hüllkurven
 
 # Dauern und Hüllkurven
 

--- a/etc/doc/tutorial/de/09.1-Live-Coding-Fundamentals.md
+++ b/etc/doc/tutorial/de/09.1-Live-Coding-Fundamentals.md
@@ -1,4 +1,4 @@
-9.1 Live Coding
+9.1 Live Coding Grundlagen
 
 # Live Coding
 


### PR DESCRIPTION
English tutorial changed the order of the chapters, this does the same for the German files (and fixes the headlines accordingly).