### PR TITLE
Fix multibyte chars in OSC implementation

### DIFF
--- a/app/gui/qt/oschandler.cpp
+++ b/app/gui/qt/oschandler.cpp
@@ -91,7 +91,7 @@ void OscHandler::oscMessage(std::vector<char> buffer){
             QMetaObject::invokeMethod( out, "setTextColor", Qt::QueuedConnection, Q_ARG(QColor, QColor("green")));
           }
 
-          ss.append(QString::fromStdString(s));
+          ss.append(QString::fromUtf8(s.c_str()));
 
           QMetaObject::invokeMethod( out, "insertPlainText", Qt::QueuedConnection,
                                      Q_ARG(QString, ss) );

--- a/app/server/sonicpi/lib/sonicpi/oscencode.rb
+++ b/app/server/sonicpi/lib/sonicpi/oscencode.rb
@@ -127,7 +127,7 @@ module SonicPi
     def encode_string(s)
       s = s.sub(/\000.*\z/, '')
       s << "\000"
-      (s << ("\000" * ((4 - (s.size % 4)) % 4)))
+      (s << ("\000" * ((4 - (s.bytesize % 4)) % 4)))
     end
 
     def time_encoded(time)

--- a/app/server/sonicpi/lib/sonicpi/spiderapi.rb
+++ b/app/server/sonicpi/lib/sonicpi/spiderapi.rb
@@ -376,9 +376,7 @@ puts version.minor # => Prints out the minor version number such as 0",
 puts version.patch # => Prints out the patch level for this version such as 0"]
 
 
-    ## Hide this fn as it currently doesn't work across all platforms
-    ## due to encoding issues.
-    def __spark(*values)
+    def spark(*values)
       if values.first.is_a?(Array) && values.length == 1
         values = values.first
       end
@@ -401,9 +399,9 @@ puts version.patch # => Prints out the patch level for this version such as 0"]
         @ticks[(((x - min) / range) * scale).round]
       }.join
     end
-    doc name:         :__spark,
-      hide:           true,
-      introduced:     Version.new(2,4,0),
+    doc name:         :spark,
+      hide:           false,
+      introduced:     Version.new(2,5,0),
       summary:        "Render a list of numeric values as a spark graph/bar chart",
       args:           [],
       opts:           nil,


### PR DESCRIPTION
As of Ruby 1.9 the String#size method rationalised itself for multibyte
chars, so that a unicode string of a single character would have a size
of 1. This was a sensible fix *unless* you were doing something that had
to take account of how many bytes were used to represent the character.
This is what was wrong with our OSC implementation (and was actually an
issue against one of the ruby OSC libs - see maca/ruby-osc#4). This
meant that characters that took 3 bytes to represent didn't work nicely.

This was very confusing to debug as the spark function appeared to work
fine on OSX. Then it didn't on the Raspberry Pi (for which the Unicode
str function is added here). But spark didn't work for arrays of odd
lengths

```
spark(1,2) # worked
spark(1,2,3) # broke the log output
```

This was because the [utf8 block
chars](http://www.utf8-character.info/#!%E2%96%81%20%E2%96%82%20%E2%96%83%20%E2%96%84%20%E2%96%85%20%E2%96%86%20%E2%96%87)
used in spark take 3 bytes to represent. Therefore pairing them up to
form chains of 6's (even numbers of bytes) worked, whereas odd numbers
left 3 trailing bytes which broke the modulo function that relied on
String#size. In short, this was a hell of a bug.