### PR TITLE
Add `spark` method for quick graphing of numbers

### DIFF
--- a/app/server/sonicpi/Rakefile
+++ b/app/server/sonicpi/Rakefile
@@ -1,3 +1,4 @@
+# encoding: utf-8
 require 'rake'
 
 require 'rake/testtask'

--- a/app/server/sonicpi/lib/sonicpi/spiderapi.rb
+++ b/app/server/sonicpi/lib/sonicpi/spiderapi.rb
@@ -1,3 +1,4 @@
+## encoding: utf-8
 #--
 # This file is part of Sonic Pi: http://sonic-pi.net
 # Full project source: https://github.com/samaaron/sonic-pi
@@ -375,6 +376,40 @@ puts version.minor # => Prints out the minor version number such as 0",
 puts version.patch # => Prints out the patch level for this version such as 0"]
 
 
+    def spark(*values)
+      if values.first.is_a?(Array) && values.length == 1
+        values = values.first
+      end
+
+      return "" if values.length == 0
+      return "spark error: can't use nested arrays" if Array(values).flatten.length != Array(values).length
+      return "spark error: arguments should be numeric" if values.any? {|x| not (x.is_a? Numeric) }
+
+      #implementation stolen from @jcromartie https://gist.github.com/jcromartie/1367091
+      @ticks = %w[▁ ▂ ▃ ▄ ▅ ▆ ▇]
+      values = values.map { |x| x.to_f rescue 0.0 }
+      min = values.min
+      range = values.max - values.min
+      scale = @ticks.length - 1
+
+      # Guard lists of length 1 or repeating vals
+      range = 1.0 if range.to_f == 0.0
+
+      values.map {|x|
+        @ticks[(((x - min) / range) * scale).round]
+      }.join
+    end
+    doc name:         :spark,
+      introduced:     Version.new(2,4,0),
+      summary:        "Render a list of numeric values as a spark graph/bar chart",
+      args:           [],
+      opts:           nil,
+      accepts_block:  false,
+      doc:            "Given a list of numeric values, this method turns them into a string of bar heights. Useful for quickly graphing the shape of an array. Remember to use puts so you can see the output.",
+      examples:       [
+        "puts (spark (range 1, 5))    #=> ▁▃▅█",
+        "puts (spark (range 1, 5).to_a.shuffle) #=> ▃█▅▁"
+    ]
 
 
     def defonce(name, *opts, &block)

--- a/app/server/sonicpi/test/test_spark.rb
+++ b/app/server/sonicpi/test/test_spark.rb
@@ -1,0 +1,32 @@
+# encoding: utf-8
+#--
+# This file is part of Sonic Pi: http://sonic-pi.net
+# Full project source: https://github.com/samaaron/sonic-pi
+# License: https://github.com/samaaron/sonic-pi/blob/master/LICENSE.md
+#
+# Copyright 2013, 2014 by Sam Aaron (http://sam.aaron.name).
+# All rights reserved.
+#
+# Permission is granted for use, copying, modification, distribution,
+# and distribution of modified versions of this work as long as this
+# notice is included.
+#++
+
+require 'test/unit'
+require_relative "../lib/sonicpi/spiderapi"
+
+module SonicPi
+  class SparkTester < Test::Unit::TestCase
+    include SonicPi::SpiderAPI
+
+    def test_spark
+      assert_equal("▁▃▅▇", spark(1, 2, 3, 4))
+      assert_equal("▁▃▅▇", spark([1, 2, 3, 4]))
+      assert_equal("▁", spark(1))
+      assert_equal("▁▁▁", spark(3, 3, 3))
+      assert_equal("", spark([]))
+      assert_equal("spark error: can't use nested arrays", spark([1, 2], 3, 4))
+      assert_equal("spark error: arguments should be numeric", spark('foo', 'apple', 'banana', {silly: :hash}))
+    end
+  end
+end


### PR DESCRIPTION
This adds a small method to render a UTF-8 based spark graph to a
string, suitable for `puts`ing to standard out. It takes a list of
numeric arguments or a single array of numeric arguments. For nested
arrays or non-numeric lists it returns a string saying `"spark
error:..."`

See the tests in `test_spark.rb` for expected behaviour.

Implementation stolen from this gist:
https://gist.github.com/jcromartie/1367091