### PR TITLE
don't build empty structs in qt-doc.rb

### DIFF
--- a/app/server/bin/qt-doc.rb
+++ b/app/server/bin/qt-doc.rb
@@ -76,7 +76,7 @@ end.parse!
 
 # valid names: lang, synths, fx, samples, examples
 make_tab = lambda do |name, doc_items, titleize=false, should_sort=true, with_keyword=false|
-
+  return if doc_items.empty?
   list_widget = "#{name}NameList"
   layout = "#{name}Layout"
   tab_widget = "#{name}TabWidget"


### PR DESCRIPTION
Visual Studio won't compile structs with empty initializers, so bypass make_tab unless there are items to be added.