### PR TITLE
update Windows installer and build script

### DIFF
--- a/app/gui/qt/sonic-pi.bat
+++ b/app/gui/qt/sonic-pi.bat
@@ -1,1 +1,0 @@
-start "" "%~dp0\app\gui\qt\release\Sonic-Pi.exe"

--- a/app/gui/qt/sonic-pi.wxs
+++ b/app/gui/qt/sonic-pi.wxs
@@ -2,35 +2,42 @@
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi" xmlns:util="http://schemas.microsoft.com/wix/UtilExtension" xmlns:firewall="http://schemas.microsoft.com/wix/FirewallExtension">
 <!-- so you want to be a WiXard?
 
-> heat dir etc -gg -g1 -sfrag -dr SonicPi -cg ETC -out etc.wxs 
-> heat dir etc -gg -g1 -sfrag -dr AppDir -cg GUI -out gui.wxs 
-> heat dir etc -gg -g1 -sfrag -dr AppDir -cg SERVER -out server.wxs 
-> candle sonic-pi.wxs etc.wxs gui.wxs server.wxs -ext WixUtilExtension -ext WixFirewallExtension
-> light sonic-pi.wixobj etc.wixobj gui.wixobj server.wixobj -ext WixUtilExtension -ext WixUIExtension -ext WixFirewallExtension -o Sonic-Pi.msi -b etc -b app\gui -b app\server
+heat dir etc -gg -g1 -sfrag -dir SonicPi -cg ETC -out etc.wxs 
+heat dir etc -gg -g1 -sfrag -dir AppDir -cg GUI -out gui.wxs 
+heat dir etc -gg -g1 -sfrag -dir AppDir -cg SERVER -out server.wxs 
+edit sonic-pi.wxs
+    change version number
+edit gui.wxs
+    remove sonic-pi.exe component and componentref
+edit server.wxs
+	remove scsynth.exe component and componentref
+candle sonic-pi.wxs etc.wxs gui.wxs server.wxs -ext WixUtilExtension
+light sonic-pi.wixobj etc.wixobj gui.wixobj server.wixobj -ext WixUtilExtension -ext WixUIExtension -o Sonic-Pi.msi -b etc -b app\gui -b app\server
 
 -->
-    <Product Id="*" Name="Sonic Pi" Language="1033" Version="2.3" Manufacturer="Sonic Pi" UpgradeCode="ECA5D03B-CEBD-4672-A0A2-176CBCBA4429">
-        <Package Description="Sonic Pi Installer" Comments="Sonic Pi Installer" InstallerVersion="200" Compressed="yes" />
-		<MajorUpgrade AllowDowngrades="yes" Schedule="afterInstallInitialize"/>
+    <Product Id="*" Name="Sonic Pi" Language="1033" Version="2.4" Manufacturer="Sonic Pi" UpgradeCode="ECA5D03B-CEBD-4672-A0A2-176CBCBA4429">
+        <Package Description="Sonic Pi Installer" Comments="Sonic Pi Installer" InstallScope="perMachine" InstallerVersion="200" Compressed="yes" />
+		<Property Id="REINSTALLMODE" Value="amus"/>
+		<MajorUpgrade AllowDowngrades="yes" Schedule="afterInstallInitialize"/>		
         <Media Id="1" Cabinet="simple.cab" EmbedCab="yes" />
         <Directory Id="TARGETDIR" Name="SourceDir">
             <Directory Id="ProgramFilesFolder" Name="PFiles">
                 <Directory Id="SonicPi" Name="Sonic Pi">
 					<Directory Id="AppDir" Name="app">
-                        <Directory Id="GuiDir" Name="gui">
-                            <Directory Id="QtDir" Name="qt">
+                        <Directory Id="GUI" Name="gui">
+                            <Directory Id="QT" Name="qt">
                                 <Directory Id="RELEASE" Name="release">
                                     <Component Id="SONIC_PI.EXE" DiskId="1" Guid="BA4C72F9-C198-436A-B1E2-B2DF8EC65960">
                                         <File Id="SONIC_PI.EXE" Name="sonic-pi.exe" Source="SourceDir\app\gui\qt\release\sonic-pi.exe" />
-                                        <firewall:FirewallException Id="SonicPiFirewall" Name="SonicPiFirewall" Scope="any" IgnoreFailure="yes" Program="[#SONIC_PI.EXE]" />
-                                        <firewall:FirewallException Id="SonicPiSynthFirewall" Name="SonicPiSynthFirewall" IgnoreFailure="yes" Program="[#SCSYNTH.EXE]" Scope="any" />
+											<firewall:FirewallException Id="SonicPiFirewall" Name="SonicPiFirewall" Scope="any" IgnoreFailure="yes" Program="[#SONIC_PI.EXE]" />
+											<firewall:FirewallException Id="SonicPiSynthFirewall" Name="SonicPiSynthFirewall" IgnoreFailure="yes" Program="[#SCSYNTH.EXE]" Scope="any" />
                                     </Component>
 								</Directory>
 							</Directory>
 						</Directory>
-						<Directory Id="ServerDir" Name="server">
-							<Directory Id="NativeDir" Name="native">
-								<Directory Id="NativeWindowsDir" Name="windows">
+						<Directory Id="SERVER" Name="server">
+							<Directory Id="NATIVE" Name="native">
+								<Directory Id="WINDOWS" Name="windows">
                                     <Component Id="SCSYNTH.EXE" DiskId="1" Guid="AE2F1766-69A6-4EFB-9DAE-E11A2BD717F5">
                                         <File Id="SCSYNTH.EXE" Name="scsynth.exe" Source="SourceDir\app\server\native\windows\scsynth.exe" />
                                     </Component>

--- a/app/gui/qt/win-build-app.bat
+++ b/app/gui/qt/win-build-app.bat
@@ -12,6 +12,7 @@ qmake -o Makefile SonicPi.pro
 
 nmake
 @if ERRORLEVEL==9009 goto :nocl
+@if ERRORLEVEL==1 goto :done
 
 nmake install
 cd release


### PR DESCRIPTION
Windows installer updated to remove unnecessary firewall rules, install for all users, and always reinstall all components.

Build script updated to break on compile errors.

Old batch file removed.