### PR TITLE
i18n - turn off translations for this release

### DIFF
--- a/TRANSLATION.md
+++ b/TRANSLATION.md
@@ -8,6 +8,12 @@ Translations for the tutorial are located in
 Translations for the Qt GUI are located in
 [`app/gui/qt/lang/sonic-pi_<LANG>.ts`](./app/gui/qt/lang/).
 
+## Please note
+
+The i18n code is disabled right now. If you want to enable it to test
+your translation, set the required constants in `main.cpp`
+(`ENABLE_I18N`) and `qt-doc.rb` (`enable_i18n`).
+
 ## Translating the tutorial
 
 - Sign up with [github](https://help.github.com/categories/bootcamp/)

--- a/app/gui/qt/main.cpp
+++ b/app/gui/qt/main.cpp
@@ -11,6 +11,9 @@
 // notice is included.
 //++
 
+// i18n not enabled until translations are ready
+// #define ENABLE_I18N
+
 #include <QApplication>
 #include <QSplashScreen>
 #include <QPixmap>
@@ -28,6 +31,7 @@ int main(int argc, char *argv[])
 
   QApplication app(argc, argv);
 
+#ifdef ENABLE_I18N
   QString systemLocale = QLocale::system().name();
 
   QTranslator qtTranslator;
@@ -40,6 +44,7 @@ int main(int argc, char *argv[])
     std::cout << "Please contact us if you want to translate Sonic Pi to your language." << std::endl;
   }
   app.installTranslator(&translator);
+#endif
   
   app.setApplicationName(QObject::tr("Sonic Pi"));
   app.setStyle("gtk");

--- a/app/server/bin/qt-doc.rb
+++ b/app/server/bin/qt-doc.rb
@@ -25,6 +25,8 @@ require_relative "../sonicpi/lib/sonicpi/mods/sound"
 require 'kramdown'
 require 'active_support/inflector'
 
+# i18n not enabled until translations are ready
+enable_i18n = false
 
 class MarkdownConverter
   def self.convert(contents)
@@ -176,16 +178,20 @@ ruby_html_map = {
 #  "loop" => "Loop forever",
 }
 
-# this will sort locale code names by reverse length
-# to make sure that a more specific locale is handled
-# before the generic language code,
-# e.g., "de_CH" should be handled before "de"
-languages = Dir.
-  glob("#{tutorial_path}/*").
-  select {|f| File.directory? f}.
-  map {|f| File.basename f}.
-  select {|n| n != "en"}.
-  sort_by {|n| -n.length}
+if enable_i18n then
+  # this will sort locale code names by reverse length
+  # to make sure that a more specific locale is handled
+  # before the generic language code,
+  # e.g., "de_CH" should be handled before "de"
+  languages = Dir.
+    glob("#{tutorial_path}/*").
+    select {|f| File.directory? f}.
+    map {|f| File.basename f}.
+    select {|n| n != "en"}.
+    sort_by {|n| -n.length}
+else
+  languages = []
+end
 
 docs << "\n  QString systemLocale = QLocale::system().name();\n\n" unless languages.empty?
 


### PR DESCRIPTION
Note: There are two locations where i18n needs to be enabled, later: `qt-doc.rb` and `main.cpp`