### PR TITLE
Make it easier to build synths

### DIFF
--- a/etc/synthdefs/project.clj
+++ b/etc/synthdefs/project.clj
@@ -1,0 +1,4 @@
+(defproject sp "0.0.1-SNAPSHOT"
+  :dependencies [[org.clojure/clojure "1.5.1"]
+                 [overtone "0.10-SNAPSHOT"]]
+  :source-paths ["."])

--- a/etc/synthdefs/synth_designs.clj
+++ b/etc/synthdefs/synth_designs.clj
@@ -15,7 +15,7 @@
 ;; SuperCollider compatible binary files. Overtone is Sonic Pi's big
 ;; brother. See: http://overtone.github.io
 
-(ns sp
+(ns sp.synth-designs
   (:use [overtone.live])
 
   (:require [clojure.string :as str]

--- a/etc/synthdefs/synth_designs_incubator.clj
+++ b/etc/synthdefs/synth_designs_incubator.clj
@@ -15,7 +15,7 @@
 ;; SuperCollider compatible binary files. Overtone is Sonic Pi's big
 ;; brother. See: http://overtone.github.io
 
-(ns sp
+(ns sp.synth-designs-incubator
   (:use [overtone.live])
 
   (:require [clojure.string :as str]


### PR DESCRIPTION
# Goal

Make it easier to compile synths.

## What

Some simple initial steps to make building synths easier.

1. Add a project.clj which makes it easier to boot a repl with the correct overtone version.
2. Use correct Clojure filenames/namespaces.

My end thought was to have a Makefile within /etc which runs something like `lein run sp.synth-designs.clj`.
Which will generate all the synths compiled files. Still stuck on the fn limit. But some simple steps here initially.