### PR TITLE
refactor new shortcuts: C-k and TAB

### DIFF
--- a/app/gui/qt/mainwindow.cpp
+++ b/app/gui/qt/mainwindow.cpp
@@ -141,26 +141,19 @@ MainWindow::MainWindow(QApplication &app, QSplashScreen* splash)
   lexer->setAutoIndentStyle(SonicPiScintilla::AiMaintain);
 
   // create workspaces and add them to the tabs
-  signalMapper = new QSignalMapper (this) ;
   for(int ws = 0; ws < workspace_max; ws++) {
-    std::string s;
-
-
     SonicPiScintilla *workspace = new SonicPiScintilla(lexer);
 
     QShortcut *indentLine = new QShortcut(QKeySequence("Tab"), workspace);
-
-    connect (indentLine, SIGNAL(activated()), signalMapper, SLOT(map())) ;
-    signalMapper -> setMapping (indentLine, (QObject*)workspace);
+    connect(indentLine, SIGNAL(activated()), this, SLOT(completeListOrBeautifyCode()));
 
     QShortcut *cutToEndOfLine = new QShortcut(ctrlKey('k'), workspace);
-    connect(cutToEndOfLine, SIGNAL(activated()), workspace, SLOT(cutLineFromPoint()));
+    connect(cutToEndOfLine, SIGNAL(activated()), this, SLOT(cutLineFromPoint()));
+
     QString w = QString(tr("Workspace %1")).arg(QString::number(ws));
     workspaces[ws] = workspace;
     tabs->addTab(workspace, w);
   }
-
-  connect (signalMapper, SIGNAL(mapped(QObject*)), this, SLOT(completeListOrBeautifyCode(QObject*)));
 
   QFont font("Monospace");
   font.setStyleHint(QFont::Monospace);
@@ -301,14 +294,19 @@ MainWindow::MainWindow(QApplication &app, QSplashScreen* splash)
   }
 }
 
-void MainWindow::completeListOrBeautifyCode(QObject* ws){
-  SonicPiScintilla *spws = ((SonicPiScintilla*)ws);
-  if(spws->isListActive()) {
-    spws->tabCompleteifList();
-  }
-  else {
+void MainWindow::completeListOrBeautifyCode() {
+  SonicPiScintilla *ws = ((SonicPiScintilla*)tabs->currentWidget());
+  if(ws->isListActive()) {
+    ws->tabCompleteifList();
+  } else {
     beautifyCode();
   }
+}
+
+void MainWindow::cutLineFromPoint()
+{
+  SonicPiScintilla *ws = ((SonicPiScintilla*)tabs->currentWidget());
+  ws->cutLineFromPoint();
 }
 
 QString MainWindow::rootPath() {

--- a/app/gui/qt/mainwindow.h
+++ b/app/gui/qt/mainwindow.h
@@ -86,7 +86,8 @@ private slots:
     void disableCheckUpdates();
     void stopCode();
     void beautifyCode();
-    void completeListOrBeautifyCode(QObject *ws);
+    void completeListOrBeautifyCode();
+    void cutLineFromPoint();
     void reloadServerCode();
     void stopRunningSynths();
     void mixerInvertStereo();
@@ -130,7 +131,6 @@ private slots:
     void helpClosed(bool visible);
 
 private:
-    QSignalMapper *signalMapper;
     void startServer();
     void waitForServiceSync();
     void clearOutputPanels();

--- a/app/gui/qt/sonicpiscintilla.cpp
+++ b/app/gui/qt/sonicpiscintilla.cpp
@@ -156,8 +156,7 @@ void SonicPiScintilla::addKeyBinding(QSettings &qs, int cmd, int key)
   qs.setValue(skey, key);
 }
 
-void SonicPiScintilla::cutLineFromPoint()
-{
+void SonicPiScintilla::cutLineFromPoint() {
   //  SendScintilla(SCI_CLEARSELECTIONS);
   int pos = SendScintilla(SCI_GETCURRENTPOS);
   SendScintilla(SCI_LINEEND);

--- a/app/gui/qt/sonicpiscintilla.h
+++ b/app/gui/qt/sonicpiscintilla.h
@@ -19,17 +19,13 @@ class QSettings;
 
 class SonicPiScintilla : public QsciScintilla
 {
-  Q_OBJECT
-
  public:
   SonicPiScintilla(SonicPiLexer *lexer);
 
   virtual QStringList apiContext(int pos, int &context_start,
 				 int &last_word_start);
-
-  public slots:
-    void cutLineFromPoint();
-    void tabCompleteifList();
+  void cutLineFromPoint();
+  void tabCompleteifList();
 
  private:
     void addKeyBinding(QSettings &qs, int cmd, int key);


### PR DESCRIPTION
98b0ee957afa28b813b2dd4d00b0b58d97c030ad causes this link error on Windows:
````
moc_sonicpiscintilla.obj : error LNK2001: unresolved external symbol "public: static struct QMetaObject const QsciScintilla::staticMetaObject" (?staticMetaObject@QsciScintilla@@2UQMetaObject@@B)
release\sonic-pi.exe : fatal error LNK1120: 1 unresolved externals
````
Apparently caused by missing the MOC headers for Qscintilla?  I have no idea how to fix it at this time, having exhausted my Google-fu.  Workaround is to move the cutLineFromPoint slot to mainwindow.cpp so that SonicPiScintilla doesn't have to be a Q_OBJECT.