### PR TITLE
Windows: warnings as errors

### DIFF
--- a/app/gui/qt/SonicPi.pro
+++ b/app/gui/qt/SonicPi.pro
@@ -34,7 +34,14 @@ macx {
   DEFINES += DONT_USE_OSX_KEYS
 }
 
-QMAKE_CXXFLAGS += -Wall -Werror -Wextra
+!win32 {
+  QMAKE_CXXFLAGS += -Wall -Werror -Wextra
+}
+win32 {
+  QMAKE_CXXFLAGS += /WX
+  DEFINES += _CRT_SECURE_NO_WARNINGS
+}
+
 CODECFORSRC = UTF-8
 CODECFORTR = UTF-8
 


### PR DESCRIPTION
Treat warnings as errors, and suppress warnings about strcpy() in oscpkt.h