### PR TITLE
Add focus mode

### DIFF
--- a/app/gui/qt/mainwindow.cpp
+++ b/app/gui/qt/mainwindow.cpp
@@ -106,8 +106,6 @@ MainWindow::MainWindow(QApplication &app, bool i18n, QSplashScreen* splash)
   }
 
   this->i18n = i18n;
-  focusMode = false;
-  disableFocusMode();
 
   printAsciiArtLogo();
   // kill any zombie processes that may exist
@@ -396,6 +394,9 @@ MainWindow::MainWindow(QApplication &app, bool i18n, QSplashScreen* splash)
 
   initPrefsWindow();
   initDocsWindow();
+
+  focusMode = false;
+  disableFocusMode();
 
   QSettings settings("uk.ac.cam.cl", "Sonic Pi");
 

--- a/app/gui/qt/mainwindow.cpp
+++ b/app/gui/qt/mainwindow.cpp
@@ -432,6 +432,9 @@ void MainWindow::updateFocusMode(){
     toolBar->close();
     prefsWidget->close();
     mainWidgetLayout->setMargin(0);
+    this->setWindowFlags(Qt::FramelessWindowHint);
+    this->setWindowState(Qt::WindowFullScreen);
+    this->show();
   }
 }
 
@@ -441,6 +444,9 @@ void MainWindow::disableFocusMode(){
   outputWidget->show();
   toolBar->show();
   mainWidgetLayout->setMargin(9);
+  this->setWindowState(windowState() & ~(Qt::WindowFullScreen));
+  this->setWindowFlags(Qt::WindowTitleHint);
+  this->show();
 }
 
 void MainWindow::completeListOrIndentLine(QObject* ws){

--- a/app/gui/qt/mainwindow.cpp
+++ b/app/gui/qt/mainwindow.cpp
@@ -106,6 +106,7 @@ MainWindow::MainWindow(QApplication &app, bool i18n, QSplashScreen* splash)
   }
 
   this->i18n = i18n;
+  focusMode = false;
 
   printAsciiArtLogo();
   // kill any zombie processes that may exist
@@ -414,6 +415,23 @@ MainWindow::MainWindow(QApplication &app, bool i18n, QSplashScreen* splash)
 
 void MainWindow::changeTab(int id){
   tabs->setCurrentIndex(id);
+}
+
+void MainWindow::updateFocusMode(){
+  if(focusMode == true){
+    focusMode = false;
+    hudWidget->show();
+    docWidget->show();
+    outputWidget->show();
+    toolBar->show();
+  }
+  else{
+    focusMode = true;
+    hudWidget->close();
+    docWidget->close();
+    outputWidget->close();
+    toolBar->close();
+  }
 }
 
 void MainWindow::completeListOrIndentLine(QObject* ws){
@@ -1360,6 +1378,7 @@ void MainWindow::createShortcuts()
   new QShortcut(metaKey('<'), this, SLOT(tabPrev()));
   new QShortcut(metaKey('>'), this, SLOT(tabNext()));
   //new QShortcut(metaKey('U'), this, SLOT(reloadServerCode()));
+  new QShortcut(QKeySequence("F10"), this, SLOT(updateFocusMode()));
 }
 
 void MainWindow::createToolBar()

--- a/app/gui/qt/mainwindow.cpp
+++ b/app/gui/qt/mainwindow.cpp
@@ -368,7 +368,7 @@ MainWindow::MainWindow(QApplication &app, bool i18n, QSplashScreen* splash)
   // connect(docWidget, SIGNAL(visibilityChanged(bool)), this,
   // SLOT(helpClosed(bool)));
 
-  QVBoxLayout *mainWidgetLayout = new QVBoxLayout;
+  mainWidgetLayout = new QVBoxLayout;
   mainWidgetLayout->addWidget(tabs);
   mainWidgetLayout->addWidget(errorPane);
   QWidget *mainWidget = new QWidget;
@@ -431,6 +431,7 @@ void MainWindow::updateFocusMode(){
     outputWidget->close();
     toolBar->close();
     prefsWidget->close();
+    mainWidgetLayout->setMargin(0);
   }
 }
 
@@ -439,6 +440,7 @@ void MainWindow::disableFocusMode(){
   docWidget->show();
   outputWidget->show();
   toolBar->show();
+  mainWidgetLayout->setMargin(9);
 }
 
 void MainWindow::completeListOrIndentLine(QObject* ws){

--- a/app/gui/qt/mainwindow.cpp
+++ b/app/gui/qt/mainwindow.cpp
@@ -431,6 +431,10 @@ void MainWindow::updateFocusMode(){
     outputWidget->close();
     toolBar->close();
     prefsWidget->close();
+
+    QTabBar *tabBar = tabs->findChild<QTabBar *>();
+    tabBar->hide();
+
     mainWidgetLayout->setMargin(0);
     this->setWindowFlags(Qt::FramelessWindowHint);
     this->setWindowState(Qt::WindowFullScreen);
@@ -443,6 +447,10 @@ void MainWindow::disableFocusMode(){
   docWidget->show();
   outputWidget->show();
   toolBar->show();
+
+  QTabBar *tabBar = tabs->findChild<QTabBar *>();
+  tabBar->show();
+
   mainWidgetLayout->setMargin(9);
   this->setWindowState(windowState() & ~(Qt::WindowFullScreen));
   this->setWindowFlags(Qt::WindowTitleHint);

--- a/app/gui/qt/mainwindow.cpp
+++ b/app/gui/qt/mainwindow.cpp
@@ -431,6 +431,7 @@ void MainWindow::updateFocusMode(){
     docWidget->close();
     outputWidget->close();
     toolBar->close();
+    prefsWidget->close();
   }
 }
 

--- a/app/gui/qt/mainwindow.cpp
+++ b/app/gui/qt/mainwindow.cpp
@@ -107,6 +107,7 @@ MainWindow::MainWindow(QApplication &app, bool i18n, QSplashScreen* splash)
 
   this->i18n = i18n;
   focusMode = false;
+  disableFocusMode();
 
   printAsciiArtLogo();
   // kill any zombie processes that may exist
@@ -420,10 +421,7 @@ void MainWindow::changeTab(int id){
 void MainWindow::updateFocusMode(){
   if(focusMode == true){
     focusMode = false;
-    hudWidget->show();
-    docWidget->show();
-    outputWidget->show();
-    toolBar->show();
+    disableFocusMode();
   }
   else{
     focusMode = true;
@@ -433,6 +431,13 @@ void MainWindow::updateFocusMode(){
     toolBar->close();
     prefsWidget->close();
   }
+}
+
+void MainWindow::disableFocusMode(){
+  hudWidget->show();
+  docWidget->show();
+  outputWidget->show();
+  toolBar->show();
 }
 
 void MainWindow::completeListOrIndentLine(QObject* ws){

--- a/app/gui/qt/mainwindow.cpp
+++ b/app/gui/qt/mainwindow.cpp
@@ -433,6 +433,7 @@ void MainWindow::updateFocusMode(){
     outputWidget->close();
     toolBar->close();
     prefsWidget->close();
+    statusBar()->close();
 
     QTabBar *tabBar = tabs->findChild<QTabBar *>();
     tabBar->hide();
@@ -451,6 +452,7 @@ void MainWindow::disableFocusMode(){
   }
   outputWidget->show();
   toolBar->show();
+  statusBar()->show();
 
   QTabBar *tabBar = tabs->findChild<QTabBar *>();
   tabBar->show();

--- a/app/gui/qt/mainwindow.cpp
+++ b/app/gui/qt/mainwindow.cpp
@@ -395,9 +395,6 @@ MainWindow::MainWindow(QApplication &app, bool i18n, QSplashScreen* splash)
   initPrefsWindow();
   initDocsWindow();
 
-  focusMode = false;
-  disableFocusMode();
-
   QSettings settings("uk.ac.cam.cl", "Sonic Pi");
 
   if(settings.value("first_time", 1).toInt() == 1) {
@@ -413,6 +410,9 @@ MainWindow::MainWindow(QApplication &app, bool i18n, QSplashScreen* splash)
     docWidget->show();
     startupPane->show();
   }
+
+  focusMode = false;
+  disableFocusMode();
 }
 
 void MainWindow::changeTab(int id){
@@ -426,8 +426,10 @@ void MainWindow::updateFocusMode(){
   }
   else{
     focusMode = true;
-    hudWidget->close();
-    docWidget->close();
+    if(docWidget->isVisible()){
+      restoreDocPane = true;
+      docWidget->close();
+    }
     outputWidget->close();
     toolBar->close();
     prefsWidget->close();
@@ -443,8 +445,10 @@ void MainWindow::updateFocusMode(){
 }
 
 void MainWindow::disableFocusMode(){
-  hudWidget->show();
-  docWidget->show();
+ if(restoreDocPane){
+    docWidget->show();
+    restoreDocPane = false;
+  }
   outputWidget->show();
   toolBar->show();
 

--- a/app/gui/qt/mainwindow.h
+++ b/app/gui/qt/mainwindow.h
@@ -133,6 +133,7 @@ private slots:
     void docScrollUp();
     void docScrollDown();
     void helpClosed(bool visible);
+    void updateFocusMode();
 
 private:
     QSignalMapper *signalMapper;
@@ -175,6 +176,7 @@ private:
     QFuture<void> osc_thread, server_thread;
     int protocol;
 
+    bool focusMode;
     bool startup_error_reported;
     bool is_recording;
     bool show_rec_icon_a;

--- a/app/gui/qt/mainwindow.h
+++ b/app/gui/qt/mainwindow.h
@@ -205,6 +205,7 @@ private:
     QTextBrowser *docPane;
     QTextBrowser *hudPane;
     bool hidingDocPane;
+    bool restoreDocPane;
 
     QTabWidget *tabs;
 

--- a/app/gui/qt/mainwindow.h
+++ b/app/gui/qt/mainwindow.h
@@ -134,6 +134,7 @@ private slots:
     void docScrollDown();
     void helpClosed(bool visible);
     void updateFocusMode();
+    void disableFocusMode();
 
 private:
     QSignalMapper *signalMapper;

--- a/app/gui/qt/mainwindow.h
+++ b/app/gui/qt/mainwindow.h
@@ -22,6 +22,7 @@
 #include <QRadioButton>
 #include <QListWidgetItem>
 #include <QListWidget>
+#include <QVBoxLayout>
 #include <QProcess>
 #include <QFuture>
 #include <QShortcut>
@@ -239,6 +240,7 @@ private:
     QWidget *infoWidg;
     QTextEdit *startupPane;
     QLabel *imageLabel;
+    QVBoxLayout *mainWidgetLayout;
 
     int currentLine;
     int currentIndex;


### PR DESCRIPTION
A mode which hides everything but the error pane and the code pane.

Bound to "F10"

Always defaults to off on startup

TODO:

- [x] Bug: The help menu gets detached when its closed, fullscreen and then back to normal screen