### PR TITLE
i18n - update German translation

### DIFF
--- a/TRANSLATION.md
+++ b/TRANSLATION.md
@@ -29,7 +29,7 @@ Translations for the Qt GUI are located in
 - `cd app/gui/qt`
 - Want to add a new language to the Qt GUI? Then first add a reference
   to the new language file to `SonicPi.Pro` and `SonicPi.qrc`, then run
-  `lupdate` to have the new .ts file created for you.
+  `lupdate -pro SonicPi.pro` to have the new .ts file created for you.
 - Edit the translation with Qt Linguist,
   `linguist lang/sonic-pi_<LANG>.ts`.
 - Build a new binary, test it.
@@ -43,7 +43,7 @@ Messages you want to have translated need to be marked with `tr()`
 in the source.
 
 If you added or changed a translation string during development,
-don't forget to run `lupdate --pro SonicPi.pro` afterwards to update
+don't forget to run `lupdate -pro SonicPi.pro` afterwards to update
 the `.ts` files.
 
 Then push them back to github and ask the translators to pull and

--- a/app/gui/qt/lang/sonic-pi_de.ts
+++ b/app/gui/qt/lang/sonic-pi_de.ts
@@ -5,112 +5,112 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../mainwindow.cpp" line="177"/>
+        <location filename="../mainwindow.cpp" line="180"/>
         <source>Preferences</source>
         <translation>Einstellungen</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="186"/>
+        <location filename="../mainwindow.cpp" line="189"/>
         <source>Log</source>
         <translation>Protokoll</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="255"/>
-        <location filename="../mainwindow.cpp" line="1277"/>
-        <location filename="../mainwindow.cpp" line="1295"/>
+        <location filename="../mainwindow.cpp" line="258"/>
+        <location filename="../mainwindow.cpp" line="1319"/>
+        <location filename="../mainwindow.cpp" line="1337"/>
         <source>Sonic Pi</source>
         <translation>Sonic Pi</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="327"/>
+        <location filename="../mainwindow.cpp" line="330"/>
         <source>ruby could not be started, is it installed and in your PATH?</source>
         <translation>Konnte ruby nicht starten - ist es korrekt installiert?</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="346"/>
+        <location filename="../mainwindow.cpp" line="349"/>
         <source>Failed to start server, please check %1.</source>
         <oldsource>Failed to start server, please check </oldsource>
         <translation>Konnte Server nicht starten, bitte in %1 nachsehen.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="403"/>
+        <location filename="../mainwindow.cpp" line="414"/>
         <source>Raspberry Pi System Volume</source>
         <translation>Raspberry Pi Lautstärke</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="406"/>
+        <location filename="../mainwindow.cpp" line="417"/>
         <source>Studio Settings</source>
         <translation>Studio-Einstellungen</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="423"/>
+        <location filename="../mainwindow.cpp" line="434"/>
         <source>Raspberry Pi Audio Output</source>
         <translation>Raspberry Pi Audio-Ausgabe</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="425"/>
+        <location filename="../mainwindow.cpp" line="436"/>
         <source>&amp;Default</source>
         <translation>&amp;Standard</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="426"/>
+        <location filename="../mainwindow.cpp" line="437"/>
         <source>&amp;Headphones</source>
         <translation>&amp;Kopfhörerbuchse</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="427"/>
+        <location filename="../mainwindow.cpp" line="438"/>
         <source>&amp;HDMI</source>
         <translation>&amp;HDMI</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="621"/>
+        <location filename="../mainwindow.cpp" line="647"/>
         <source>Save Current Workspace</source>
         <translation>Arbeitsbereich speichern</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="660"/>
+        <location filename="../mainwindow.cpp" line="686"/>
         <source>Running Code...</source>
         <oldsource>Running Code....</oldsource>
         <translation>Führe Programm aus...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="703"/>
+        <location filename="../mainwindow.cpp" line="729"/>
         <source>Beautifying...</source>
         <oldsource>Beautifying....</oldsource>
         <translation>Textausrichtung...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="714"/>
+        <location filename="../mainwindow.cpp" line="740"/>
         <source>Reloading...</source>
         <oldsource>Reloading....</oldsource>
         <translation>Neu laden...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="721"/>
+        <location filename="../mainwindow.cpp" line="761"/>
         <source>Enabling Mixer HPF...</source>
         <oldsource>Enabling Mixer HPF....</oldsource>
         <translation>Mixer-Hochpassfilter aktiv...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="729"/>
+        <location filename="../mainwindow.cpp" line="769"/>
         <source>Disabling Mixer HPF...</source>
         <oldsource>Disabling Mixer HPF....</oldsource>
         <translation>Mixer-Hochpassfilter inaktiv...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="143"/>
-        <location filename="../mainwindow.cpp" line="682"/>
+        <location filename="../mainwindow.cpp" line="146"/>
+        <location filename="../mainwindow.cpp" line="708"/>
         <source>Workspace %1</source>
         <translation>Arbeitsbereich %1</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="404"/>
+        <location filename="../mainwindow.cpp" line="415"/>
         <source>Use this slider to change the system volume of your Raspberry Pi.</source>
         <oldsource>Use this slider to change the system volume of your Raspberry Pi</oldsource>
-        <translation>Hier veränderst du die Systemlautstärke deines Raspberry Pi.</translation>
+        <translation>Hier veränderst Du die Systemlautstärke Deines Raspberry Pi.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="407"/>
+        <location filename="../mainwindow.cpp" line="418"/>
         <source>Advanced audio settings for working with
 external PA systems when performing with Sonic Pi.</source>
         <oldsource>Advanced audio settings for working with external PA systems when performing with Sonic Pi.</oldsource>
@@ -118,17 +118,17 @@ external PA systems when performing with Sonic Pi.</source>
 an einem externen Verstärker gut gebrauchen kann.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="408"/>
+        <location filename="../mainwindow.cpp" line="419"/>
         <source>Invert Stereo</source>
         <translation>Stereokanäle tauschen</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="410"/>
+        <location filename="../mainwindow.cpp" line="421"/>
         <source>Force Mono</source>
         <translation>Mono-Ton erzwingen</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="424"/>
+        <location filename="../mainwindow.cpp" line="435"/>
         <source>Your Raspberry Pi has two forms of audio output.
 Firstly, there is the headphone jack of the Raspberry Pi itself.
 Secondly, some HDMI monitors/TVs support audio through the HDMI port.
@@ -141,311 +141,339 @@ For example, if you have headphones connected to your Raspberry Pi, choose &apos
         <translation>Dein Raspberry Pi hat zwei verschiedene Anschlüsse für die Tonausgabe.
 Erstens: Die analoge Kopfhörerbuchse am Raspberry Pi selbst.
 Zweitens: Der digitale HDMI-Monitoranschluss, der den Ton zum Monitor/Fernseher überträgt.
-Hier wählst du aus, über welchen davon die Tonausgabe gehen soll.</translation>
+Hier wählst Du aus, über welchen davon die Tonausgabe gehen soll.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="447"/>
+        <location filename="../mainwindow.cpp" line="458"/>
         <source>Debug Options</source>
         <translation>Debug-Einstellungen</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="448"/>
+        <location filename="../mainwindow.cpp" line="459"/>
         <source>Print output</source>
         <translation>Ausgabe anzeigen</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="449"/>
+        <location filename="../mainwindow.cpp" line="460"/>
         <source>Check synth args</source>
         <translation>Synth-Parameter prüfen</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="450"/>
+        <location filename="../mainwindow.cpp" line="461"/>
         <source>Clear output on run</source>
         <translation>Vorm Ausführen Ausgabe leeren</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="515"/>
+        <location filename="../mainwindow.cpp" line="470"/>
+        <source>Updates</source>
+        <translation>Updates</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="471"/>
+        <source>Check for updates</source>
+        <translation>Auf Updates prüfen</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="474"/>
+        <source>Configure whether Sonic Pi may check for new updates on launch.
+Please note, the checking process includes sending
+anonymous information to the Sonic Pi server.</source>
+        <translation>Sonic Pi kann beim Programmstart nachsehen, ob die Software noch aktuell ist.
+Bitte beachte, dass dabei einige anonymisierte Informationen
+an den Server des Sonic-Pi-Entwicklers geschickt werden.</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="541"/>
         <source>We&apos;re sorry, but Sonic Pi was unable to start...</source>
         <translation>Sonic Pi konnte nicht starten. Das tut uns leid...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="736"/>
+        <location filename="../mainwindow.cpp" line="776"/>
         <source>Enabling Mixer LPF...</source>
         <oldsource>Enabling Mixer LPF....</oldsource>
         <translation>Mixer-Tiefpassfilter aktiv...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="744"/>
+        <location filename="../mainwindow.cpp" line="784"/>
         <source>Disabling Mixer LPF...</source>
         <oldsource>Disabling Mixer LPF....</oldsource>
         <translation>Mixer-Tiefpassfilter inaktiv...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="751"/>
+        <location filename="../mainwindow.cpp" line="791"/>
         <source>Enabling Inverted Stereo...</source>
         <oldsource>Enabling Inverted Stereo....</oldsource>
         <translation>Stereo-Kanaltausch aktiv...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="758"/>
+        <location filename="../mainwindow.cpp" line="798"/>
         <source>Enabling Standard Stereo...</source>
         <oldsource>Enabling Standard Stereo....</oldsource>
         <translation>Stereo-Kanaltausch inaktiv...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="765"/>
+        <location filename="../mainwindow.cpp" line="805"/>
         <source>Mono Mode...</source>
         <oldsource>Mono Mode....</oldsource>
         <translation>Mono-Ton aktiv...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="772"/>
+        <location filename="../mainwindow.cpp" line="812"/>
         <source>Stereo Mode...</source>
         <oldsource>Stereo Mode....</oldsource>
         <translation>Stereo-Ton aktiv...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="780"/>
+        <location filename="../mainwindow.cpp" line="820"/>
         <source>Stopping...</source>
         <translation>Stopp...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="844"/>
-        <location filename="../mainwindow.cpp" line="860"/>
+        <location filename="../mainwindow.cpp" line="884"/>
+        <location filename="../mainwindow.cpp" line="900"/>
         <source>Updating System Volume.</source>
         <oldsource>Updating system volume.</oldsource>
         <translation>Setze System-Lautstärke.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="873"/>
-        <location filename="../mainwindow.cpp" line="879"/>
+        <location filename="../mainwindow.cpp" line="913"/>
+        <location filename="../mainwindow.cpp" line="919"/>
         <source>Switching To Headphone Audio Output.</source>
         <oldsource>Switching To Headphone Audio Output .</oldsource>
         <translation>Umschalten auf Kopfhörerbuchse.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="892"/>
-        <location filename="../mainwindow.cpp" line="898"/>
+        <location filename="../mainwindow.cpp" line="932"/>
+        <location filename="../mainwindow.cpp" line="938"/>
         <source>Switching To HDMI Audio Output.</source>
         <oldsource>Switching To HDMI Audio Output .</oldsource>
         <translation>Umschalten auf HDMI-Anschluss.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="911"/>
-        <location filename="../mainwindow.cpp" line="917"/>
+        <location filename="../mainwindow.cpp" line="951"/>
+        <location filename="../mainwindow.cpp" line="957"/>
         <source>Switching To Default Audio Output.</source>
         <oldsource>Switching To Default Audio Output .</oldsource>
         <translation>Umschalten auf Standard-Tonausgabe.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1041"/>
+        <location filename="../mainwindow.cpp" line="1081"/>
         <source>Run</source>
         <translation>Ausführen</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1042"/>
+        <location filename="../mainwindow.cpp" line="1082"/>
         <source>Run the code in the current workspace</source>
         <translation>Das Programm im aktuellen Arbeitsbereich ausführen</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1046"/>
+        <location filename="../mainwindow.cpp" line="1086"/>
         <source>Stop</source>
         <translation>Stopp</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1047"/>
+        <location filename="../mainwindow.cpp" line="1087"/>
         <source>Stop all running code</source>
         <translation>Alle laufenden Programme beenden</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1050"/>
+        <location filename="../mainwindow.cpp" line="1090"/>
         <source>Save As...</source>
         <translation>Speichern als...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1051"/>
+        <location filename="../mainwindow.cpp" line="1091"/>
         <source>Save current workspace as an external file</source>
         <translation>Den aktuellen Arbeitsbereich als Datei speichern</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1054"/>
+        <location filename="../mainwindow.cpp" line="1094"/>
         <source>Info</source>
         <translation>Info</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1055"/>
+        <location filename="../mainwindow.cpp" line="1095"/>
         <source>See information about Sonic Pi</source>
         <translation>Einige Informationen über Sonic Pi</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="230"/>
-        <location filename="../mainwindow.cpp" line="1059"/>
+        <location filename="../mainwindow.cpp" line="233"/>
+        <location filename="../mainwindow.cpp" line="1099"/>
         <source>Help</source>
         <translation>Hilfe</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1060"/>
+        <location filename="../mainwindow.cpp" line="747"/>
+        <source>Enabling update checking....</source>
+        <translation>Update-Prüfung aktiv...</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="754"/>
+        <source>Disabling update checking....</source>
+        <translation>Update-Prüfung inaktiv...</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1100"/>
         <source>Toggle help pane</source>
         <translation>Hilfetexte anzeigen</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1063"/>
+        <location filename="../mainwindow.cpp" line="1103"/>
         <source>Prefs</source>
         <translation>Einstellungen</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1064"/>
+        <location filename="../mainwindow.cpp" line="1104"/>
         <source>Toggle preferences pane</source>
         <translation>Einstellungen anzeigen</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1068"/>
-        <location filename="../mainwindow.cpp" line="1069"/>
-        <location filename="../mainwindow.cpp" line="1179"/>
-        <location filename="../mainwindow.cpp" line="1180"/>
+        <location filename="../mainwindow.cpp" line="1108"/>
+        <location filename="../mainwindow.cpp" line="1109"/>
+        <location filename="../mainwindow.cpp" line="1219"/>
+        <location filename="../mainwindow.cpp" line="1220"/>
         <source>Start Recording</source>
         <translation>Aufnahme starten</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1073"/>
+        <location filename="../mainwindow.cpp" line="1113"/>
         <source>Auto-Align Text</source>
         <oldsource>Auto Align Text</oldsource>
         <translation>Text automatisch ausrichten</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1074"/>
+        <location filename="../mainwindow.cpp" line="1114"/>
         <source>Auto-align text</source>
         <translation>Text automatisch ausrichten</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1078"/>
+        <location filename="../mainwindow.cpp" line="1118"/>
         <source>Increase Text Size</source>
         <translation>Text vergrößern</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1079"/>
+        <location filename="../mainwindow.cpp" line="1119"/>
         <source>Make text bigger</source>
         <translation>Text vergrößern</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1084"/>
+        <location filename="../mainwindow.cpp" line="1124"/>
         <source>Decrease Text Size</source>
         <translation>Text verkleinern</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1085"/>
+        <location filename="../mainwindow.cpp" line="1125"/>
         <source>Make text smaller</source>
         <translation>Text verkleinern</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1091"/>
+        <location filename="../mainwindow.cpp" line="1131"/>
         <source>Tools</source>
         <translation>Werkzeuge</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1131"/>
+        <location filename="../mainwindow.cpp" line="1171"/>
         <source>About</source>
         <translation>Über Sonic Pi</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1131"/>
+        <location filename="../mainwindow.cpp" line="1171"/>
         <source>Core Team</source>
         <translation>Kern-Team</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1131"/>
+        <location filename="../mainwindow.cpp" line="1171"/>
         <source>Contributors</source>
         <translation>Mitwirkende</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1132"/>
+        <location filename="../mainwindow.cpp" line="1172"/>
         <source>Community</source>
         <translation>Gemeinschaft</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1132"/>
+        <location filename="../mainwindow.cpp" line="1172"/>
         <source>License</source>
         <translation>Lizenz</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1132"/>
+        <location filename="../mainwindow.cpp" line="1172"/>
         <source>History</source>
         <translation>Änderungen</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1152"/>
+        <location filename="../mainwindow.cpp" line="1192"/>
         <source>Sonic Pi - Info</source>
         <translation>Über Sonic Pi</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1172"/>
-        <location filename="../mainwindow.cpp" line="1173"/>
+        <location filename="../mainwindow.cpp" line="1212"/>
+        <location filename="../mainwindow.cpp" line="1213"/>
         <source>Stop Recording</source>
         <translation>Aufnahme stoppen</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1184"/>
+        <location filename="../mainwindow.cpp" line="1224"/>
         <source>Save Recording</source>
         <translation>Aufnahme speichern</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1199"/>
+        <location filename="../mainwindow.cpp" line="1239"/>
         <source>Ready</source>
         <translation>Bereit</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1278"/>
+        <location filename="../mainwindow.cpp" line="1320"/>
         <source>Cannot read file %1:
 %2.</source>
         <translation>Kann Datei %1 nicht laden:
 %2.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1288"/>
+        <location filename="../mainwindow.cpp" line="1330"/>
         <source>File loaded</source>
         <translation>Datei geladen</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1296"/>
+        <location filename="../mainwindow.cpp" line="1338"/>
         <source>Cannot write file %1:
 %2.</source>
         <translation>Kann Datei %1 nicht schreiben:
 %2.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1312"/>
+        <location filename="../mainwindow.cpp" line="1354"/>
         <source>File saved</source>
         <translation>Datei geschrieben</translation>
     </message>
     <message>
-        <location filename="../ruby_help.h" line="32"/>
-        <location filename="../ruby_help.h" line="41"/>
-        <location filename="../ruby_help.h" line="96"/>
+        <location filename="../ruby_help.h" line="64"/>
+        <location filename="../ruby_help.h" line="122"/>
         <source>Tutorial</source>
         <translation>Tutorial</translation>
     </message>
     <message>
-        <location filename="../ruby_help.h" line="123"/>
+        <location filename="../ruby_help.h" line="152"/>
         <source>Examples</source>
         <translation>Beispiele</translation>
     </message>
     <message>
-        <location filename="../ruby_help.h" line="156"/>
+        <location filename="../ruby_help.h" line="190"/>
         <source>Synths</source>
         <translation>Synths</translation>
     </message>
     <message>
-        <location filename="../ruby_help.h" line="188"/>
+        <location filename="../ruby_help.h" line="222"/>
         <source>Fx</source>
         <translation>Fx</translation>
     </message>
     <message>
-        <location filename="../ruby_help.h" line="205"/>
+        <location filename="../ruby_help.h" line="239"/>
         <source>Samples</source>
         <translation>Samples</translation>
     </message>
     <message>
-        <location filename="../ruby_help.h" line="313"/>
+        <location filename="../ruby_help.h" line="348"/>
         <source>Lang</source>
         <translation>Lang</translation>
     </message>

--- a/app/gui/qt/mainwindow.cpp
+++ b/app/gui/qt/mainwindow.cpp
@@ -471,7 +471,7 @@ void MainWindow::initPrefsWindow() {
   check_updates = new QCheckBox(tr("Check for updates"));
   connect(check_updates, SIGNAL(clicked()), this, SLOT(update_check_updates()));
 
-  update_box->setToolTip("Configure whether Sonic Pi may check for new updates on launch. Please note, the checking process includes sending anonymous information to the Sonic Pi server.");
+  update_box->setToolTip(tr("Configure whether Sonic Pi may check for new updates on launch. Please note, the checking process includes sending anonymous information to the Sonic Pi server."));
 
   QVBoxLayout *update_box_layout = new QVBoxLayout;
   update_box_layout->addWidget(check_updates);

--- a/app/gui/qt/mainwindow.cpp
+++ b/app/gui/qt/mainwindow.cpp
@@ -471,7 +471,7 @@ void MainWindow::initPrefsWindow() {
   check_updates = new QCheckBox(tr("Check for updates"));
   connect(check_updates, SIGNAL(clicked()), this, SLOT(update_check_updates()));
 
-  update_box->setToolTip(tr("Configure whether Sonic Pi may check for new updates on launch.\nPlease note, the checking process includes\nsending anonymous information to the Sonic Pi server."));
+  update_box->setToolTip(tr("Configure whether Sonic Pi may check for new updates on launch.\nPlease note, the checking process includes sending\nanonymous information to the Sonic Pi server."));
 
   QVBoxLayout *update_box_layout = new QVBoxLayout;
   update_box_layout->addWidget(check_updates);

--- a/app/gui/qt/mainwindow.cpp
+++ b/app/gui/qt/mainwindow.cpp
@@ -744,14 +744,14 @@ void MainWindow::reloadServerCode()
 
 void MainWindow::enableCheckUpdates()
 {
-  statusBar()->showMessage(tr("enabling update checking...."), 2000);
+  statusBar()->showMessage(tr("Enabling update checking...."), 2000);
   Message msg("/enable-update-checking");
   sendOSC(msg);
 }
 
 void MainWindow::disableCheckUpdates()
 {
-  statusBar()->showMessage(tr("disabling update checking...."), 2000);
+  statusBar()->showMessage(tr("Disabling update checking...."), 2000);
   Message msg("/disable-update-checking");
   sendOSC(msg);
 }

--- a/app/gui/qt/mainwindow.cpp
+++ b/app/gui/qt/mainwindow.cpp
@@ -471,7 +471,7 @@ void MainWindow::initPrefsWindow() {
   check_updates = new QCheckBox(tr("Check for updates"));
   connect(check_updates, SIGNAL(clicked()), this, SLOT(update_check_updates()));
 
-  update_box->setToolTip(tr("Configure whether Sonic Pi may check for new updates on launch. Please note, the checking process includes sending anonymous information to the Sonic Pi server."));
+  update_box->setToolTip(tr("Configure whether Sonic Pi may check for new updates on launch.\nPlease note, the checking process includes\nsending anonymous information to the Sonic Pi server."));
 
   QVBoxLayout *update_box_layout = new QVBoxLayout;
   update_box_layout->addWidget(check_updates);


### PR DESCRIPTION
also adds one missing tr() call and fixes an error in the TRANSLATION.md doc file.