### PR TITLE
Fix warning errors breaking the build

### DIFF
--- a/app/gui/qt/sonicpiapis.cpp
+++ b/app/gui/qt/sonicpiapis.cpp
@@ -108,10 +108,11 @@ void SonicPiAPIs::updateAutoCompletionList(const QStringList &context,
   }
 }
 
-QStringList SonicPiAPIs::callTips(const QStringList &context, int commas,
-				  QsciScintilla::CallTipsStyle style,
-				  QList<int> &shifts) {
-  QStringList ctx = context; commas = commas; style = style; shifts = shifts;
+QStringList SonicPiAPIs::callTips(const QStringList &context, int commas, QsciScintilla::CallTipsStyle style, QList<int> &shifts) {
+  Q_UNUSED( commas );
+  Q_UNUSED( style );
+  Q_UNUSED( shifts );
+  QStringList ctx = context;
   // some day...
   QStringList none;
   return none;


### PR DESCRIPTION
Fixing:
```
sonicpiapis.cpp:111:67: error: unused parameter 'commas' [-Werror,-Wunused-parameter]
QStringList SonicPiAPIs::callTips(const QStringList &context, int commas, QsciScintilla::CallTipsStyle style, QList<int> &shifts) {
                                                                  ^
sonicpiapis.cpp:111:104: error: unused parameter 'style' [-Werror,-Wunused-parameter]
QStringList SonicPiAPIs::callTips(const QStringList &context, int commas, QsciScintilla::CallTipsStyle style, QList<int> &shifts) {
                                                                                                       ^
sonicpiapis.cpp:111:123: error: unused parameter 'shifts' [-Werror,-Wunused-parameter]
QStringList SonicPiAPIs::callTips(const QStringList &context, int commas, QsciScintilla::CallTipsStyle style, QList<int> &shifts) {
```