### PR TITLE
changed paragraph wrapping of German markdown files

### DIFF
--- a/etc/doc/tutorial/de/01-Welcome-to-Sonic-Pi.md
+++ b/etc/doc/tutorial/de/01-Welcome-to-Sonic-Pi.md
@@ -2,14 +2,32 @@
 
 # Hallo zusammen :-)
 
-Willkommen bei Sonic Pi! Ich hoffe, Du bist genauso aufgeregt, verrückte Sounds zu machen, wie ich es bin, dir zu zeigen, wie das geht. Wir werden viel Spaß dabei haben, alles über Musik, Synthese, Coding, Komposition, Aufführung und andere Dinge zu lernen.
+Willkommen bei Sonic Pi! Ich hoffe, Du bist genauso aufgeregt, 
+verrückte Sounds zu machen, wie ich es bin, dir zu zeigen, wie das 
+geht. Wir werden viel Spaß dabei haben, alles über Musik, Synthese, 
+Coding, Komposition, Aufführung und andere Dinge zu lernen.
 
-Doch halt, wie unhöflich von mir. Ich sollte mich erst einmal vorstellen - ich bin [Sam Aaron](http://twitter.com/samaaron) - der Typ, der Sonic Pi gebaut hat. Du kannst mich unter [@samaaron](http://twitter.com/samaaron) auf Twitter finden, ich freue mich, wenn du mal vorbeischaust. Vielleicht interessierst du dich auch für meine Live Coding Band [Meta-eX](http://meta-ex.com), wo ich den Code direkt vor dem Publikum schreibe und damit Musik mache. Du kannst einen 
-[Meta-eX](http://meta-ex.com) Track in den Beispielen finden.
+Doch halt, wie unhöflich von mir. Ich sollte mich erst einmal 
+vorstellen - ich bin [Sam Aaron](http://twitter.com/samaaron) - der 
+Typ, der Sonic Pi gebaut hat. Du kannst mich unter 
+[@samaaron](http://twitter.com/samaaron) auf Twitter finden, ich freue 
+mich, wenn du mal vorbeischaust. Vielleicht interessierst du dich auch 
+für meine Live Coding Band [Meta-eX](http://meta-ex.com), wo ich den 
+Code direkt vor dem Publikum schreibe und damit Musik mache. Du kannst 
+einen [Meta-eX](http://meta-ex.com) Track in den Beispielen finden.
 
-Wenn du irgendwelche Gedanken oder Ideen zur Verbesserung von Sonic Pi hast - bitte schicke sie an mich - Feedback ist sehr hilfreich. Man kann ja nie wissen, vielleicht ist deine Idee das nächste große Feature!
+Wenn du irgendwelche Gedanken oder Ideen zur Verbesserung von Sonic Pi 
+hast - bitte schicke sie an mich - Feedback ist sehr hilfreich. Man 
+kann ja nie wissen, vielleicht ist deine Idee das nächste große 
+Feature!
 
-Schließlich: Dieses Tutorial ist in Abschnitte aufgeteilt, die in Gruppen zu unterschiedlichen Themen aufgeteilt sind. Auch wenn ich es so geschrieben habe, dass man damit von Anfang bis zum Ende einfach lernen kann, kannst du an jeder Stelle einsteigen, so wie es für dich gut ist. Wenn du meinst, dass etwas im Tutorial fehlt, lass' es mich wissen, und ich überlege, wie ich das in zukünftige Versionen einbauen kann.
+Schließlich: Dieses Tutorial ist in Abschnitte aufgeteilt, die in 
+Gruppen zu unterschiedlichen Themen aufgeteilt sind. Auch wenn ich es 
+so geschrieben habe, dass man damit von Anfang bis zum Ende einfach 
+lernen kann, kannst du an jeder Stelle einsteigen, so wie es für dich 
+gut ist. Wenn du meinst, dass etwas im Tutorial fehlt, lass' es mich 
+wissen, und ich überlege, wie ich das in zukünftige Versionen einbauen 
+kann.
 
 Ok, legen wir los...
 

--- a/etc/doc/tutorial/de/01.2-Exploring-the-Interface.md
+++ b/etc/doc/tutorial/de/01.2-Exploring-the-Interface.md
@@ -2,7 +2,8 @@
 
 # Die Programmoberfläche von Sonic Pi
 
-Sonic PI hat eine sehr einfache Oberfläche zum Coden von Musik. Schauen wir uns das einmal genauer an.
+Sonic PI hat eine sehr einfache Oberfläche zum Coden von Musik. Schauen 
+wir uns das einmal genauer an.
 
 ![Sonic Pi Interface](:/images/tutorial/GUI.png)
 
@@ -14,26 +15,59 @@ Sonic PI hat eine sehr einfache Oberfläche zum Coden von Musik. Schauen wir uns
 * *E* - Protokoll-Fenster
 * *F* - Hilfesystem
 
-Mit diesen pinkfarbenen Buttons kannst du Klänge abspielen und stoppen. Es gibt einen *Ausführen*-Button, mit dem der Code im Editor ausgeführt wird, *Stop* hält den ablaufenden Code an, mit *Speichern* kannst du den Code in einer Datei speichern und *Aufnehmen* nimmt den gerade laufenden Sound auf (in einer WAV-Datei).
+Mit diesen pinkfarbenen Buttons kannst du Klänge abspielen und stoppen. 
+Es gibt einen *Ausführen*-Button, mit dem der Code im Editor ausgeführt 
+wird, *Stop* hält den ablaufenden Code an, mit *Speichern* kannst du 
+den Code in einer Datei speichern und *Aufnehmen* nimmt den gerade 
+laufenden Sound auf (in einer WAV-Datei).
 
 ## B. Editor-Steuerung
 
-Die orangefarbenen Buttons steuern den Code-Editor. Mit den *Text vergrößern* and *Text verkleinern*-Buttons kannst du den Text vergrößern und verkleinern. *Auto-Align Text*-Button richtet den Code ordentlich aus, damit er professioneller aussieht und besser lesbar ist.
+Die orangefarbenen Buttons steuern den Code-Editor. Mit den *Text 
+vergrößern* and *Text verkleinern*-Buttons kannst du den Text 
+vergrößern und verkleinern. *Auto-Align Text*-Button richtet den Code 
+ordentlich aus, damit er professioneller aussieht und besser lesbar 
+ist.
 
 ## C. Information und Hilfe
 
-Die blauen Buttons bieten dir den Zugriff auf Informationen, die Hilfe und die Voreinstellungen. Der *Info*-Button öffnet ein Fenster mit Informationen über Sonic Pi selbst - das Entwicklerteam, die Änderungen, Beitragende und die Gemeinschaft. Der *Hilfe*-Button zeigt/verbirgt das Hilfesystem (*F*) und  *Einstellungen* zeigt/verbirgt das Fenster, wo du einige grundsätzliche Einstellungen regeln kannst.
+Die blauen Buttons bieten dir den Zugriff auf Informationen, die Hilfe 
+und die Voreinstellungen. Der *Info*-Button öffnet ein Fenster mit 
+Informationen über Sonic Pi selbst - das Entwicklerteam, die 
+Änderungen, Beitragende und die Gemeinschaft. Der *Hilfe*-Button 
+zeigt/verbirgt das Hilfesystem (*F*) und  *Einstellungen* 
+zeigt/verbirgt das Fenster, wo du einige grundsätzliche Einstellungen 
+regeln kannst.
 
 ## D. Code-Editor
 
-Dies ist der Bereich, wo du deinen Code schreibst und deine Musik komponierst/aufführst. Es ist ein einfacher Texteditor, mit dem du Code eingeben oder löschen, auschneiden und einfügen kannst usw.; so ähnlich wie eine einfache Word-Version oder Google Docs. Der Editor färbt bestimmte Begriffe automatisch ein, je nachdem, welche Bedeutung sie innerhalb des Codes haben. Am Anfang ist das vielleicht ein wenig merkwürdig, aber du wirst es bald nützlich finden. Zum Beispiel siehst du, dass etwas eine Zahl ist, weil es blau eingefärbt dargestellt wird.
+Dies ist der Bereich, wo du deinen Code schreibst und deine Musik 
+komponierst/aufführst. Es ist ein einfacher Texteditor, mit dem du Code 
+eingeben oder löschen, auschneiden und einfügen kannst usw.; so ähnlich 
+wie eine einfache Word-Version oder Google Docs. Der Editor färbt 
+bestimmte Begriffe automatisch ein, je nachdem, welche Bedeutung sie 
+innerhalb des Codes haben. Am Anfang ist das vielleicht ein wenig 
+merkwürdig, aber du wirst es bald nützlich finden. Zum Beispiel siehst 
+du, dass etwas eine Zahl ist, weil es blau eingefärbt dargestellt wird.
 
 ## E. Protokoll-Fenster
 
-Wenn du deinen Code ablaufen läßt, siehst du im Protokoll-Fenster, was das Programm gerade tut. Standardmäßig siehst du eine Nachricht für jeden erzeugten Klang und die exakte Zeit, zu der der Klang ausgelöst wurde. Das kann sehr hilfreich sein, um Fehler zu entdecken und zu verstehen, was dein Code macht.
+Wenn du deinen Code ablaufen läßt, siehst du im Protokoll-Fenster, was 
+das Programm gerade tut. Standardmäßig siehst du eine Nachricht für 
+jeden erzeugten Klang und die exakte Zeit, zu der der Klang ausgelöst 
+wurde. Das kann sehr hilfreich sein, um Fehler zu entdecken und zu 
+verstehen, was dein Code macht.
 
 ## F. Help System
 
-Das Hilfe-System im unteren Bereich des Programmfensters ist einer der wichtigsten Teile von Sonic Pi. Du kannst es ein- und ausblenden, indem du den blauen *Hilfe*-Button klickst. Es enthält Hilfe und Informationen über alle Aspekte von Sonic Pi, einschließlich dieses Tutorials, eine Liste der mitgelieferten Synths, Samples, Beispiele, Effekte (FX[^1]) sowie eine komplette Liste aller Funktionen, die Sonic Pi bereitstellt, um damit Musik zu coden.
+Das Hilfe-System im unteren Bereich des Programmfensters ist einer der 
+wichtigsten Teile von Sonic Pi. Du kannst es ein- und ausblenden, indem 
+du den blauen *Hilfe*-Button klickst. Es enthält Hilfe und 
+Informationen über alle Aspekte von Sonic Pi, einschließlich dieses 
+Tutorials, eine Liste der mitgelieferten Synths, Samples, Beispiele, 
+Effekte (FX[^1]) sowie eine komplette Liste aller Funktionen, die Sonic 
+Pi bereitstellt, um damit Musik zu coden.
 
-[^1]: Im Englischen wird der Begriff *Effekte* manchmal lautmalerisch mit *FX* („ef-eks“) abgekürzt; *FX* bezeichnet also die Klangeffekte in Sonic Pi.
+[^1]: Im Englischen wird der Begriff *Effekte* manchmal lautmalerisch 
+mit *FX* („ef-eks“) abgekürzt; *FX* bezeichnet also die Klangeffekte in 
+Sonic Pi.

--- a/etc/doc/tutorial/de/01.3-Learning-through-Play.md
+++ b/etc/doc/tutorial/de/01.3-Learning-through-Play.md
@@ -2,14 +2,37 @@
 
 # Spielend lernen
 
-Sonic Pi soll dich dazu animieren, etwas über Computer und Musik zu lernen - und zwar auf eine spielerische und experimentelle Weise. Das allerwichtigste ist, dass du Spaß hast, und bevor du es überhaupt bemerkt hast, wirst du zufällig gelernt haben, Code zu schreiben, zu komponieren und Musik aufzuführen.
+Sonic Pi soll dich dazu animieren, etwas über Computer und Musik zu 
+lernen - und zwar auf eine spielerische und experimentelle Weise. Das 
+allerwichtigste ist, dass du Spaß hast, und bevor du es überhaupt 
+bemerkt hast, wirst du zufällig gelernt haben, Code zu schreiben, zu 
+komponieren und Musik aufzuführen.
 
 ## Es gibt keine Fehler
 
-Bevor wir anfangen, möchte ich dir noch einen kleinen Rat geben. Ich habe das über die Jahre gelernt, in denen ich Musik live programmiert habe - *es gibt keine Fehler, nur Gelegenheiten*. Im Jazz habe ich das schön öfters gehört, aber man kann diese Idee auch auf das Live Coding anwenden. Es spielt keine Rolle, wieviel Erfahrung du hast, ob du ein absoluter Anfänger oder ein erfahrender Algoraver bist, du wirst Code laufen lassen, der vollkommen unerwartete Ergebnisse mit sich bringt. Kann sein, dass es unglaublich cool klingt - dann mache weiter. Kann auch sein, dass es schrecklich klingt und vollkommen fehl am Platz ist. Es spielt keine Rolle, dass soetwas passiert, wichtig ist, was du damit als nächstes macht. Nimm den Sound, bearbeite ihn und mach daraus etwas Tolles. Die Menge wird durchdrehen.
+Bevor wir anfangen, möchte ich dir noch einen kleinen Rat geben. Ich 
+habe das über die Jahre gelernt, in denen ich Musik live programmiert 
+habe - *es gibt keine Fehler, nur Gelegenheiten*. Im Jazz habe ich das 
+schön öfters gehört, aber man kann diese Idee auch auf das Live Coding 
+anwenden. Es spielt keine Rolle, wieviel Erfahrung du hast, ob du ein 
+absoluter Anfänger oder ein erfahrender Algoraver bist, du wirst Code 
+laufen lassen, der vollkommen unerwartete Ergebnisse mit sich bringt. 
+Kann sein, dass es unglaublich cool klingt - dann mache weiter. Kann 
+auch sein, dass es schrecklich klingt und vollkommen fehl am Platz ist. 
+Es spielt keine Rolle, dass soetwas passiert, wichtig ist, was du damit 
+als nächstes macht. Nimm den Sound, bearbeite ihn und mach daraus etwas 
+Tolles. Die Menge wird durchdrehen.
 
 ## Fang einfach an
 
-Wenn man lernt, will man die tollen Sachen am liebsten *sofort* machen. Vergiß das nicht, aber sieh es als ein Ziel an, welches du erst etwas *später* erreichen kannst. Überlege dir aber zunächst mal die *einfachste* Sache, die dir Spaß machen wird, und die lohnend erscheint; diese Sache ist ein kleiner Schritt auf dem Weg zu dem faszinierenden Ding, das dir im Kopf herumgeht. Wenn dir dieser einfache Schritt klar ist, dann versuche ihn umzusetzen, spiele damit herum und finde heraus, auf was für neue Ideen du kommst. Es wird nicht lange dauern, und du wirst viel Spaß haben und Fortschritte machen.
+Wenn man lernt, will man die tollen Sachen am liebsten *sofort* machen. 
+Vergiß das nicht, aber sieh es als ein Ziel an, welches du erst etwas 
+*später* erreichen kannst. Überlege dir aber zunächst mal die 
+*einfachste* Sache, die dir Spaß machen wird, und die lohnend 
+erscheint; diese Sache ist ein kleiner Schritt auf dem Weg zu dem 
+faszinierenden Ding, das dir im Kopf herumgeht. Wenn dir dieser 
+einfache Schritt klar ist, dann versuche ihn umzusetzen, spiele damit 
+herum und finde heraus, auf was für neue Ideen du kommst. Es wird nicht 
+lange dauern, und du wirst viel Spaß haben und Fortschritte machen.
 
 Und: Kümmere dich darum, dass du deine Arbeit mit anderen teilst!

--- a/etc/doc/tutorial/de/02-Synths.md
+++ b/etc/doc/tutorial/de/02-Synths.md
@@ -4,6 +4,15 @@
 
 Ok, genug der Einführung - lasst uns Klänge machen.
 
-In diesem Abschnitt besprechen wir, wie man Synths ansteuert und manipuliert. Synth ist die Kurzform von Synthesizer, welches ein hochtrabendes Wort für ein Ding ist, welches einen Klang erzeugt. Typischerweise sind Synths ziemlich kompliziert im Gebrauch - vor allem analoge Synths mit vielen Kabeln und Modulen. Sonic Pi jedoch stellt dir vieles davon auf eine einfache und gut zugänglich Art zur Verfügung.
+In diesem Abschnitt besprechen wir, wie man Synths ansteuert und 
+manipuliert. Synth ist die Kurzform von Synthesizer, welches ein 
+hochtrabendes Wort für ein Ding ist, welches einen Klang erzeugt. 
+Typischerweise sind Synths ziemlich kompliziert im Gebrauch - vor allem 
+analoge Synths mit vielen Kabeln und Modulen. Sonic Pi jedoch stellt 
+dir vieles davon auf eine einfache und gut zugänglich Art zur 
+Verfügung.
 
-Lass dich nicht von der scheinbaren Einfachheit der Programmoberfläche von Sonic Pi täuschen. Du kannst sehr tief in ausgeklügelte Klangmanipulationen eintauchen - wenn das dein Ding ist. Haltet euch fest...
+Lass dich nicht von der scheinbaren Einfachheit der Programmoberfläche 
+von Sonic Pi täuschen. Du kannst sehr tief in ausgeklügelte 
+Klangmanipulationen eintauchen - wenn das dein Ding ist. Haltet euch 
+fest...

--- a/etc/doc/tutorial/de/02.1-Your-First-Beeps.md
+++ b/etc/doc/tutorial/de/02.1-Your-First-Beeps.md
@@ -8,13 +8,17 @@ Seht Euch den folgenden Code an:
 play 70
 ```
 
-So fängt alles an. Leg los, kopiere und setze das in das Code-Fenster oben im Programm ein (der große weiße Raum unter dem Ausführen-Button. Nun klicke auf Ausführen...
+So fängt alles an. Leg los, kopiere und setze das in das Code-Fenster 
+oben im Programm ein (der große weiße Raum unter dem Ausführen-Button. 
+Nun klicke auf Ausführen...
 
 ## Beep!
 
 Stark. Klicke den Button nochmal. Und nochmal. *Und nochmal...*
 
-Wow, verrückt, ich bin sicher, dass könntet Ihr den ganzen Tag lang machen. Aber halt, bevor Ihr Euch in einem endlosen Strom von Piepstönen verliert, versuche es mit einer anderen Zahl:
+Wow, verrückt, ich bin sicher, dass könntet Ihr den ganzen Tag lang 
+machen. Aber halt, bevor Ihr Euch in einem endlosen Strom von 
+Piepstönen verliert, versuche es mit einer anderen Zahl:
 
 ```
 play 75
@@ -26,13 +30,25 @@ Hörst du den Unterschied? Nimm eine niedrigere Zahl:
 play 60
 ```
 
-Also, niedrigere Nummern erzeugen niedrigere Töne und höhere Nummern höhrere. Wie auf dem Klavier spielt man mit den unteren Tasten (die Seite der linken Hand) niedrigere Töne und mit den oberen Tasten (die Seite der rechten Hand) höhere Töne. Tatsächlich stehen die Zahlen und die Töne auf dem Klavier in einer Beziehung zueinander. `play 47` bedeutet, spiel den 47. Ton auf dem Klavier. Das bedeutet, dass `play 48` eine Note höher spielt (die nächste Taste zur rechten Seite hin). Daraus ergibt sich, dass das C in der vierten Oktave die Nummer 60 hat. Das kannst du so spielen: `play 60`.
+Also, niedrigere Nummern erzeugen niedrigere Töne und höhere Nummern 
+höhrere. Wie auf dem Klavier spielt man mit den unteren Tasten (die 
+Seite der linken Hand) niedrigere Töne und mit den oberen Tasten (die 
+Seite der rechten Hand) höhere Töne. Tatsächlich stehen die Zahlen und 
+die Töne auf dem Klavier in einer Beziehung zueinander. `play 47` 
+bedeutet, spiel den 47. Ton auf dem Klavier. Das bedeutet, dass `play 
+48` eine Note höher spielt (die nächste Taste zur rechten Seite hin). 
+Daraus ergibt sich, dass das C in der vierten Oktave die Nummer 60 hat. 
+Das kannst du so spielen: `play 60`.
 
-*Keine Sorge*, wenn du keine Ahnung hast, was das alles bedeutet. Das ging mir auch so, als ich anfing. Für den Anfang reicht es zu wissen, *niedrigere Zahlen bedeuten tiefere Klänge* und *höhere Zahlen bedeuten höhere Klänge*.
+*Keine Sorge*, wenn du keine Ahnung hast, was das alles bedeutet. Das 
+ging mir auch so, als ich anfing. Für den Anfang reicht es zu wissen, 
+*niedrigere Zahlen bedeuten tiefere Klänge* und *höhere Zahlen bedeuten 
+höhere Klänge*.
 
 ## Akkorde
 
-Eine Note zu spielen kann ganz lustig sein, aber mehrere zur selben Zeit zu spielen ist noch besser. Versuche es:
+Eine Note zu spielen kann ganz lustig sein, aber mehrere zur selben 
+Zeit zu spielen ist noch besser. Versuche es:
 
 ```
 play 72
@@ -40,11 +56,16 @@ play 75
 play 79
 ```
 
-Wow! Wenn du also mehrere `play`s hinschreibst, spielen sie alle zur selben Zeit. Versuche es selbst - welche Nummern klingen gut zusammen? Was klingt fürchterlich? Experimentiere, erforsche und erkunde selbst.
+Wow! Wenn du also mehrere `play`s hinschreibst, spielen sie alle zur 
+selben Zeit. Versuche es selbst - welche Nummern klingen gut zusammen? 
+Was klingt fürchterlich? Experimentiere, erforsche und erkunde selbst.
 
 ## Melodie
 
-Einzelne Noten und Akkorde zu spielen macht Spaß - aber wie wäre es mit einer Melodie? Was, wenn du eine Note nach der anderen spielen wolltest und nicht alle zur selben Zeit? Also das geht ganz einfach, du brauchst nur ein `sleep` zwischen den Noten:
+Einzelne Noten und Akkorde zu spielen macht Spaß - aber wie wäre es mit 
+einer Melodie? Was, wenn du eine Note nach der anderen spielen wolltest 
+und nicht alle zur selben Zeit? Also das geht ganz einfach, du brauchst 
+nur ein `sleep` zwischen den Noten:
 
 ```
 play 72
@@ -54,7 +75,12 @@ sleep 1
 play 79
 ```
 
-Wie hübsch, ein kleines Arpeggio. Was bedeutet die `1` in `sleep 1`? Sie gibt die *Dauer von sleep* an. Tatsächlich bedeutet das, schlafe für einen Schlag, aber vorläufig können wir uns vorstellen, dass es bedeutet, schlafe für eine Sekunde. Wie könnten wir unser Arpeggio schneller ablaufen lassen? Dazu brauchen wir kürzere Werte für sleep. Wie wäre es z.B. mit `0.5`:
+Wie hübsch, ein kleines Arpeggio. Was bedeutet die `1` in `sleep 1`? 
+Sie gibt die *Dauer von sleep* an. Tatsächlich bedeutet das, schlafe 
+für einen Schlag, aber vorläufig können wir uns vorstellen, dass es 
+bedeutet, schlafe für eine Sekunde. Wie könnten wir unser Arpeggio 
+schneller ablaufen lassen? Dazu brauchen wir kürzere Werte für sleep. 
+Wie wäre es z.B. mit `0.5`:
 
 ```
 play 72
@@ -64,13 +90,21 @@ sleep 0.5
 play 79
 ```
 
-Achte darauf, dass die Melodie nun schneller spielt. Probiere das selbst aus, ändere die Zeiten, verwende unterschiedliche Zeiten und Noten.
+Achte darauf, dass die Melodie nun schneller spielt. Probiere das 
+selbst aus, ändere die Zeiten, verwende unterschiedliche Zeiten und 
+Noten.
 
-Versuche einmal Zwischennoten wie `play 52.3`[^1] und `play 52.63`. Es gibt überhaupt keinen Grund nur ganze Zahlen zu verwenden. Spiel damit herum und hab  Spaß dabei.
+Versuche einmal Zwischennoten wie `play 52.3`[^1] und `play 52.63`. Es 
+gibt überhaupt keinen Grund nur ganze Zahlen zu verwenden. Spiel damit 
+herum und hab  Spaß dabei.
 
 ## Traditionelle Notennamen
 
-Für die unter euch, die das Notenschreiben schon ein bisschen kennen (keine Sorge, wenn nicht - du brauchst es nicht unbedingt), vielleicht möchtet ihr eine Melodie mit Notennamen anstelle von Zahlen schreiben, also C oder F#[^2]; auch das geht mit Sonic Pi. Du kannst folgendes machen:
+Für die unter euch, die das Notenschreiben schon ein bisschen kennen 
+(keine Sorge, wenn nicht - du brauchst es nicht unbedingt), vielleicht 
+möchtet ihr eine Melodie mit Notennamen anstelle von Zahlen schreiben, 
+also C oder F#[^2]; auch das geht mit Sonic Pi. Du kannst folgendes 
+machen:
 
 ```
 play :C
@@ -80,7 +114,9 @@ sleep 0.5
 play :E
 ```
 
-Denk daran, vor den Notennamen einen `:` zu stellen, sodass dieser sich Pink einfärbt. Die jeweilige Oktave kannst du mit einer nachgestellten Zahl angeben:
+Denk daran, vor den Notennamen einen `:` zu stellen, sodass dieser sich 
+Pink einfärbt. Die jeweilige Oktave kannst du mit einer nachgestellten 
+Zahl angeben:
 
 ```
 play :C3
@@ -90,15 +126,28 @@ sleep 0.5
 play :E4
 ```
 
-Wenn du eine Note um einen Halbton erhöhen willst, dann füge ein `s` hinzu, also `play :Fs3`, und wenn du die Note um einen Halbton erniedrigen möchtest, dann füge ein `b` an, also `play :Eb3`.
+Wenn du eine Note um einen Halbton erhöhen willst, dann füge ein `s` 
+hinzu, also `play :Fs3`, und wenn du die Note um einen Halbton 
+erniedrigen möchtest, dann füge ein `b` an, also `play :Eb3`.
 
 Jetzt mach was *verrücktes* und baue deine eigenen Melodien.
 
 
 ## Anmerkungen des Übersetzers
 
-[^1]: Im deutschsprachigen Raum schreibt man solche Zahlen normalerweise mit Komma, also `52,3`; der Computer versteht aber nur Englisch, und deshalb werden Zahlen mit Nachkommastellen mit Punkt geschrieben, also `52.3`.
+[^1]: Im deutschsprachigen Raum schreibt man solche Zahlen 
+normalerweise mit Komma, also `52,3`; der Computer versteht aber nur 
+Englisch, und deshalb werden Zahlen mit Nachkommastellen mit Punkt 
+geschrieben, also `52.3`.
 
-[^2]: Auch hier gibt es im deutschsprachigen Raum eine andere Schreibweise: Erhöhte oder erniedrigte Noten z.B. das F werden als Fis oder Fes bezeichnet. Im Englischen heisst das Fis "F sharp" oder auch F# und das Fes "Fb" oder auch "F flat". Ansonsten sind die Notennamen mit eine Ausnahme gleich: Die Note H ist im Englischen das B. Und das um einen Halbton erniedrigte H heisst bei uns B, während es im Englischen logischerweise als "B flat" bezeichnet wird. Die C-Dur-Tonleiter lautet im Deutschen `C D E F G A H C`, während sie im Englischen so lautet: `C D E F G A B C`.
+[^2]: Auch hier gibt es im deutschsprachigen Raum eine andere 
+Schreibweise: Erhöhte oder erniedrigte Noten z.B. das F werden als Fis 
+oder Fes bezeichnet. Im Englischen heisst das Fis "F sharp" oder auch 
+F# und das Fes "Fb" oder auch "F flat". Ansonsten sind die Notennamen 
+mit eine Ausnahme gleich: Die Note H ist im Englischen das B. Und das 
+um einen Halbton erniedrigte H heisst bei uns B, während es im 
+Englischen logischerweise als "B flat" bezeichnet wird. Die 
+C-Dur-Tonleiter lautet im Deutschen `C D E F G A H C`, während sie im 
+Englischen so lautet: `C D E F G A B C`.
 
 

--- a/etc/doc/tutorial/de/02.2-Synth-Params.md
+++ b/etc/doc/tutorial/de/02.2-Synth-Params.md
@@ -2,51 +2,92 @@
 
 # Parameters: Amp and Pan
 
-So, wie du steuern kannst, welche Note oder welches Sample gespielt wird, bietet Sonic Pi auch eine Reihe von Paramtern, um Klänge zu gestalten und zu kontrollieren. Wir werden viele davon in diesem Tutorial behandeln, und es gibt für jeden Parameter ausführliche Informationen in der Hilfe. Jetzt sehen wir uns aber erstmal den nützlichsten an: *amplitude*. Lass uns zunächst ansehen, was Parameter eigentlich sind.
+So, wie du steuern kannst, welche Note oder welches Sample gespielt 
+wird, bietet Sonic Pi auch eine Reihe von Paramtern, um Klänge zu 
+gestalten und zu kontrollieren. Wir werden viele davon in diesem 
+Tutorial behandeln, und es gibt für jeden Parameter ausführliche 
+Informationen in der Hilfe. Jetzt sehen wir uns aber erstmal den 
+nützlichsten an: *amplitude*. Lass uns zunächst ansehen, was Parameter 
+eigentlich sind.
 
 ## Parameter
 
-Sonic Pi unterstützt die Idee von Parametern für seine Synths und Samples. Parameter sind Steuerelemente, die `play` oder `sample` übergeben werden; sie verändern und steuern die Art, wie sich die Klänge anhören. Jeder Synth hat seine eigenen Parameter, um den Klang fein einzustellen. Allerdings gibt es auch Parameter, die für viele Klänge gleich sind wie z.B. `amp:` und Hüllkurven-Parameter (die wir an anderer Stelle besprechen).
+Sonic Pi unterstützt die Idee von Parametern für seine Synths und 
+Samples. Parameter sind Steuerelemente, die `play` oder `sample` 
+übergeben werden; sie verändern und steuern die Art, wie sich die 
+Klänge anhören. Jeder Synth hat seine eigenen Parameter, um den Klang 
+fein einzustellen. Allerdings gibt es auch Parameter, die für viele 
+Klänge gleich sind wie z.B. `amp:` und Hüllkurven-Parameter (die wir an 
+anderer Stelle besprechen).
 
-Parameter haben zwei Hauptbestandteile, ihren Namen (der Name des Kontrollemements) und ihren Wert (den Wert, auf den du das Kontrollelement setzten möchtest). Zum Beispiel könntest du einen Parameter mit dem Namen `cheese:` haben, dem du den Wert `1` geben möchtest.
+Parameter haben zwei Hauptbestandteile, ihren Namen (der Name des 
+Kontrollemements) und ihren Wert (den Wert, auf den du das 
+Kontrollelement setzten möchtest). Zum Beispiel könntest du einen 
+Parameter mit dem Namen `cheese:` haben, dem du den Wert `1` geben 
+möchtest.
 
-Parameter werden den Aufrufen von `play` und `sample`, mit einem Komma `,` übergeben, dem der Name des Parameters folgt, etwa `amp:` (vergiss den Doppelpunkt nicht `:`), dann eine Leerstelle und schließlich der Wert des Parameters. Zum Beispiel:
+Parameter werden den Aufrufen von `play` und `sample`, mit einem Komma 
+`,` übergeben, dem der Name des Parameters folgt, etwa `amp:` (vergiss 
+den Doppelpunkt nicht `:`), dann eine Leerstelle und schließlich der 
+Wert des Parameters. Zum Beispiel:
 
 ```
 play 50, cheese: 1
 ```
 
-(Den Parameter `chesse:` gibt es in Wirklichkeit gar nicht, wir nehmen ihn nur als Beispiel).
+(Den Parameter `chesse:` gibt es in Wirklichkeit gar nicht, wir nehmen 
+ihn nur als Beispiel).
 
-Du kannst mehrere Parameter hintereinanderschreiben, indem du sie mit weiteren Kommata abtrennst:
+Du kannst mehrere Parameter hintereinanderschreiben, indem du sie mit 
+weiteren Kommata abtrennst:
 
 ```
 play 50, cheese: 1, beans: 0.5
 ```
 
-Die Reihenfolge der Parameter spielt keine Rolle, sodass die nächste Zeile dasselbe wie die vorherige tun würde:
+Die Reihenfolge der Parameter spielt keine Rolle, sodass die nächste 
+Zeile dasselbe wie die vorherige tun würde:
 
 ```
 play 50, beans: 0.5, cheese: 1
 ```
 
-Parameter, die vom Synth nicht erkannt werden, werden einfach links liegen gelassen (so wie `cheese` und `beans`, welches ja wirklich lachhafte Namen für einen Parameter wären!).
+Parameter, die vom Synth nicht erkannt werden, werden einfach links 
+liegen gelassen (so wie `cheese` und `beans`, welches ja wirklich 
+lachhafte Namen für einen Parameter wären!).
 
-Wenn du aus Versehen zweimal denselben Parameter benutzt, gewinnt der letzte. Im folgenden Beispiel wird `beans` den Wert 2 bekommen und nicht 0.5:
+Wenn du aus Versehen zweimal denselben Parameter benutzt, gewinnt der 
+letzte. Im folgenden Beispiel wird `beans` den Wert 2 bekommen und 
+nicht 0.5:
 
 ```
 play 50, beans: 0.5, cheese: 3, eggs: 0.1, beans: 2
 ```
 
-Viele Dinge in Sonic Pi lassen sich über Parameter steuern; nimm dir ein bisschen Zeit zu lernen, wie du sie einsetzten kannst und du bist startklar. Jetzt spielen wir mal mit unseren ersten Parameter: `amp:`.
+Viele Dinge in Sonic Pi lassen sich über Parameter steuern; nimm dir 
+ein bisschen Zeit zu lernen, wie du sie einsetzten kannst und du bist 
+startklar. Jetzt spielen wir mal mit unseren ersten Parameter: `amp:`.
 
 ## Amplitude
 
-Die Amplitude ist die Weise, wie sich der Computer die Lautstärke eines Klangs vorstellt. Eine *hohe Amplitude ergibt einen lauteren Klang* und eine *niedrige Amplitude ergibt einen leiseren Klang*. So wie Sonic Pi Zahlen dazu benutzt, um Zeit und Töne darzustellen, so benutzt es Zahlen auch dazu, um die Lautstärke abzubilden. Ein Amplitude von 0 bedeutet Stille (du wirst nichts hören) wohingegen eine Amplitude von 1 normale Lautstärke bedeutet. Du kannst die Amplitude aufdrehen auf 2, 10, 100. Allerdings, wenn die Amplitude aller gemeinsamen Klänge zu hoch wird, dann setzt Sonic Pi das ein, was man einen Kompressor nennt, damit die Klänge nicht zu laut für dein Ohr werden. Oft klingt das dann matschig und schräg. Verwende also lieber niedrigere Amplituden, das heisst zwischen 0 und 0.5, um die Kompression zu verhindern.
+Die Amplitude ist die Weise, wie sich der Computer die Lautstärke eines 
+Klangs vorstellt. Eine *hohe Amplitude ergibt einen lauteren Klang* und 
+eine *niedrige Amplitude ergibt einen leiseren Klang*. So wie Sonic Pi 
+Zahlen dazu benutzt, um Zeit und Töne darzustellen, so benutzt es 
+Zahlen auch dazu, um die Lautstärke abzubilden. Ein Amplitude von 0 
+bedeutet Stille (du wirst nichts hören) wohingegen eine Amplitude von 1 
+normale Lautstärke bedeutet. Du kannst die Amplitude aufdrehen auf 2, 
+10, 100. Allerdings, wenn die Amplitude aller gemeinsamen Klänge zu 
+hoch wird, dann setzt Sonic Pi das ein, was man einen Kompressor nennt, 
+damit die Klänge nicht zu laut für dein Ohr werden. Oft klingt das dann 
+matschig und schräg. Verwende also lieber niedrigere Amplituden, das 
+heisst zwischen 0 und 0.5, um die Kompression zu verhindern.
 
 ## Amp verwenden
 
-Um die Amplitude eines Klangs zu ändern, setze den Parameter `amp:` ein. Wenn du zum Beispiel mit halber Amplitude spielen willst, dann übergib den Wert 0.5:
+Um die Amplitude eines Klangs zu ändern, setze den Parameter `amp:` 
+ein. Wenn du zum Beispiel mit halber Amplitude spielen willst, dann 
+übergib den Wert 0.5:
 
 ```
 play 60, amp: 0.5
@@ -58,7 +99,10 @@ Um mit doppelter Amplitude zu spielen:
 play 60, amp: 2
 ```
 
-Der Parameter `amp:` beeinflusst nur den Aufruf von `play`, mit dem er unmittelbar zusammenhängt. Das heisst, in dem folgenden Beispiel wird der erste Aufruf von `play` mit halber Lautstärke gespielt und der zweite wieder mit der Standardlautstärke (1) [^1]:
+Der Parameter `amp:` beeinflusst nur den Aufruf von `play`, mit dem er 
+unmittelbar zusammenhängt. Das heisst, in dem folgenden Beispiel wird 
+der erste Aufruf von `play` mit halber Lautstärke gespielt und der 
+zweite wieder mit der Standardlautstärke (1) [^1]:
 
 ```
 play 60, amp: 0.5
@@ -66,7 +110,8 @@ sleep 0.5
 play 65
 ```
 
-Natürlich kannst du für jeden Aufruf von `play` andere Werte für `amp:` übergeben:
+Natürlich kannst du für jeden Aufruf von `play` andere Werte für `amp:` 
+übergeben:
 
 ```
 play 50, amp: 0.1
@@ -80,7 +125,12 @@ play 62, amp: 1
 
 ## Panning
 
-Ein weiterer interessanter Parameter ist `pan:` der angibt, aus welcher Richtung der Klang kommt, wenn wir in Stereo hören. Dafür benutzen wir als Werte eine -1, um den Klang ganz nach links zu schieben, 0 für die Mitte und 1, damit der Klang nur aus dem rechten Lautsprecher kommt. Natürlich kannst du jeden Wert zwischen -1 und 1 verwenden, um deine Klänge im Stereofeld zu positionieren.
+Ein weiterer interessanter Parameter ist `pan:` der angibt, aus welcher 
+Richtung der Klang kommt, wenn wir in Stereo hören. Dafür benutzen wir 
+als Werte eine -1, um den Klang ganz nach links zu schieben, 0 für die 
+Mitte und 1, damit der Klang nur aus dem rechten Lautsprecher kommt. 
+Natürlich kannst du jeden Wert zwischen -1 und 1 verwenden, um deine 
+Klänge im Stereofeld zu positionieren.
 
 Spiel einen Klang, der nur aus linken Lautsprecher kommt:
 
@@ -100,6 +150,9 @@ Nun lass den Klang aus der Mitte herauskommen (die Standardposition):
 play 60, pan: 0
 ```
 
-Jetzt leg los und arbeite mit der Amplitude und dem Panning von deinen Klängen.
+Jetzt leg los und arbeite mit der Amplitude und dem Panning von deinen 
+Klängen.
 
-[^1]: In Programmiersprachen nennt man einen Standardwert einen `default`. Genauer gesagt ist ein `default`-Wert der Wert, der automatisch gesetzt wird also die `Voreinstellung` im Programm.
+[^1]: In Programmiersprachen nennt man einen Standardwert einen 
+`default`. Genauer gesagt ist ein `default`-Wert der Wert, der 
+automatisch gesetzt wird also die `Voreinstellung` im Programm.

--- a/etc/doc/tutorial/de/02.3-Switching-Synths.md
+++ b/etc/doc/tutorial/de/02.3-Switching-Synths.md
@@ -2,15 +2,27 @@
 
 # Synths wechseln
 
-Bis jetzt hatten wir viel Spaß mit Tönen und Samples. Aber wahrscheinlich wird dir langsam langweilig, immer denselben Klang zu hören. Ist das alles, was Sonic Pi anzubieten hat? Besteht das Live Coding nicht aus mehr als Pieptönen? Aber klar doch, und in diesem Abschnitt sehen wir uns die spannende Auswahl an Sounds an, die Sonic Pi mitbringt.
+Bis jetzt hatten wir viel Spaß mit Tönen und Samples. Aber 
+wahrscheinlich wird dir langsam langweilig, immer denselben Klang zu 
+hören. Ist das alles, was Sonic Pi anzubieten hat? Besteht das Live 
+Coding nicht aus mehr als Pieptönen? Aber klar doch, und in diesem 
+Abschnitt sehen wir uns die spannende Auswahl an Sounds an, die Sonic 
+Pi mitbringt.
 
 ## Synths
 
-Sonic Pi bringt eine Palette an Instrumenten mit, die Synths heissen, eine *Kurzform für Synthesizer*. Samples sind vorher aufgenommene Klänge; demgegenüber können Synths neue Klänge erzeugen, je nachdem, wie du sie anlegst (wie das geht, werden wir später sehen). Sonic Pi's Synths sind sehr wirkungsvoll und ausdrucksstark und man kann damit tolle Sachen machen. Als erstes lernen wir, wie man einen Synth auswählt, den man benutzen möchte.
+Sonic Pi bringt eine Palette an Instrumenten mit, die Synths heissen, 
+eine *Kurzform für Synthesizer*. Samples sind vorher aufgenommene 
+Klänge; demgegenüber können Synths neue Klänge erzeugen, je nachdem, 
+wie du sie anlegst (wie das geht, werden wir später sehen). Sonic Pi's 
+Synths sind sehr wirkungsvoll und ausdrucksstark und man kann damit 
+tolle Sachen machen. Als erstes lernen wir, wie man einen Synth 
+auswählt, den man benutzen möchte.
 
 ## Brilliante Sägen und Prophets[^1]
 
-Einen spaßigen Sound ergibt die *Sägezahn-Welle* - probieren wir es mal aus:
+Einen spaßigen Sound ergibt die *Sägezahn-Welle* - probieren wir es mal 
+aus:
 
 ```
 use_synth :saw
@@ -59,11 +71,17 @@ play 57
 sleep 0.25
 ```
 
-Hast du bemerkt, dass das `use_synth`-Kommando nur die nachfolgenden `play`-Kommandos beeinflusst? Stell es dir vor als einen *großen Schalter* - neue Aufrufe von `play` werden immer den Synth benutzen, auf den synth gerade zeigt. Du kannst diesen Schalter mit `use_synth` auf einen anderen Synth umschalten.
+Hast du bemerkt, dass das `use_synth`-Kommando nur die nachfolgenden 
+`play`-Kommandos beeinflusst? Stell es dir vor als einen *großen 
+Schalter* - neue Aufrufe von `play` werden immer den Synth benutzen, 
+auf den synth gerade zeigt. Du kannst diesen Schalter mit `use_synth` 
+auf einen anderen Synth umschalten.
 
 ## Synths entdecken
 
-Du kannst herausfinden, welche Synths Sonic Pi für dich bereitstellt, indem du im Menü auf der linken Seite Synths anklickst (gleich über Fx). Es gibt über 20 Stück. Hier sind einige meiner Lieblings-Synths:
+Du kannst herausfinden, welche Synths Sonic Pi für dich bereitstellt, 
+indem du im Menü auf der linken Seite Synths anklickst (gleich über 
+Fx). Es gibt über 20 Stück. Hier sind einige meiner Lieblings-Synths:
 
 * `:prophet`
 * `:dsaw`
@@ -71,6 +89,12 @@ Du kannst herausfinden, welche Synths Sonic Pi für dich bereitstellt, indem du 
 * `:tb303`
 * `:pulse`
 
-Spiel mal ein bisschen herum indem du *in deinem Stück die Synths wechselst*. Kombiniere unterschiedliche Synths oder setze sie für unterschiedliche Stellen in deinem Stück ein.
+Spiel mal ein bisschen herum indem du *in deinem Stück die Synths 
+wechselst*. Kombiniere unterschiedliche Synths oder setze sie für 
+unterschiedliche Stellen in deinem Stück ein.
 
-[^1]: Die Name "Sägezahn" (engl. saw) kommt von der Wellenform, die dieser Synthesizer produziert. Wenn man sich diesen Klang mit einem Oszilloskop anzeigen lässt, sieht er aus wie die Zähne einer Säge. Der Name "Prophet" kommt von einem Synthesizer, den der amerikanische Hersteller Sequential Circuits Ende der 70er Jahre herstellte.
+[^1]: Die Name "Sägezahn" (engl. saw) kommt von der Wellenform, die 
+dieser Synthesizer produziert. Wenn man sich diesen Klang mit einem 
+Oszilloskop anzeigen lässt, sieht er aus wie die Zähne einer Säge. Der 
+Name "Prophet" kommt von einem Synthesizer, den der amerikanische 
+Hersteller Sequential Circuits Ende der 70er Jahre herstellte.

--- a/etc/doc/tutorial/de/02.4-Durations-with-Envelopes.md
+++ b/etc/doc/tutorial/de/02.4-Durations-with-Envelopes.md
@@ -2,48 +2,89 @@
 
 # Dauern und Hüllkurven
 
-Wie wir schon vorher gesehen haben, können wir mit dem `sleep`-Kommando steuern, wann ein Klang anfängt zu spielen. Bislang konnten wir aber noch nicht die Dauer eines Klangs steuern (außer bei Samplen, die wir strecken oder verdichten können).
+Wie wir schon vorher gesehen haben, können wir mit dem `sleep`-Kommando 
+steuern, wann ein Klang anfängt zu spielen. Bislang konnten wir aber 
+noch nicht die Dauer eines Klangs steuern (außer bei Samplen, die wir 
+strecken oder verdichten können).
 
-Um die *Dauer von Klängen* auf einfache aber weitgehende Weise zu beeinflussen, bietet Sonic Pi das Prinzip der *ADSR-Hüllkurve* [^1] (wir werden später sehen, was ADSR genau bedeutet). Eine Hüllkurve (engl. envelope) hat zwei nutzbringende Eigenschaften:
+Um die *Dauer von Klängen* auf einfache aber weitgehende Weise zu 
+beeinflussen, bietet Sonic Pi das Prinzip der *ADSR-Hüllkurve* [^1] 
+(wir werden später sehen, was ADSR genau bedeutet). Eine Hüllkurve 
+(engl. envelope) hat zwei nutzbringende Eigenschaften:
 
 * Kontrolle über die Dauer eines Klangs
 * Kontrolle über die Amplitude (Lautstärke) eines Klangs
 
 ## Dauer
 
-Die Dauer bestimmt, wie lange ein Klang klingt. Eine erhöhte Dauer bedeutet, dass du den Klang länger hören kannst. Alle Klänge in Sonic Pi haben eine Hüllkurve, die beeinflusst werden kann, und die gesamte Dauer dieser Hüllkurve bestimmt die Dauer des Klangs. Deshalb kann man über die Kontrolle der Hüllkurve die Dauer des Klangs beeinflussen.
+Die Dauer bestimmt, wie lange ein Klang klingt. Eine erhöhte Dauer 
+bedeutet, dass du den Klang länger hören kannst. Alle Klänge in Sonic 
+Pi haben eine Hüllkurve, die beeinflusst werden kann, und die gesamte 
+Dauer dieser Hüllkurve bestimmt die Dauer des Klangs. Deshalb kann man 
+über die Kontrolle der Hüllkurve die Dauer des Klangs beeinflussen.
  
 ## Amplitude
 
-Die ADSR-Hüllkuve kontrolliert nicht nur die Dauer, sondern ermöglicht die auch die *genaue Kontrolle über die Amplitude eines Klangs*. Alle Klänge beginnen und enden mit Stille; dazwischen ist irgendetwas hörbar. Hüllkurven erlauben dir, die Amplitude der hörbaren Anteile des Klanges zu verschieben, zu verlängern und zu verkürzen. Es ist so, als würdest du jemanden sagen, wie er die Lautstärke einer Musik lauter und leiser dreht. Du könntest denjenigen z.B. bitten "fang' bitte mit einer Stille an, dreh' dann die Lautstärke langsam bis zum Anschlag hoch, lass' es eine Weile so und blende dann schnell runter, bis man nichts mehr hört". Soetwas kann man in Sonic Pi mit Hüllkurven machen.
+Die ADSR-Hüllkuve kontrolliert nicht nur die Dauer, sondern ermöglicht 
+die auch die *genaue Kontrolle über die Amplitude eines Klangs*. Alle 
+Klänge beginnen und enden mit Stille; dazwischen ist irgendetwas 
+hörbar. Hüllkurven erlauben dir, die Amplitude der hörbaren Anteile des 
+Klanges zu verschieben, zu verlängern und zu verkürzen. Es ist so, als 
+würdest du jemanden sagen, wie er die Lautstärke einer Musik lauter und 
+leiser dreht. Du könntest denjenigen z.B. bitten "fang' bitte mit einer 
+Stille an, dreh' dann die Lautstärke langsam bis zum Anschlag hoch, 
+lass' es eine Weile so und blende dann schnell runter, bis man nichts 
+mehr hört". Soetwas kann man in Sonic Pi mit Hüllkurven machen.
 
-Wie wir vorher schon gesehen haben, bedeutet eine Amplitude von 0 Stille und eine Amplitude von 1 entspricht der normalen Lautstärke.
+Wie wir vorher schon gesehen haben, bedeutet eine Amplitude von 0 
+Stille und eine Amplitude von 1 entspricht der normalen Lautstärke.
 
 ## Release-Zeit
 
-Standardmäßig haben alle Synths eine Release-Zeit von der Länge 1. Das bedeutet, sie haben eine Dauer von 1 Sekunde, bevor sie verklungen sind. Wir können diese Dauer verändern, indem wir das `release`-Argument der Funktion `play` übergeben. Damit ein Synth 2 Sekunden lang spielt, übergeben wir z.B. einen `release` von `2`:
+Standardmäßig haben alle Synths eine Release-Zeit von der Länge 1. Das 
+bedeutet, sie haben eine Dauer von 1 Sekunde, bevor sie verklungen 
+sind. Wir können diese Dauer verändern, indem wir das 
+`release`-Argument der Funktion `play` übergeben. Damit ein Synth 2 
+Sekunden lang spielt, übergeben wir z.B. einen `release` von `2`:
 
 ```
 play 60, release: 2
 ```
 
-Wir können den Synth-Klang auch sehr kurz machen, indem wir eine sehr kurze Release-Zeit festlegen:
+Wir können den Synth-Klang auch sehr kurz machen, indem wir eine sehr 
+kurze Release-Zeit festlegen:
 
 ```
 play 60, release: 0.2
 ```
 
-Also was ist nun die Release-Zeit? Es ist die Zeit, die der Klang braucht, um von der vollen Höhe der Kurve (typischerweise der Wert 1) bis auf Null abzufallen. Das nennt man auch die *Release-Phase* und es ist ein linearer Übergang (d.h. eine gerade Linie). Die folgende Abbildung illustriert, wie ein solcher Übergang aussieht:
+Also was ist nun die Release-Zeit? Es ist die Zeit, die der Klang 
+braucht, um von der vollen Höhe der Kurve (typischerweise der Wert 1) 
+bis auf Null abzufallen. Das nennt man auch die *Release-Phase* und es 
+ist ein linearer Übergang (d.h. eine gerade Linie). Die folgende 
+Abbildung illustriert, wie ein solcher Übergang aussieht:
 
 ![release envelope](:/images/tutorial/env-release.png)
 
-Die senkrechte Linie ganz links im Bild zeigt, dass der Klang mit einer Amplitude von 0 startet, jedoch sofort auf die volle Höhe geht (das ist die Attack-Phase, die wir gleich ansehen werden). Wenn die volle Höhe erreicht ist, geht die Amplitude in einer geraden Linie bis auf Null zurück, wobei dies solange dauert, wie es mit `release` festgelegt wurde. *Je länger die Release-Zeit eines Synth, desto länger wird dieser ausgeblendet.*
+Die senkrechte Linie ganz links im Bild zeigt, dass der Klang mit einer 
+Amplitude von 0 startet, jedoch sofort auf die volle Höhe geht (das ist 
+die Attack-Phase, die wir gleich ansehen werden). Wenn die volle Höhe 
+erreicht ist, geht die Amplitude in einer geraden Linie bis auf Null 
+zurück, wobei dies solange dauert, wie es mit `release` festgelegt 
+wurde. *Je länger die Release-Zeit eines Synth, desto länger wird 
+dieser ausgeblendet.*
 
-Deshalb kannst du die Länge eines Klangs ändern, wenn du seine Release-Zeit änderst. Spiel einmal mit unterschiedlichen Release-Zeiten herum.
+Deshalb kannst du die Länge eines Klangs ändern, wenn du seine 
+Release-Zeit änderst. Spiel einmal mit unterschiedlichen Release-Zeiten 
+herum.
 
 ## Attack Time
 
-Standardmäßig ist die Attack-Phase für alle Synths 0, was bedeutet, dass diese sofort von der Amplitude 0 auf 1 hochgehen. Dies gibt dem Synth einen perkussiven Klang. Vielleicht möchtest du den Klang jedoch einblenden. Dies kannst du mit dem `attack`-Argument erreichen. Blende einige Klänge ein:
+Standardmäßig ist die Attack-Phase für alle Synths 0, was bedeutet, 
+dass diese sofort von der Amplitude 0 auf 1 hochgehen. Dies gibt dem 
+Synth einen perkussiven Klang. Vielleicht möchtest du den Klang jedoch 
+einblenden. Dies kannst du mit dem `attack`-Argument erreichen. Blende 
+einige Klänge ein:
 
 ```
 play 60, attack: 2
@@ -51,17 +92,20 @@ sleep 3
 play 65, attack: 0.5
 ```
 
-Du kannst mehrere Argumente zur selben Zeit anwenden. Zum Beispiel für eine kurze Attack- und eine lange Release-Zeit:
+Du kannst mehrere Argumente zur selben Zeit anwenden. Zum Beispiel für 
+eine kurze Attack- und eine lange Release-Zeit:
 
 ```
 play 60, attack: 0.7, release: 4
 ```
 
-Dies Hüllkurve mit einem kurzen Attack und langem Release wird in der folgenden Abbildung dargestellt:
+Dies Hüllkurve mit einem kurzen Attack und langem Release wird in der 
+folgenden Abbildung dargestellt:
 
 ![attack release envelope](:/images/tutorial/env-attack-release.png)
 
-Natürlich kann man die Dinge auch umdrehen. Versuche einen langen Attack und einen kurzen Release:
+Natürlich kann man die Dinge auch umdrehen. Versuche einen langen 
+Attack und einen kurzen Release:
 
 ```
 play 60, attack: 4, release: 0.7
@@ -69,7 +113,8 @@ play 60, attack: 4, release: 0.7
 
 ![long attack short release envelope](:/images/tutorial/env-long-attack-short-release.png)
 
-Schließlich kannst du auch einen kurzen Attack und Release für kürzere Klänge verwenden.
+Schließlich kannst du auch einen kurzen Attack und Release für kürzere 
+Klänge verwenden.
 
 ```
 play 60, attack: 0.5, release: 0.5
@@ -79,7 +124,10 @@ play 60, attack: 0.5, release: 0.5
 
 ## Sustain-Zeit
 
-Zusätzlich zu den Attack- und Release-Zeiten kannst du auch die Sustain-Zeit bestimmen. Das ist die Zeitdauer, den der Klang anhält, wenn er die eingestellte Lautstärke erreicht hat, also zwischen dem Attack- und dem Release-Stadium.
+Zusätzlich zu den Attack- und Release-Zeiten kannst du auch die 
+Sustain-Zeit bestimmen. Das ist die Zeitdauer, den der Klang anhält, 
+wenn er die eingestellte Lautstärke erreicht hat, also zwischen dem 
+Attack- und dem Release-Stadium.
 
 ```
 play 60, attack: 0.3, sustain: 1, release: 1
@@ -87,11 +135,24 @@ play 60, attack: 0.3, sustain: 1, release: 1
 
 ![ASR envelope](:/images/tutorial/env-attack-sustain-release.png)
 
-Die Sustain-Zeit kann man gut dafür gebrauchen, um wichtige Klänge in einem Mix hervorzuheben, bevor möglicherweise der Release einsetzt. Natürlich kann man ohne weiteres sowohl den Attack als auch den Release auf 0 setzen und nur den Sustain gebrauchen; damit bekommt man einen Klang ohne Ein- und Ausblendung. Aber vorsicht, ein Release von 0 kann Klickgeräusche in der Aufnahme verursachen, und meist ist es besser einen geringen Wert von z.B. 0.2 zu verwenden.
+Die Sustain-Zeit kann man gut dafür gebrauchen, um wichtige Klänge in 
+einem Mix hervorzuheben, bevor möglicherweise der Release einsetzt. 
+Natürlich kann man ohne weiteres sowohl den Attack als auch den Release 
+auf 0 setzen und nur den Sustain gebrauchen; damit bekommt man einen 
+Klang ohne Ein- und Ausblendung. Aber vorsicht, ein Release von 0 kann 
+Klickgeräusche in der Aufnahme verursachen, und meist ist es besser 
+einen geringen Wert von z.B. 0.2 zu verwenden.
 
 ## Decay-Zeit
 
-Und schließlich, falls du alles ganz genau beeinflussen möchtest, kannst du noch die Decay-Zeit festlegen. Das ist eine Phase der Hüllkurve, die zwischen die Attack- und die Release-Phase passt; sie gibt die Zeit an, wo die Amplitude vom  `attack_level` zum `sustain_level` hinunterfällt. Normalerweise steht das Decay-Argument auf 0, während sowohl das Attack- als auch das Sustain-Level auf 1 stehen; Attack und Sustain muss also angegeben werden, damit die Decay-Zeit einen hörbaren Effekt hat:
+Und schließlich, falls du alles ganz genau beeinflussen möchtest, 
+kannst du noch die Decay-Zeit festlegen. Das ist eine Phase der 
+Hüllkurve, die zwischen die Attack- und die Release-Phase passt; sie 
+gibt die Zeit an, wo die Amplitude vom  `attack_level` zum 
+`sustain_level` hinunterfällt. Normalerweise steht das Decay-Argument 
+auf 0, während sowohl das Attack- als auch das Sustain-Level auf 1 
+stehen; Attack und Sustain muss also angegeben werden, damit die 
+Decay-Zeit einen hörbaren Effekt hat:
 
 ```
 play 60, attack: 0.1, attack_level: 1, decay: 0.2, sustain_level: 0.4, sustain: 1, release: 0.5
@@ -101,14 +162,17 @@ play 60, attack: 0.1, attack_level: 1, decay: 0.2, sustain_level: 0.4, sustain: 
 
 ## ADSR-Hüllkurven
 
-Fassen wir noch einmal zusammen: Sonic Pi's ADSR-Hüllkurven bestehen aus den folgenden Phasen:
+Fassen wir noch einmal zusammen: Sonic Pi's ADSR-Hüllkurven bestehen 
+aus den folgenden Phasen:
 
 1. *attack* - die Zeit, die die Amplitude von 0 bis zum `attack_level` benötigt,
 2. *decay* - die Zeit, in der die Amplitude vom `attack_level` zum `sustain_level` übergeht,
 3. *sustain* - die Zeit, in der sich die Amplitude auf dem `sustain_level` hält,
 4. *release* - die Zeit, die die Amplitude vom `sustain_level` auf 0 bringt
 
-Eins ist wichtig: der Klang dauert so lange, wie die Summe aller Zeiten der unterschiedlichen Phasen. Deshalb hat der folgende Klang eine Dauer von 0.5 + 1 + 2 + 0.5 = 4 Sekunden:
+Eins ist wichtig: der Klang dauert so lange, wie die Summe aller Zeiten 
+der unterschiedlichen Phasen. Deshalb hat der folgende Klang eine Dauer 
+von 0.5 + 1 + 2 + 0.5 = 4 Sekunden:
 
 ```
 play 60, attack: 0.5, decay: 1, sustain_level: 0.4, sustain: 2, release: 0.5
@@ -116,7 +180,9 @@ play 60, attack: 0.5, decay: 1, sustain_level: 0.4, sustain: 2, release: 0.5
 
 Jetzt weisst du, wie du deine Klänge mit Hüllkurven verändern kannst...
 
-[^1]: Im Englischen heisst der Begriff *Hüllkurve* *envelope*. *ADSR* steht als Kurzform für die Begriffe *Attack*, *Decay*, *Sustain* und *Release*, die in diesem Kapitel erklärt werden.
+[^1]: Im Englischen heisst der Begriff *Hüllkurve* *envelope*. *ADSR* 
+steht als Kurzform für die Begriffe *Attack*, *Decay*, *Sustain* und 
+*Release*, die in diesem Kapitel erklärt werden.
 
 
 

--- a/etc/doc/tutorial/de/03-Samples.md
+++ b/etc/doc/tutorial/de/03-Samples.md
@@ -2,6 +2,13 @@
 
 # Samples
 
-Du kannst deine Musik auch prima mit aufgenommenen Sounds erweitern. In der großen Tradition des Hip-Hop nennen wir diese aufgenommenen Sounds auch *Samples*. Also, wenn du ein Mikrophon mit nach draußen nimmst und den zarten Klang der Regentropfen auf einem Zeltdach aufnimmst, dann hast du ein Sample erzeugt.
+Du kannst deine Musik auch prima mit aufgenommenen Sounds erweitern. In 
+der großen Tradition des Hip-Hop nennen wir diese aufgenommenen Sounds 
+auch *Samples*. Also, wenn du ein Mikrophon mit nach draußen nimmst und 
+den zarten Klang der Regentropfen auf einem Zeltdach aufnimmst, dann 
+hast du ein Sample erzeugt.
 
-Mit Samples kann man in Sonic Pi viele tolle Sachen machen. Es bringt nicht nur 90 freie Samples zum sofortigen Gebrauch mit, sondern du kannst auch deinen eigenen Sampes einbauen und manipulieren. Legen wir los...
+Mit Samples kann man in Sonic Pi viele tolle Sachen machen. Es bringt 
+nicht nur 90 freie Samples zum sofortigen Gebrauch mit, sondern du 
+kannst auch deinen eigenen Sampes einbauen und manipulieren. Legen wir 
+los...

--- a/etc/doc/tutorial/de/03.1-Triggering-Samples.md
+++ b/etc/doc/tutorial/de/03.1-Triggering-Samples.md
@@ -2,13 +2,16 @@
 
 # Samples ansteuern
 
-Pieptöne zu spielen ist erst der Anfang. Mit aufgenommenen Samples hat man noch viel mehr Spaß. Versuche es:
+Pieptöne zu spielen ist erst der Anfang. Mit aufgenommenen Samples hat 
+man noch viel mehr Spaß. Versuche es:
 
 ```
 sample :ambi_lunar_land
 ```
 
-Sonic Pi enthält viele Samples, mit denen du spielen kannst. Du kannst sie benutzen, genauso wie du das `play`-Kommando verwendest. Um mehrere Samples gleichzeitig zu spielen, schreib sie einfach untereinander:
+Sonic Pi enthält viele Samples, mit denen du spielen kannst. Du kannst 
+sie benutzen, genauso wie du das `play`-Kommando verwendest. Um mehrere 
+Samples gleichzeitig zu spielen, schreib sie einfach untereinander:
 
 ```
 play 36
@@ -30,13 +33,24 @@ sleep 1
 play 36
 ```
 
-Hast du bemerkt, dass Sonic Pi nicht wartet, bis ein Klang beendet ist, bevor der nächste beginnt? Der `sleep`-Befehl beschreibt nur, wann ein Klang *ausgelöst* wird, und wann der nächste nachfolgt. Damit kannst du Klänge in Schichten übereinander legen und interessante überlappende Effekte herstellen. Später sehen wir uns in dieser Einführung an, wie man die Länge von Klängen mit *Hüllkurven* kontrollieren kann.
+Hast du bemerkt, dass Sonic Pi nicht wartet, bis ein Klang beendet ist, 
+bevor der nächste beginnt? Der `sleep`-Befehl beschreibt nur, wann ein 
+Klang *ausgelöst* wird, und wann der nächste nachfolgt. Damit kannst du 
+Klänge in Schichten übereinander legen und interessante überlappende 
+Effekte herstellen. Später sehen wir uns in dieser Einführung an, wie 
+man die Länge von Klängen mit *Hüllkurven* kontrollieren kann.
 
 ## Samples entdecken
 
-Es gibt zwei Arten, wie du die Samples erforschen kannst, die Sonic Pi mitbringt. Erstens kannst du dieses Hilfesystem benutzen. Klicke auf Samples im Menü auf der linken Seite, wähle eine Gruppe aus und lass die die Liste aller verfügbaren Klänge anzeigen.
+Es gibt zwei Arten, wie du die Samples erforschen kannst, die Sonic Pi 
+mitbringt. Erstens kannst du dieses Hilfesystem benutzen. Klicke auf 
+Samples im Menü auf der linken Seite, wähle eine Gruppe aus und lass 
+die die Liste aller verfügbaren Klänge anzeigen.
 
-Du kannst auch das *auto-completion system* verwenden. Tipp einfach den Anfang eines Gruppennamens von Samples ein, also: `sample :ambi_`und ein Menü klappt auf, aus dem du ein Sample auswählen kannst. Versuche einen der folgenden Anfänge von Gruppennamen:
+Du kannst auch das *auto-completion system* verwenden. Tipp einfach den 
+Anfang eines Gruppennamens von Samples ein, also: `sample :ambi_`und 
+ein Menü klappt auf, aus dem du ein Sample auswählen kannst. Versuche 
+einen der folgenden Anfänge von Gruppennamen:
 
 * `:ambi_` 
 * `:bass_`

--- a/etc/doc/tutorial/de/03.2-Sample-Params.md
+++ b/etc/doc/tutorial/de/03.2-Sample-Params.md
@@ -2,11 +2,14 @@
 
 # Sample Parameter: Amp und Pan
 
-Genauso wie mit den Synths können wir auch unsere Sounds mit Parametern steuern. Samples funktionieren mit demselben Parameter-Mechanismus. Besuchen wir unsere Freunde `amp:` and `pan:` nocheinmal.
+Genauso wie mit den Synths können wir auch unsere Sounds mit Parametern 
+steuern. Samples funktionieren mit demselben Parameter-Mechanismus. 
+Besuchen wir unsere Freunde `amp:` and `pan:` nocheinmal.
 
 ## Die Amplitude von Samples verändern
 
-Du kannst die Amplitude (Lautstärke) von Samples so steuern, wie du es auch von den Synths kennst:
+Du kannst die Amplitude (Lautstärke) von Samples so steuern, wie du es 
+auch von den Synths kennst:
 
 ```
 sample :ambi_lunar_land, amp: 0.5
@@ -14,7 +17,9 @@ sample :ambi_lunar_land, amp: 0.5
 
 ## Das Stereo-Feld von Samples verändern
 
-Wir können auch den `pan:`-Parameter auf Samples anwenden. Hier zum Beispiel spielen wir den Amen Break zunächst zunächst für das linke und nach der Hälfte für das rechte Ohr:
+Wir können auch den `pan:`-Parameter auf Samples anwenden. Hier zum 
+Beispiel spielen wir den Amen Break zunächst zunächst für das linke und 
+nach der Hälfte für das rechte Ohr:
 
 ```
 sample :loop_amen, pan: -1
@@ -24,4 +29,6 @@ sample :loop_amen, pan: 1
 
 0.877 ist genau die Hälfte der Dauer des Amen Breaks in Sekunden.
 
-Schließlich: Beachte bitte, dass, wenn du Grundeinstellungen für einen Synth mit `use_synth_defaults` setzt (dazu kommen wir später noch), diese von Samples nicht berücksichtigt werden.
+Schließlich: Beachte bitte, dass, wenn du Grundeinstellungen für einen 
+Synth mit `use_synth_defaults` setzt (dazu kommen wir später noch), 
+diese von Samples nicht berücksichtigt werden.

--- a/etc/doc/tutorial/de/03.3-Stretching-Samples.md
+++ b/etc/doc/tutorial/de/03.3-Stretching-Samples.md
@@ -2,37 +2,62 @@
 
 # Samples ausdehnen
 
-Jetzt, wo wir eine ganze Menge Synths und Samples spielen können, um damit Musik zu machen, wird es Zeit zu lernen, wie wir diese Synths und Samples verändern könnten; das macht unsere Musik einzigartiger und spannender. Als erstes sehen wir uns an, wie wir Samples *strecken* und *stauchen* können.
+Jetzt, wo wir eine ganze Menge Synths und Samples spielen können, um 
+damit Musik zu machen, wird es Zeit zu lernen, wie wir diese Synths und 
+Samples verändern könnten; das macht unsere Musik einzigartiger und 
+spannender. Als erstes sehen wir uns an, wie wir Samples *strecken* und 
+*stauchen* können.
 
 ## Wie Samples Klänge darstellen
 
-Samples sind aufgenommene Klänge, die als eine Menge von Zahlen gespeichert werden; die Zahlen sagen der Lautsprechermembran, wie sie sich bewegen muss, um den Klang wiederzugeben. Die Lautsprechermembran kann sich nach innen und nach außen bewegen, also müssen die Zahlen angeben, wie weit sich die Membran zu jedem Zeitpunkt nach innern oder nach außen bewegen soll. Um einen Klang als Aufnahme wirklichkeitsgetreu wiederzugeben, muss das Sample je Sekunde viele tausend Zahlen speichern. Sonic Pi nimmt diese Liste von Zahlen und gibt sie in der richtigen Samplerate [^1] an den Lautsprecher in deinem Computer genauso, dass der Klang richtig wiedergegeben wird. Jedoch macht es auch Spaß die Raten zu ändern, mit der die Zahlen an den Lautsprecher geschickt werden, und so den Klang zu ändern.
+Samples sind aufgenommene Klänge, die als eine Menge von Zahlen 
+gespeichert werden; die Zahlen sagen der Lautsprechermembran, wie sie 
+sich bewegen muss, um den Klang wiederzugeben. Die Lautsprechermembran 
+kann sich nach innen und nach außen bewegen, also müssen die Zahlen 
+angeben, wie weit sich die Membran zu jedem Zeitpunkt nach innern oder 
+nach außen bewegen soll. Um einen Klang als Aufnahme 
+wirklichkeitsgetreu wiederzugeben, muss das Sample je Sekunde viele 
+tausend Zahlen speichern. Sonic Pi nimmt diese Liste von Zahlen und 
+gibt sie in der richtigen Samplerate [^1] an den Lautsprecher in deinem 
+Computer genauso, dass der Klang richtig wiedergegeben wird. Jedoch 
+macht es auch Spaß die Raten zu ändern, mit der die Zahlen an den 
+Lautsprecher geschickt werden, und so den Klang zu ändern.
 
 ## Die Samplerate ändern
 
-Lass uns mit einem der Ambient-Klänge spielen: `ambi_choir`. Um diesen mit Standard-Samplerate wiederzugeben, kannst du dem `sample` das Argument[^2] `rate:` übergeben:
+Lass uns mit einem der Ambient-Klänge spielen: `ambi_choir`. Um diesen 
+mit Standard-Samplerate wiederzugeben, kannst du dem `sample` das 
+Argument[^2] `rate:` übergeben:
 
 ```
 sample :ambi_choir, rate: 1
 ```
 
-Das Sample wird mit der normalen Samplerate (1) abgespielt, also nichts Besonderes. Aber wir können die Zahl jederzeit verändern. Was ist mit `0.5`?
+Das Sample wird mit der normalen Samplerate (1) abgespielt, also nichts 
+Besonderes. Aber wir können die Zahl jederzeit verändern. Was ist mit 
+`0.5`?
 
 ```
 sample :ambi_choir, rate: 0.5
 ```
 
-Wow! Was ist denn jetzt los? Also, hier passieren zwei Dinge. Erstens braucht der Sample zweimal solange und zweitens klingt er eine Oktave niedriger. Sehen wir uns das mal genauer an.
+Wow! Was ist denn jetzt los? Also, hier passieren zwei Dinge. Erstens 
+braucht der Sample zweimal solange und zweitens klingt er eine Oktave 
+niedriger. Sehen wir uns das mal genauer an.
 
 ## Lasst uns stretchen
 
-Mit dem Amen Break-Sample macht das strecken und zusammenstauchen besonders viel Spass. Mit der normalen Samplerate könnten wir dieses in einem *Drum 'n' Bass*-Track verwenden:
+Mit dem Amen Break-Sample macht das strecken und zusammenstauchen 
+besonders viel Spass. Mit der normalen Samplerate könnten wir dieses in 
+einem *Drum 'n' Bass*-Track verwenden:
 
 ```
 sample :loop_amen
 ```
 
-Wenn wir die Samplerate ändern, dann können wir die Stilrichtungen wechseln. Versuche es mal mit halber Samplerate für *Hip-Hop der alten Schule*:
+Wenn wir die Samplerate ändern, dann können wir die Stilrichtungen 
+wechseln. Versuche es mal mit halber Samplerate für *Hip-Hop der alten 
+Schule*:
 
 ```
 sample :loop_amen, rate: 0.5
@@ -44,29 +69,61 @@ Wenn wir es beschleunigen, dann betreten wir das *Jungle*-Territorium:
 sample :loop_amen, rate: 1.5
 ```
 
-Und als letzten Trick - sehen wir mal, was passiert, wenn wir eine negative Rate angeben:
+Und als letzten Trick - sehen wir mal, was passiert, wenn wir eine 
+negative Rate angeben:
 
 ```
 sample :loop_amen, rate: -1
 ```
 
-Geil! Er wird *rückwärts* gespielt! Jetzt probier herum mit vielen unterschiedlichen Samples und unterschiedlichen Sampleraten. Versuch's mit sehr hohen oder mit verrückt langsamen. Finde heraus, welche spannenden Klänge du damit produzieren kannst.
+Geil! Er wird *rückwärts* gespielt! Jetzt probier herum mit vielen 
+unterschiedlichen Samples und unterschiedlichen Sampleraten. Versuch's 
+mit sehr hohen oder mit verrückt langsamen. Finde heraus, welche 
+spannenden Klänge du damit produzieren kannst.
 
 ## Eine einfache Erklärung der Samplerate
 
-Man kann sich Samples gut als Sprungfedern vorstellen. Wenn man die Samplerate verändert, ist das so, als ob man die Feder zusammendrückt oder auseinanderzieht. Wenn du ein Sample mit der doppelten Samplerate abspielst, dann drückst du die Feder zusammen, bis sie nur noch die Hälfte ihrer normalen Länge hat. Das Sample braucht also auch nur die Hälfte der Abspielzeit. Wenn du das Sample mit halber Samplerate spielst, dann ziehst du die Feder auf ihre doppelte Länge auseinander. Das Sample dauert also nun doppelt so lange. Je mehr du zusammendrückst (höhere Rate), desto kürzer das Sample, je mehr du auseinanderziehst (geringere Rate), desto länger dauert das Sample.
+Man kann sich Samples gut als Sprungfedern vorstellen. Wenn man die 
+Samplerate verändert, ist das so, als ob man die Feder zusammendrückt 
+oder auseinanderzieht. Wenn du ein Sample mit der doppelten Samplerate 
+abspielst, dann drückst du die Feder zusammen, bis sie nur noch die 
+Hälfte ihrer normalen Länge hat. Das Sample braucht also auch nur die 
+Hälfte der Abspielzeit. Wenn du das Sample mit halber Samplerate 
+spielst, dann ziehst du die Feder auf ihre doppelte Länge auseinander. 
+Das Sample dauert also nun doppelt so lange. Je mehr du zusammendrückst 
+(höhere Rate), desto kürzer das Sample, je mehr du auseinanderziehst 
+(geringere Rate), desto länger dauert das Sample.
 
-Wenn man eine Feder zusammendrückt, dann erhöht man ihre Dichtheit (die Anzahl der Windungen je Zentimeter) - das ist so ähnlich wie bei einem Sample, der *höher klingt*. Wenn man die Feder auseinanderzieht, dann verringert sich ihre Dichtheit, vergleichbar einem Klang, der tiefer klingt.
+Wenn man eine Feder zusammendrückt, dann erhöht man ihre Dichtheit (die 
+Anzahl der Windungen je Zentimeter) - das ist so ähnlich wie bei einem 
+Sample, der *höher klingt*. Wenn man die Feder auseinanderzieht, dann 
+verringert sich ihre Dichtheit, vergleichbar einem Klang, der tiefer 
+klingt.
 
 ## Die Mathematik hinter der Samplerate
 
-(Dieser Abschnitt ist für diejenigen, die Genaueres wissen möchten. Wenn nicht, könnt ihr den gerne überspringen...)
+(Dieser Abschnitt ist für diejenigen, die Genaueres wissen möchten. 
+Wenn nicht, könnt ihr den gerne überspringen...)
 
-Wie wir oben gesehen haben, wird ein Sample durch eine lange Liste von Zahlen dargestellt, die der Lautsprechermebran sagen, wo sie zu welchem Zeitpunkt sein soll. Wir können diese Zahlenliste nehmen und eine Kurve zeichnen, die ungefähr so aussieht:
+Wie wir oben gesehen haben, wird ein Sample durch eine lange Liste von 
+Zahlen dargestellt, die der Lautsprechermebran sagen, wo sie zu welchem 
+Zeitpunkt sein soll. Wir können diese Zahlenliste nehmen und eine Kurve 
+zeichnen, die ungefähr so aussieht:
 
 ![sample graph](:/images/tutorial/sample.png)
 
-Vielleicht hast du Bilder wie dieses schon einmal gesehen. Das ist die *Kurvenform* eines Sample. Es ist bloß eine Kurve, die aus Zahlen gebildet ist. Typischerweise wird eine solche Kurve aus 44100 Datenpunkten je Sekunde gebildet (das hat mit dem Nyquist-Shannon-Abtasttheorem zu tun). Wenn also das Sample 2 Sekunden dauert, dann wird die Kurve aus 88200 Zahlen gebildet, die wir an den Lautsprecher mit einer Datenrate von 44100 Datenpunkten pro Sekunde senden. Natürlich könnten wir es mit der doppelten Datenrate senden, also 88200 Datenpunkten pro Sekunde. Dann würde das Sample nur eine Sekunde lang dauern. Wir können es auch mit der halben Datenrate abspielen; das wären dann 22050 Datenpunkte pro Sekunde und würde 4 Sekunden dauern.
+Vielleicht hast du Bilder wie dieses schon einmal gesehen. Das ist die 
+*Kurvenform* eines Sample. Es ist bloß eine Kurve, die aus Zahlen 
+gebildet ist. Typischerweise wird eine solche Kurve aus 44100 
+Datenpunkten je Sekunde gebildet (das hat mit dem 
+Nyquist-Shannon-Abtasttheorem zu tun). Wenn also das Sample 2 Sekunden 
+dauert, dann wird die Kurve aus 88200 Zahlen gebildet, die wir an den 
+Lautsprecher mit einer Datenrate von 44100 Datenpunkten pro Sekunde 
+senden. Natürlich könnten wir es mit der doppelten Datenrate senden, 
+also 88200 Datenpunkten pro Sekunde. Dann würde das Sample nur eine 
+Sekunde lang dauern. Wir können es auch mit der halben Datenrate 
+abspielen; das wären dann 22050 Datenpunkte pro Sekunde und würde 4 
+Sekunden dauern.
 
 Die Dauer des Sample ist also abhängig von der Datenrate:
 
@@ -81,10 +138,27 @@ Wir können das in einer Formel zusammenfassen:
 neue_sample_dauer = (1 / rate) * sample_dauer
 ```
 
-Wenn du die Samplerate veränderst, beeinflusst das auch die Tonhöhen des Sample. Die Frequenz oder Tonhöhe einer Kurve wird dadurch bestimmt, wie schnell sie hoch und runter geht. Unsere Gehirne machen aus schnellen Bewegungen einer Lautsprechermembran hohe Töne und aus langsamen tiefe. Deshalb kannst du manchmal sogar sehen, wie sich ein großer Basslautsprecher bewegt, wenn ein sehr tiefer Ton rauskommt. Er bewegt sich dann wesentlich langsamer, als ein Lautsprecher, der hohe Töne wiedergibt.
+Wenn du die Samplerate veränderst, beeinflusst das auch die Tonhöhen 
+des Sample. Die Frequenz oder Tonhöhe einer Kurve wird dadurch 
+bestimmt, wie schnell sie hoch und runter geht. Unsere Gehirne machen 
+aus schnellen Bewegungen einer Lautsprechermembran hohe Töne und aus 
+langsamen tiefe. Deshalb kannst du manchmal sogar sehen, wie sich ein 
+großer Basslautsprecher bewegt, wenn ein sehr tiefer Ton rauskommt. Er 
+bewegt sich dann wesentlich langsamer, als ein Lautsprecher, der hohe 
+Töne wiedergibt.
 
-Wenn du eine Kurve nimmst und sie zusammendrückst, dann wird sie je Sekunde öfter hoch und runter gehen als vorher. Ihr Ton wird dann auch höher sein. (Wenn man die Auf- und Abbewegungen je Sekunde verdoppelt (Oszillationen), dann wird die Frequenz, die Tonhöhe, verdoppelt. Also, *wenn du dein Sample mit doppelter Samplerate abspielst, dann wird er auch doppelt so hoch klingen*; andererseits: *eine Halbierung der Samplerate wird auch die Frequenz halbieren*. Andere Sampleraten werden dementsprechend die Tonhöhe beinflussen.
+Wenn du eine Kurve nimmst und sie zusammendrückst, dann wird sie je 
+Sekunde öfter hoch und runter gehen als vorher. Ihr Ton wird dann auch 
+höher sein. (Wenn man die Auf- und Abbewegungen je Sekunde verdoppelt 
+(Oszillationen), dann wird die Frequenz, die Tonhöhe, verdoppelt. Also, 
+*wenn du dein Sample mit doppelter Samplerate abspielst, dann wird er 
+auch doppelt so hoch klingen*; andererseits: *eine Halbierung der 
+Samplerate wird auch die Frequenz halbieren*. Andere Sampleraten werden 
+dementsprechend die Tonhöhe beinflussen.
 
-[^1]: Die Samplerate heißt auch Samplingrate oder Abtastrate; *rate* steht für die Frequenz, mit der Sonic Pi die Zahlen, die im Sample den Klang darstellen, an die Lautsprechermembran sendet.
+[^1]: Die Samplerate heißt auch Samplingrate oder Abtastrate; *rate* 
+steht für die Frequenz, mit der Sonic Pi die Zahlen, die im Sample den 
+Klang darstellen, an die Lautsprechermembran sendet.
 
-[^2]: *Argument* ist ein anderer Begriff für *Parameter*; an dieser Stelle bedeutet beide Begriffe dasselbe.
+[^2]: *Argument* ist ein anderer Begriff für *Parameter*; an dieser 
+Stelle bedeutet beide Begriffe dasselbe.

--- a/etc/doc/tutorial/de/03.4-Enveloped-Samples.md
+++ b/etc/doc/tutorial/de/03.4-Enveloped-Samples.md
@@ -2,7 +2,15 @@
 
 # Enveloped Samples
 
-Es ist auch möglich, die *Dauer* und *Amplitude* eines Sample mit einer ADSR-Hüllkurve zu verändern. Das funktioniert jedoch ein wenig anders als die ADSR-Hüllkurven bei den Synths. Sample-Hüllkurven erlauben dir nur die Amplitude und die Dauer eines Sample zu verringern - niemals zu vergrößern. Das Sample wird stoppen, entweder wenn seine normale Laufzeit zuende ist, oder wenn die Hüllkurve das Sample begrenzt - je nachdem welche kürzer ist. Wenn du also einen sehr langen `release` verwendest, wird das Sample nicht über seine normale Laufzeit hinaus verlängert werden.
+Es ist auch möglich, die *Dauer* und *Amplitude* eines Sample mit einer 
+ADSR-Hüllkurve zu verändern. Das funktioniert jedoch ein wenig anders 
+als die ADSR-Hüllkurven bei den Synths. Sample-Hüllkurven erlauben dir 
+nur die Amplitude und die Dauer eines Sample zu verringern - niemals zu 
+vergrößern. Das Sample wird stoppen, entweder wenn seine normale 
+Laufzeit zuende ist, oder wenn die Hüllkurve das Sample begrenzt - je 
+nachdem welche kürzer ist. Wenn du also einen sehr langen `release` 
+verwendest, wird das Sample nicht über seine normale Laufzeit hinaus 
+verlängert werden.
 
 ## Amen-Hüllkuven
 
@@ -12,7 +20,9 @@ Kommen wir zu unserem treuen Freund dem Amen Break zurück:
 sample :loop_amen
 ```
 
-Ohne Parameter hören wir das Sample in seiner gesamten Länge und mit voller Lautstärke. Wenn wir möchten, dass das Sample eingeblendet wird, dann können wir den `attack`-Parameter benutzen.
+Ohne Parameter hören wir das Sample in seiner gesamten Länge und mit 
+voller Lautstärke. Wenn wir möchten, dass das Sample eingeblendet wird, 
+dann können wir den `attack`-Parameter benutzen.
 
 ```
 sample :loop_amen, attack: 1
@@ -26,67 +36,101 @@ sample :loop_amen, attack: 0.3
 
 ## Auto-Sustain
 
-Beim *Sustain*-Wert unterscheidet sich das Verhalten einer ADSR-Hüllkuve. Bei der Hüllkurve für Standard-Synths steht der Sustain normalerweise auf 0 - außer du setzt den Wert ausdrücklich. Bei Samples wird der Sustain-Wert auf einen *automagical* Wert gesetzt - nämlich die Zeit, die es braucht, bis das gesamte Sample abgelaufen ist. Darum hören wir das Sample komplett, wenn wir keine Default-Werte übergeben. Wenn die Werte für Attack, Decay, Sustain und Release alle 0 wären, würden wir keinen Pieps hören. Deshalb kalkuliert Sonic Pi zunächst, wie lange das Sample von sich aus dauert, zieht etwaige Dauern für Attack, Decay und Release davon ab und setzt die restliche Zeit als Sustain-Wert. Wenn die Werte von Attack, Decay und Release zusammengenommen länger dauern als das gesamte Sample, wird der Sustain-Wert einfach auf 0 gesetzt.
+Beim *Sustain*-Wert unterscheidet sich das Verhalten einer 
+ADSR-Hüllkuve. Bei der Hüllkurve für Standard-Synths steht der Sustain 
+normalerweise auf 0 - außer du setzt den Wert ausdrücklich. Bei Samples 
+wird der Sustain-Wert auf einen *automagical* Wert gesetzt - nämlich 
+die Zeit, die es braucht, bis das gesamte Sample abgelaufen ist. Darum 
+hören wir das Sample komplett, wenn wir keine Default-Werte übergeben. 
+Wenn die Werte für Attack, Decay, Sustain und Release alle 0 wären, 
+würden wir keinen Pieps hören. Deshalb kalkuliert Sonic Pi zunächst, 
+wie lange das Sample von sich aus dauert, zieht etwaige Dauern für 
+Attack, Decay und Release davon ab und setzt die restliche Zeit als 
+Sustain-Wert. Wenn die Werte von Attack, Decay und Release 
+zusammengenommen länger dauern als das gesamte Sample, wird der 
+Sustain-Wert einfach auf 0 gesetzt.
 
 ## Ausblenden
 
-Um das auszuprobieren, schauen wir uns den Amen Break genauer an. Wir fragen Sonic Pi, wie lang das Sample ist:
+Um das auszuprobieren, schauen wir uns den Amen Break genauer an. Wir 
+fragen Sonic Pi, wie lang das Sample ist:
 
 ```
 print sample_duration :loop_amen
 ```
 
-Es wird `1.753310657596372` ausgeben; das ist die Länge des Sample in Sekunden. Wir runden das einmal bequemerweise auf `1.75` ab. Wenn wir nun den Release-Wert auf `0.75` setzen, wird etwas erstaunliches passieren:
+Es wird `1.753310657596372` ausgeben; das ist die Länge des Sample in 
+Sekunden. Wir runden das einmal bequemerweise auf `1.75` ab. Wenn wir 
+nun den Release-Wert auf `0.75` setzen, wird etwas erstaunliches 
+passieren:
 
 ```
 sample :loop_amen, release: 0.75
 ```
 
-Die erste Sekunde des Sample wird mit voller Lautstärke gespielt, danach wird über eine Periode von 0.75 Sekunden ausgeblendet. Das ist der *autosustain* in Aktion. Standardmäßig wird der Release immer vom Ende des Sample aus berechnet. Wenn unser Sample 10.75 Sekunde lang wäre, würden die ersten 10 Sekunden in voller Lautstärke gespielt bevor dann eine Ausblende über 0.75 Sekunden erfolgt.
+Die erste Sekunde des Sample wird mit voller Lautstärke gespielt, 
+danach wird über eine Periode von 0.75 Sekunden ausgeblendet. Das ist 
+der *autosustain* in Aktion. Standardmäßig wird der Release immer vom 
+Ende des Sample aus berechnet. Wenn unser Sample 10.75 Sekunde lang 
+wäre, würden die ersten 10 Sekunden in voller Lautstärke gespielt bevor 
+dann eine Ausblende über 0.75 Sekunden erfolgt.
 
-Zur Erinnerung: Standardmäßig blendet der `release* am Ende des Sample aus.
+Zur Erinnerung: Standardmäßig blendet der `release:` am Ende des Sample 
+aus.
 
 ## Ein- und Ausblenden
 
-Wir können `attack:` und `release:` zusammen mit Auto-Sustain nutzen, um über die Laufzeit des Sample ein- und auszublenden:
+Wir können `attack:` und `release:` zusammen mit Auto-Sustain nutzen, 
+um über die Laufzeit des Sample ein- und auszublenden:
 
 ```
 sample :loop_amen, attack: 0.75, release: 0.75
 ```
 
-Da die Gesamtdauer des Sample 1.75s beträgt und unsere Attack- und Release-Phasen zusammen 1.5s ergeben, wird der Sustain automatisch auf 0.25s gesetzt.
+Da die Gesamtdauer des Sample 1.75s beträgt und unsere Attack- und 
+Release-Phasen zusammen 1.5s ergeben, wird der Sustain automatisch auf 
+0.25s gesetzt.
 
 ## Ausdrücklich angegebener Sustain
 
-Wir können ohne weiteres das normales Synth-ADSR-Verhalten aktivieren, indem wir dem `sustain` den Wert 0 geben:
+Wir können ohne weiteres das normales Synth-ADSR-Verhalten aktivieren, 
+indem wir dem `sustain` den Wert 0 geben:
 
 ```
 sample :loop_amen, sustain: 0, release: 0.75
 ```
 
-Jetzt spielt unser Sample insgesamt nur 0.75 Sekunden. Mit dem Standardwert 0 für `attack:` und `decay:` springt der Sample direkt auf die volle Lautstärke, bleibt dort für 0s und fällt dann innerhalb der Release-Phase mit einer Dauer von 0.75s auf den Lautstärkenwert 0 ab.
+Jetzt spielt unser Sample insgesamt nur 0.75 Sekunden. Mit dem 
+Standardwert 0 für `attack:` und `decay:` springt der Sample direkt auf 
+die volle Lautstärke, bleibt dort für 0s und fällt dann innerhalb der 
+Release-Phase mit einer Dauer von 0.75s auf den Lautstärkenwert 0 ab.
 
 ## Perkussive Becken
 
-Wir können dieses Verhalten gut dazu benutzen, um länger klingende Samples in kürzere, perkussivere Versionen zu verwandeln. Sieh dir den Sample `:drum_cymbal_open` an:
+Wir können dieses Verhalten gut dazu benutzen, um länger klingende 
+Samples in kürzere, perkussivere Versionen zu verwandeln. Sieh dir den 
+Sample `:drum_cymbal_open` an:
 
 ```
 sample :drum_cymbal_open
 ```
 
-Man kann hören, wie das Becken eine zeitlang ausklingt. Wir können aber unsere Hüllkurve so einsetzen, dass es perkussiver klingt:
+Man kann hören, wie das Becken eine zeitlang ausklingt. Wir können aber 
+unsere Hüllkurve so einsetzen, dass es perkussiver klingt:
 
 ```
 sample :drum_cymbal_open, attack: 0.01, sustain: 0, release: 0.1
 ```
 
-Indem du die Sustain-Dauer verlängerst, kannst du es so klingen lassen, als ob das Becken erst angeschlagen und dann abgedämpft würde:
+Indem du die Sustain-Dauer verlängerst, kannst du es so klingen lassen, 
+als ob das Becken erst angeschlagen und dann abgedämpft würde:
 
 ```
 sample :drum_cymbal_open, attack: 0.01, sustain: 0.3, release: 0.1
 ```
 
-Jetzt versuch' einmal, Hüllkuven über Samples zu legen. Verändere auch die Samplerate; damit kannst du sehr interessante Ergebnisse erzeugen.
+Jetzt versuch' einmal, Hüllkuven über Samples zu legen. Verändere auch 
+die Samplerate; damit kannst du sehr interessante Ergebnisse erzeugen.
 
 
 

--- a/etc/doc/tutorial/de/03.5-Partial-Samples.md
+++ b/etc/doc/tutorial/de/03.5-Partial-Samples.md
@@ -2,35 +2,48 @@
 
 # Teil-Samples
 
-Dieses Kapitel schließt unsere Erkundung von Sonic Pi's Sample-Player ab. Fassen wir noch einmal zusammen. Wir haben uns angesehen, wie wir Samples ansteuern können:
+Dieses Kapitel schließt unsere Erkundung von Sonic Pi's Sample-Player 
+ab. Fassen wir noch einmal zusammen. Wir haben uns angesehen, wie wir 
+Samples ansteuern können:
 
 ```
 sample :loop_amen
 ```
 
-Dann haben wir gesehen, dass wir die Samplerate ändern können - etwa um ein Sample mit halber Geschwindigkeit abzuspielen:
+Dann haben wir gesehen, dass wir die Samplerate ändern können - etwa um 
+ein Sample mit halber Geschwindigkeit abzuspielen:
 
 ```
 sample :loop_amen, rate: 0.5
 ```
 
-Als nächstes haben wir einen Blick darauf geworfen, wie wir ein Sample blenden können (lasst uns das hier mit halber Geschwindigkeit machen):
+Als nächstes haben wir einen Blick darauf geworfen, wie wir ein Sample 
+blenden können (lasst uns das hier mit halber Geschwindigkeit machen):
 
 ```
 sample :loop_amen, rate: 0.5, attack: 1
 ```
 
-Wir haben uns auch angeschaut, wie wir ein Sample am Anfang perkussiver klingen lassen können, indem wir `sustain:` ausdrücklich einen Wert zuweisen, und sowohl der Attack als auch der Release kurze Werte bekommt:
+Wir haben uns auch angeschaut, wie wir ein Sample am Anfang perkussiver 
+klingen lassen können, indem wir `sustain:` ausdrücklich einen Wert 
+zuweisen, und sowohl der Attack als auch der Release kurze Werte 
+bekommt:
 
 ```
 sample :loop_amen, rate: 2, attack: 0.01, sustain: 0, release: 0.35
 ```
 
-Wäre es aber nicht toll, wenn wir ein Sample nicht immer vom Anfang starten lassen müssten? Wäre es nicht auch prima, wenn das Ende des klingenden Sample nicht immer seinem wirklichen Ende entsprechen müsste?
+Wäre es aber nicht toll, wenn wir ein Sample nicht immer vom Anfang 
+starten lassen müssten? Wäre es nicht auch prima, wenn das Ende des 
+klingenden Sample nicht immer seinem wirklichen Ende entsprechen 
+müsste?
 
 ## Einen Startpunkt bestimmen
 
-Es ist möglich, einen beliebigen Startpunkt eines Sample als Wert zwischen 0 und auszuwählen, wobei 0 der Anfang, 1 das Ende und 0.5 die Mitte des Samples darstellt. Spielen wir die zweite Hälfte des Amen Break:
+Es ist möglich, einen beliebigen Startpunkt eines Sample als Wert 
+zwischen 0 und auszuwählen, wobei 0 der Anfang, 1 das Ende und 0.5 die 
+Mitte des Samples darstellt. Spielen wir die zweite Hälfte des Amen 
+Break:
 
 ```
 sample :loop_amen, start: 0.5
@@ -44,7 +57,9 @@ sample :loop_amen, start: 0.75
 
 ## Einen Endpunkt bestimmen
 
-Gleichermaßen können wir über einen Wert zwischen 0 und 1 einen beliebigen Endpunkt im Sample festlegen. Beenden wir den Amen Break nach der ersten Hälfte:
+Gleichermaßen können wir über einen Wert zwischen 0 und 1 einen 
+beliebigen Endpunkt im Sample festlegen. Beenden wir den Amen Break 
+nach der ersten Hälfte:
 
 ```
 sample :loop_amen, finish: 0.5
@@ -52,13 +67,16 @@ sample :loop_amen, finish: 0.5
 
 ## Start- und Endpunkt bestimmen
 
-Natürlich können das auch kombinieren, um einen beliebigen Abschnitt des Sample zu spielen. Wie wäre es mit einem kurzen Abschnitt aus der Mitte:
+Natürlich können das auch kombinieren, um einen beliebigen Abschnitt 
+des Sample zu spielen. Wie wäre es mit einem kurzen Abschnitt aus der 
+Mitte:
 
 ```
 sample :loop_amen, start: 0.4, finish: 0.6
 ```
 
-Was passiert, wenn wir eine Startposition nach der Endposition auswählen?
+Was passiert, wenn wir eine Startposition nach der Endposition 
+auswählen?
 
 ```
 sample :loop_amen, start: 0.6, finish: 0.4
@@ -68,7 +86,9 @@ Cool! Dann spielt es rückwärts!
 
 ## In Kombination mit der Samplerate
 
-Wir können diese neue Fähigkeit, beliebige Abschnitte eines Klangs zu spielen, mit unserem Freund `rate:` kombinieren. Zum Beispiel können wir einen sehr kurzen Abschnitt des Amen Break sehr langsam spielen:
+Wir können diese neue Fähigkeit, beliebige Abschnitte eines Klangs zu 
+spielen, mit unserem Freund `rate:` kombinieren. Zum Beispiel können 
+wir einen sehr kurzen Abschnitt des Amen Break sehr langsam spielen:
 
 ```
 sample :loop_amen, start: 0.5, finish: 0.7, rate: 0.2
@@ -76,7 +96,8 @@ sample :loop_amen, start: 0.5, finish: 0.7, rate: 0.2
 
 ## In Kombination mit Hüllkurven
 
-Schließlich können wir all dies mit unseren ADSR-Hüllkurven kombinieren und interessante Ergebnisse damit erzielen:
+Schließlich können wir all dies mit unseren ADSR-Hüllkurven kombinieren 
+und interessante Ergebnisse damit erzielen:
 
 ```
 sample :loop_amen, start: 0.5, finish: 0.8, rate: -0.2, attack: 0.3, release: 1

--- a/etc/doc/tutorial/de/03.6-External-Samples.md
+++ b/etc/doc/tutorial/de/03.6-External-Samples.md
@@ -2,17 +2,31 @@
 
 # Samples aus externen Quellen
 
-Während die mitgelieferten Samples dir die Möglichkeit bieten schnell einzusteigen, möchtest du vielleicht mit neuen aufgenommenen Klängen in deiner Musik experimentieren. Sonic Pi unterstützt das ausdrücklich. Lass' uns aber zunächst über die Übertragbarkeit deines Stücks sprechen.
+Während die mitgelieferten Samples dir die Möglichkeit bieten schnell 
+einzusteigen, möchtest du vielleicht mit neuen aufgenommenen Klängen in 
+deiner Musik experimentieren. Sonic Pi unterstützt das ausdrücklich. 
+Lass' uns aber zunächst über die Übertragbarkeit deines Stücks 
+sprechen.
 
 ## Übertragbarkeit
 
-Wenn du dein Stück nur mithilfe der eingebauten Synths und Samples komponierst, dann ist der Code alles, was man braucht, um deine Musik so, wie du sie  geschrieben hast, wieder abzuspielen. Denk' darüber einen Augenblick nach - das ist erstaunlich! Ein bisschen Text, den du per Email verschicken oder auf [Gist](https://gist.github.com) ablegen kannst, reicht vollkommen aus, um deine Klänge wieder abzuspielen. So wird es sehr einfach, deine Kompositionen mit deinen Freunden zu teilen, da sie nur den Code brauchen.
+Wenn du dein Stück nur mithilfe der eingebauten Synths und Samples 
+komponierst, dann ist der Code alles, was man braucht, um deine Musik 
+so, wie du sie  geschrieben hast, wieder abzuspielen. Denk' darüber 
+einen Augenblick nach - das ist erstaunlich! Ein bisschen Text, den du 
+per Email verschicken oder auf [Gist](https://gist.github.com) ablegen 
+kannst, reicht vollkommen aus, um deine Klänge wieder abzuspielen. So 
+wird es sehr einfach, deine Kompositionen mit deinen Freunden zu 
+teilen, da sie nur den Code brauchen.
 
-Wenn du nun selbst aufgenommene Samples verwendest, dann verlierst du diese Übertragbarkeit. Und zwar deshalb, weil man nicht nur den Code braucht, sondern auch deine Samples, um dein Stück auf einem anderen Rechner zu spielen.
+Wenn du nun selbst aufgenommene Samples verwendest, dann verlierst du 
+diese Übertragbarkeit. Und zwar deshalb, weil man nicht nur den Code 
+braucht, sondern auch deine Samples, um dein Stück auf einem anderen 
+Rechner zu spielen.
 
 <!-- ## Unterstützung von Freesound -->
 
-<!-- Ein Möglichkeit, um mit neuen Sounds zu experimentieren und gleichzeitig die Übertragbarkeit des Codes sicherzustellen, ist es, mit Sonic Pi's  [Freesound](http:freesound.org)-Unterstützung zu arbeiten. http:freesound.org ist eine Website, auf der man Samples hochladen und mit anderen teilen kann. Jedes Sample, welches dort gespeichert wird, erhält eine spezielle Nummer (so ähnlich wie eine Telefonnummer), die du benutzen kannst, um von Sonic Pi aus, Samples einzubauen. Der Nachteil ist, dass man einen Internetzugang braucht, damit es funktioniert. -->
+<!-- Eine Möglichkeit, um mit neuen Sounds zu experimentieren und gleichzeitig die Übertragbarkeit des Codes sicherzustellen, ist es, mit Sonic Pi's  [Freesound](http:freesound.org)-Unterstützung zu arbeiten. http:freesound.org ist eine Website, auf der man Samples hochladen und mit anderen teilen kann. Jedes Sample, welches dort gespeichert wird, erhält eine spezielle Nummer (so ähnlich wie eine Telefonnummer), die du benutzen kannst, um von Sonic Pi aus, Samples einzubauen. Der Nachteil ist, dass man einen Internetzugang braucht, damit es funktioniert. -->
 
 <!-- Wenn du gerade Internetzugang hast, dann probier' es aus: -->
 
@@ -24,13 +38,17 @@ Wenn du nun selbst aufgenommene Samples verwendest, dann verlierst du diese Übe
 
 ## Lokale Samples
 
-Wie geht das nun, eine beliebige WAV- oder AIFF-Datei auf deinem Computer zu spielen? Dafür musst du dem Ausdruck `sample` nur den Pfad der Datei übergeben:
+Wie geht das nun, eine beliebige WAV- oder AIFF-Datei auf deinem 
+Computer zu spielen? Dafür musst du dem Ausdruck `sample` nur den Pfad 
+der Datei übergeben:
 
 ```
 sample "/Users/sam/Desktop/my-sound.wav"
 ```
 
-Sonic Pi wird den Sample nun automatisch laden und spielen. Du kannst auch all die anderen Standard-Parameter, die du schon kennengelernt hast, dem `sample` übergeben:
+Sonic Pi wird den Sample nun automatisch laden und spielen. Du kannst 
+auch all die anderen Standard-Parameter, die du schon kennengelernt 
+hast, dem `sample` übergeben:
 
 ```
 sample "/Users/sam/Desktop/my-sound.wav", rate: 0.5, amp: 0.3

--- a/etc/doc/tutorial/de/04-Randomisation.md
+++ b/etc/doc/tutorial/de/04-Randomisation.md
@@ -2,21 +2,41 @@
 
 # Randomisierung[^1]
 
-Zufallszahlen sind eine tolle Möglichkeit, deine Musik interessant zu gestalten. Sonic Pi bietet einige Funktionen, um Zufallsfaktoren in deine Musik einzubauen;  aber bevor wir starten, müssen wir noch einer schockierenden Wahrheit ins Gesicht sehen: In Sonic Pi bedeutet *zufällig nicht wirklich zufällig*. Was zum Teufel soll das bedeuten? Naja, sehen wir mal.
+Zufallszahlen sind eine tolle Möglichkeit, deine Musik interessant zu 
+gestalten. Sonic Pi bietet einige Funktionen, um Zufallsfaktoren in 
+deine Musik einzubauen;  aber bevor wir starten, müssen wir noch einer 
+schockierenden Wahrheit ins Gesicht sehen: In Sonic Pi bedeutet 
+*zufällig nicht wirklich zufällig*. Was zum Teufel soll das bedeuten? 
+Naja, sehen wir mal.
 
 ## Wiederholbarkeit
 
-Eine wirklich nützliche Zufallsfunktion ist `rrand`; sie liefert dir einen zufälligen Wert zwischen zwei Zahlen - einem *Minimal-* und einem *Maximalwert*. (`rrand` ist ein Kürzel für das Englische *ranged random*, also eine Zufallszahl innerhalb eines bestimmten Wertebereichs).
+Eine wirklich nützliche Zufallsfunktion ist `rrand`; sie liefert dir 
+einen zufälligen Wert zwischen zwei Zahlen - einem *Minimal-* und einem 
+*Maximalwert*. (`rrand` ist ein Kürzel für das Englische *ranged 
+random*, also eine Zufallszahl innerhalb eines bestimmten 
+Wertebereichs).
 
 ```
 play rrand(50, 100)
 ```
 
-Oh, eine zufällige Note wird gespielt. Es war die Note `77.4407`. Eine nette Note zwischen 50 und 100. Aber hallo, habe ich gerade diese angeblich zufällige Note  exakt vorhergesagt? Da ist doch etwas nicht ganz astrein. Lass' den Code noch einmal ablaufen. Wieder `77.4407`, oder? Das kann doch kein Zufall sein!
+Oh, eine zufällige Note wird gespielt. Es war die Note `77.4407`. Eine 
+nette Note zwischen 50 und 100. Aber hallo, habe ich gerade diese 
+angeblich zufällige Note  exakt vorhergesagt? Da ist doch etwas nicht 
+ganz astrein. Lass' den Code noch einmal ablaufen. Wieder `77.4407`, 
+oder? Das kann doch kein Zufall sein!
 
-Die Antwort ist, es ist nicht wirklich zufällig, sondern pseudo-zufällig. Sonic Pi liefert dir Reihenfolgen von Zufallszahlen, die wiederholbar sind. Das ist sehr nützlich, weil es sicherstellt, dass die Musik, die du auf deinem Rechner erzeugst, auf anderen Rechnern identisch klingt - sogar, wenn du einen Zufallsfaktor einbaust.
+Die Antwort ist, es ist nicht wirklich zufällig, sondern 
+pseudo-zufällig. Sonic Pi liefert dir Reihenfolgen von Zufallszahlen, 
+die wiederholbar sind. Das ist sehr nützlich, weil es sicherstellt, 
+dass die Musik, die du auf deinem Rechner erzeugst, auf anderen 
+Rechnern identisch klingt - sogar, wenn du einen Zufallsfaktor 
+einbaust.
 
-Klar, wenn in einem bestimmten Musikstück jedesmal die `77.4407` als 'zufällige' Zahl gewählt würde, dann wäre das nicht besonders interessant. Aber so ist es auch nicht. Versuch' folgendes:
+Klar, wenn in einem bestimmten Musikstück jedesmal die `77.4407` als 
+'zufällige' Zahl gewählt würde, dann wäre das nicht besonders 
+interessant. Aber so ist es auch nicht. Versuch' folgendes:
 
 ```
 loop do
@@ -25,11 +45,20 @@ loop do
 end 
 ```
 
-Jawohl! Nun klingt es zufällig. Innerhalb eines bestimmten Code-Durchgangs liefern Aufrufe von Zufallsfunktionen auch zufällige Werte. Der nächste Durchgang wird jedoch genau dieselbe Folge von Zufallswerten liefern und also auch genau gleich klingen. Es ist, als ob der Sonic Pi-Code immer zu demselben Zeitpunkt zurückspringt, wenn der Ausführen-Button geklickt wird. Es ist der Groundhog-Day[^2] der musikalischen Synthese.
+Jawohl! Nun klingt es zufällig. Innerhalb eines bestimmten 
+Code-Durchgangs liefern Aufrufe von Zufallsfunktionen auch zufällige 
+Werte. Der nächste Durchgang wird jedoch genau dieselbe Folge von 
+Zufallswerten liefern und also auch genau gleich klingen. Es ist, als 
+ob der Sonic Pi-Code immer zu demselben Zeitpunkt zurückspringt, wenn 
+der Ausführen-Button geklickt wird. Es ist der Groundhog-Day[^2] der 
+musikalischen Synthese.
 
 ## Ruhelose Glocken
 
-Eine großartige Illustration von Zufall in Aktion bieten das Beispiel der  ruhelosen Glocken, bei dem das Sample `:perc_bell` mit einer zufälligen Samplerate und Pausenzeit in einer Schleife[^3] abgespielt wird.
+Eine großartige Illustration von Zufall in Aktion bieten das Beispiel 
+der  ruhelosen Glocken, bei dem das Sample `:perc_bell` mit einer 
+zufälligen Samplerate und Pausenzeit in einer Schleife[^3] abgespielt 
+wird.
 
 ```
 loop do
@@ -40,7 +69,9 @@ end
 
 ## Zufällig abschneiden (random cutoff)
 
-Ein anderes spannendes Beispiel für die Randomisierung ist das zufällige Abschneiden[^4] eines Synth-Klangs. Der `:tb303`-Emulator ist ein guter Synth, um das auszuprobieren:
+Ein anderes spannendes Beispiel für die Randomisierung ist das 
+zufällige Abschneiden[^4] eines Synth-Klangs. Der `:tb303`-Emulator ist 
+ein guter Synth, um das auszuprobieren:
 
 ```
 use_synth :tb303
@@ -54,7 +85,11 @@ loop do
 
 ## Startpunkt der Zufallsfolge (random seed)
 
-Was aber, wenn du die Abfolge von Zufallszahlen, die Sonic Pi dir liefert, nicht magst? Nun, mit `use_random_seed`[^5] kannst du unterschiedliche Startpunkte für diese Folge angeben. Der Standard-Startpunkt ist die 0. Also wähle einfach einen anderen Startpunkt und mach' eine andere Zufallserfahrung!
+Was aber, wenn du die Abfolge von Zufallszahlen, die Sonic Pi dir 
+liefert, nicht magst? Nun, mit `use_random_seed`[^5] kannst du 
+unterschiedliche Startpunkte für diese Folge angeben. Der 
+Standard-Startpunkt ist die 0. Also wähle einfach einen anderen 
+Startpunkt und mach' eine andere Zufallserfahrung!
 
 Sieh dir den folgenden Code an:
 
@@ -65,7 +100,9 @@ Sieh dir den folgenden Code an:
 end
 ```
 
-Jedesmal, wenn du den Code ablaufen läßt, hörst du dieselbe Folge von 5 Tönen. Um eine andere Folge zu bekommen, setzte einfach einen anderen Startpunkt:
+Jedesmal, wenn du den Code ablaufen läßt, hörst du dieselbe Folge von 5 
+Tönen. Um eine andere Folge zu bekommen, setzte einfach einen anderen 
+Startpunkt:
 
 ```
 use_random_seed 40
@@ -75,13 +112,21 @@ use_random_seed 40
 end
 ```
 
-Nun wird eine andere Folge von 5 Tönen produziert. Indem du den Startpunkt wechselst und dir die Ergebnisse anhörst, kannst du eine Folge finden, die dir gefällt - und wenn du das mit anderen teilst, werden sie genau das hören, was auch du gehört hast.
+Nun wird eine andere Folge von 5 Tönen produziert. Indem du den 
+Startpunkt wechselst und dir die Ergebnisse anhörst, kannst du eine 
+Folge finden, die dir gefällt - und wenn du das mit anderen teilst, 
+werden sie genau das hören, was auch du gehört hast.
 
 Schauen wir uns noch eine andere nützlich Zufallsfunktion an.
 
 ## Auswählen (choose)
 
-Häufig kommt es vor, dass man aus einer Liste von Dingen eines zufällig auswählen möchte. Zum Beispiel möchte ich einen Ton aus der folgenden Liste auswählen: 60, 65 oder 72. Das kannst du mit `choose` erreichen. Zuerst musst du deine Zahlen in eine Liste packen; dafür schreibst du sie jeweils durch Kommata getrennt in eckige Klammern. Dann übergibst du diese Liste `choose`:
+Häufig kommt es vor, dass man aus einer Liste von Dingen eines zufällig 
+auswählen möchte. Zum Beispiel möchte ich einen Ton aus der folgenden 
+Liste auswählen: 60, 65 oder 72. Das kannst du mit `choose` erreichen. 
+Zuerst musst du deine Zahlen in eine Liste packen; dafür schreibst du 
+sie jeweils durch Kommata getrennt in eckige Klammern. Dann übergibst 
+du diese Liste `choose`:
 
 ```
 choose([60, 65, 72])
@@ -98,7 +143,15 @@ end
 
 ## rrand
 
-`rrand` haben wir schon kennengelernt, aber sehen wir uns das noch einmal genauer an. Es liefert eine zufällige Zahl zwischen zwei Werten, aber ohne diese Werte selbst; man sagt auch *exklusiv* dieser beiden Werte. Das bedeutet, dass sowohl der minimale als auch der maximale Wert niemals ausgegeben werden, immer nur eine Zahl *zwischen* diesen beiden Werten. Die Zahl wird immer eine Gleitkommazahl (engl. *float*) sein, also keine ganze Zahl, sondern eine mit einem Komma[^6]. Einige Beispiele für Gleitkommazahlen, die der wiederholte Aufruf von `rrand(20, 110)` ausgeben könnte:
+`rrand` haben wir schon kennengelernt, aber sehen wir uns das noch 
+einmal genauer an. Es liefert eine zufällige Zahl zwischen zwei Werten, 
+aber ohne diese Werte selbst; man sagt auch *exklusiv* dieser beiden 
+Werte. Das bedeutet, dass sowohl der minimale als auch der maximale 
+Wert niemals ausgegeben werden, immer nur eine Zahl *zwischen* diesen 
+beiden Werten. Die Zahl wird immer eine Gleitkommazahl (engl. *float*) 
+sein, also keine ganze Zahl, sondern eine mit einem Komma[^6]. Einige 
+Beispiele für Gleitkommazahlen, die der wiederholte Aufruf von 
+`rrand(20, 110)` ausgeben könnte:
 
 * 20.343235
 * 42.324324
@@ -106,7 +159,13 @@ end
 
 ## rrand_i
 
-Manchmal braucht man eine zufällige aber ganze Zahl, eben keine Gleitkommazahl. Hier rettet einen `rrand_i`[^7]. Es funktioniert so ähnlich `rrand`, kann jedoch auch den minimalen oder maximalen Wert, den man übergeben hat, als mögliche Zufallszahl auswählen (man kann auch sagen: es ist *inklusiv*, also nicht exklusive der Werte, mit denen man den Bereich für die Auswahl festgelegt hat). `rrand_i(20, 110)` könnte zum Beispiel die folgenden Werte ausgeben:
+Manchmal braucht man eine zufällige aber ganze Zahl, eben keine 
+Gleitkommazahl. Hier rettet einen `rrand_i`[^7]. Es funktioniert so 
+ähnlich `rrand`, kann jedoch auch den minimalen oder maximalen Wert, 
+den man übergeben hat, als mögliche Zufallszahl auswählen (man kann 
+auch sagen: es ist *inklusiv*, also nicht exklusive der Werte, mit 
+denen man den Bereich für die Auswahl festgelegt hat). `rrand_i(20, 
+110)` könnte zum Beispiel die folgenden Werte ausgeben:
 
 * 20
 * 46
@@ -114,7 +173,11 @@ Manchmal braucht man eine zufällige aber ganze Zahl, eben keine Gleitkommazahl.
 
 ## rand
 
-`rand` gibt eine zufällige Gleitkommazahl zwischen 0 (inklusiv) und einem  übergebenen Maximalwert (exklusiv) zurück. Standardmäßig - wenn also kein Maximalwert angegeben wird - wird ein Wert zwischen 0 und 1 geliefert. Deshalb kann man `rand` gut dafür gebrauchen, zufällige Werte für `amp:` (also die Lautstärke) auszuwählen.
+`rand` gibt eine zufällige Gleitkommazahl zwischen 0 (inklusiv) und 
+einem  übergebenen Maximalwert (exklusiv) zurück. Standardmäßig - wenn 
+also kein Maximalwert angegeben wird - wird ein Wert zwischen 0 und 1 
+geliefert. Deshalb kann man `rand` gut dafür gebrauchen, zufällige 
+Werte für `amp:` (also die Lautstärke) auszuwählen.
 
 ```
 loop do
@@ -125,28 +188,56 @@ end
 
 ## rand_i
 
-Ähnlich wie bei `rrand_i` und `rrand`, wählt `rand_i` eine ganze Zahl zwischen 0 und einem angegebenen Maximalwert aus.
+Ähnlich wie bei `rrand_i` und `rrand`, wählt `rand_i` eine ganze Zahl 
+zwischen 0 und einem angegebenen Maximalwert aus.
 
 ## dice
 
-Manchmal möchte man so tun, als würde man würfeln (engl. *to dice*) - das ist ein Sonderfall von `rrand_i`, wobei der niedrigste Wert immer die 1 ist. Wenn man `dice` verwendet, muss man dabei immer bestimmen, wieviele Seiten der Würfel hat. Ein normaler Würfel hat 6 Seiten, also wird `dice(6)` entsprechend funktionieren und den Wert 1, 2, 3, 4, 5 oder 6 zurückgeben. Aber - angenommen wir befänden uns in einen Fantasy-Rollenspiel - ist es dir vielleicht lieber, wenn der Würfel 4 oder 12, 20 oder sogar 120 Seiten hat!
+Manchmal möchte man so tun, als würde man würfeln (engl. *to dice*) - 
+das ist ein Sonderfall von `rrand_i`, wobei der niedrigste Wert immer 
+die 1 ist. Wenn man `dice` verwendet, muss man dabei immer bestimmen, 
+wieviele Seiten der Würfel hat. Ein normaler Würfel hat 6 Seiten, also 
+wird `dice(6)` entsprechend funktionieren und den Wert 1, 2, 3, 4, 5 
+oder 6 zurückgeben. Aber - angenommen wir befänden uns in einen 
+Fantasy-Rollenspiel - ist es dir vielleicht lieber, wenn der Würfel 4 
+oder 12, 20 oder sogar 120 Seiten hat!
 
 ## one_in
 
-Schließlich könnte es sein, das du so tun willst, als ob du beim Würfeln eine 6 hast - also den höchten Wert erreichst. `one_in` gibt - mit einer Wahrscheinlichkeit 1 im Verhältnis zur Menge der Würfelseiten - den Wert *wahr* (engl. *true*) zurück, falls die höchste Zahl gewürfelt wurde. `one_in(6)` wird also mit einer Wahrscheinlichkeit von 1 zu 6 wahr, ansonsten *falsch* (engl. *false*). Wahr- und Falsch-Werte sind sehr nützlich, wenn es um `if`-Anweisungen geht, die wir in einem folgenden Kapitel dieses Tutorials besprechen.
+Schließlich könnte es sein, das du so tun willst, als ob du beim 
+Würfeln eine 6 hast - also den höchten Wert erreichst. `one_in` gibt - 
+mit einer Wahrscheinlichkeit 1 im Verhältnis zur Menge der Würfelseiten 
+- den Wert *wahr* (engl. *true*) zurück, falls die höchste Zahl 
+gewürfelt wurde. `one_in(6)` wird also mit einer Wahrscheinlichkeit von 
+1 zu 6 wahr, ansonsten *falsch* (engl. *false*). Wahr- und Falsch-Werte 
+sind sehr nützlich, wenn es um `if`-Anweisungen geht, die wir in einem 
+folgenden Kapitel dieses Tutorials besprechen.
 
-Jetzt los, bring' deinen Code mit ein paar Zufälligkeiten durcheinander!
+Jetzt los, bring' deinen Code mit ein paar Zufälligkeiten 
+durcheinander!
 
-[^1]: Randomisierung (engl. *randomisation*) bedeutet hier, dass man eine Auswahl von Zahlen zufällig gestaltet, also jedesmal eine andere Zahl bekommt.
+[^1]: Randomisierung (engl. *randomisation*) bedeutet hier, dass man 
+eine Auswahl von Zahlen zufällig gestaltet, also jedesmal eine andere 
+Zahl bekommt.
 
-[^2]: Im Film *Groundhog Day* (deutsch: *Und täglich grüßt das Murmeltier*) erlebt Bill Murray immer wieder denselben Tag.
+[^2]: Im Film *Groundhog Day* (deutsch: *Und täglich grüßt das 
+Murmeltier*) erlebt Bill Murray immer wieder denselben Tag.
 
-[^3]: Ein Schleife wird mit dem Ausdruck `loop` eingeleitet. Alles was innerhalb der Schleife steht, wird so oft wie angegeben oder unendlich oft wiederholt. 
+[^3]: Ein Schleife wird mit dem Ausdruck `loop` eingeleitet. Alles was 
+innerhalb der Schleife steht, wird so oft wie angegeben oder unendlich 
+oft wiederholt. 
 
-[^4]: In Sonic Pi wird das das Abschneiden oder Verkürzen mit dem Ausdruck `cutoff` bezeichnet.
+[^4]: In Sonic Pi wird das das Abschneiden oder Verkürzen mit dem 
+Ausdruck `cutoff` bezeichnet.
 
-[^5]: *Seed* bedeutet im Deutschen *Keim* oder *Samen*; hier wird es als *Startpunkt* übersetzt. 
+[^5]: *Seed* bedeutet im Deutschen *Keim* oder *Samen*; hier wird es 
+als *Startpunkt* übersetzt. 
 
-[^6]: Die Sache wird noch dadurch ein wenig komplizierter, dass im Englischen anstelle eines Kommas ein Punkt steht. Die Gleitkommazahl `5,978` ist also im Englischen die *floating point nuber* (kurz: *float*) `5.978`. Alle Zahlen mit Kommawerten werden also in Sonic Pi mit einem Punkt dargestellt.
+[^6]: Die Sache wird noch dadurch ein wenig komplizierter, dass im 
+Englischen anstelle eines Kommas ein Punkt steht. Die Gleitkommazahl 
+`5,978` ist also im Englischen die *floating point nuber* (kurz: 
+*float*) `5.978`. Alle Zahlen mit Kommawerten werden also in Sonic Pi 
+mit einem Punkt dargestellt.
 
-[^7]: Das kleine *i* in `rrand_i` steht für engl. *integer* als eine ganze Zahl im Unterschied zu den Gleitkommazahlen.
+[^7]: Das kleine *i* in `rrand_i` steht für engl. *integer* als eine 
+ganze Zahl im Unterschied zu den Gleitkommazahlen.

--- a/etc/doc/tutorial/de/05-Programming-Structures.md
+++ b/etc/doc/tutorial/de/05-Programming-Structures.md
@@ -2,8 +2,14 @@
 
 # Programmstrukturen
 
-Jetzt, wo du grundsätzlich weisst, wie man Klänge mit `play` und `sample`erzeugt und einfache Melodien und Rhythmen baut, indem man `sleep` zwischen die Klänge setzt, fragst du dich vielleicht, was dir die Welt des Codes noch alles zu bieten hat...
+Jetzt, wo du grundsätzlich weisst, wie man Klänge mit `play` und 
+`sample`erzeugt und einfache Melodien und Rhythmen baut, indem man 
+`sleep` zwischen die Klänge setzt, fragst du dich vielleicht, was dir 
+die Welt des Codes noch alles zu bieten hat...
 
-Ich denke, da kommen noch einige tolle Sachen auf dich zu! Es zeigt sich, dass grundlegende Programmstrukturen wie Schleifen, Bedingungen, Funktionen und Threads wirkungsvolle Werkzeuge darstellen, wenn es für dich darum geht, deine musikalische Ideen auszusrücken.
+Ich denke, da kommen noch einige tolle Sachen auf dich zu! Es zeigt 
+sich, dass grundlegende Programmstrukturen wie Schleifen, Bedingungen, 
+Funktionen und Threads wirkungsvolle Werkzeuge darstellen, wenn es für 
+dich darum geht, deine musikalische Ideen auszusrücken.
 
 Sehen wir uns die Grundlagen an...

--- a/etc/doc/tutorial/de/05.1-Blocks.md
+++ b/etc/doc/tutorial/de/05.1-Blocks.md
@@ -2,7 +2,14 @@
 
 # Blocks
 
-Eine Struktur, die man häufig in Sonic Pi sieht, ist der Block. Blocks erlauben uns nützliche Dinge mit größeren Codeabschnitten zu tun. Mit Synth oder Sample-Parametern konnten wir etwas ändern, was in einer Codezeile geschah. Manchmal aber möchten wir etwas mit einer ganzen Reihe von Codezeilen anstellen. Zum Beispiel möchten wir diese in einer Schleife ablaufen lassen, Hall hinzufügen, bei vorgegebenen Wiederholungen nur eine von fünf ablaufen lassen etc. Sieh dir den folgenden Code an:
+Eine Struktur, die man häufig in Sonic Pi sieht, ist der Block. Blocks 
+erlauben uns nützliche Dinge mit größeren Codeabschnitten zu tun. Mit 
+Synth oder Sample-Parametern konnten wir etwas ändern, was in einer 
+Codezeile geschah. Manchmal aber möchten wir etwas mit einer ganzen 
+Reihe von Codezeilen anstellen. Zum Beispiel möchten wir diese in einer 
+Schleife ablaufen lassen, Hall hinzufügen, bei vorgegebenen 
+Wiederholungen nur eine von fünf ablaufen lassen etc. Sieh dir den 
+folgenden Code an:
 
 ```
 play 50
@@ -12,7 +19,9 @@ sleep 0.5
 play 62
 ```
 
-Um etwas mit einem mehrzeiligen Codestück zu tun, müssen wir Sonic Pi sagen, wo der Codeblock *anfängt*, und wo er *aufhört*. Dazu verwenden wir `do` für den Anfang und `end` für das Ende. Zum Beispiel:
+Um etwas mit einem mehrzeiligen Codestück zu tun, müssen wir Sonic Pi 
+sagen, wo der Codeblock *anfängt*, und wo er *aufhört*. Dazu verwenden 
+wir `do` für den Anfang und `end` für das Ende. Zum Beispiel:
 
 ```
 do
@@ -24,4 +33,11 @@ do
 end
 ```
 
-Das ist aber noch nicht alles und wird so nicht funktionieren (versuche es und du wirst eine Fehler erhalten), weil wir Sonic Pi noch nicht gesagt haben, was wir mit diesem *do/end block* machen wollen. Dafür setzen wir noch einen speziellen Ausdruck vor das `do`. Solche Ausdrücke werden wir in diesem Tutorial noch kennenlernen. Zunächst einmal ist wichtig, dass wir mehrere Codezeilen mit `do` und `end` zusammenfassen und Sonic Pi sagen können, dass wir mit diesem Codestück etwas Bestimmtes machen wollen.
+Das ist aber noch nicht alles und wird so nicht funktionieren (versuche 
+es und du wirst eine Fehler erhalten), weil wir Sonic Pi noch nicht 
+gesagt haben, was wir mit diesem *do/end block* machen wollen. Dafür 
+setzen wir noch einen speziellen Ausdruck vor das `do`. Solche 
+Ausdrücke werden wir in diesem Tutorial noch kennenlernen. Zunächst 
+einmal ist wichtig, dass wir mehrere Codezeilen mit `do` und `end` 
+zusammenfassen und Sonic Pi sagen können, dass wir mit diesem Codestück 
+etwas Bestimmtes machen wollen.

--- a/etc/doc/tutorial/de/05.2-Iteration-and-Loops.md
+++ b/etc/doc/tutorial/de/05.2-Iteration-and-Loops.md
@@ -2,13 +2,22 @@
 
 # Iteration und Schleifen
 
-Bislang haben wir einige Zeit damit verbracht, uns unterschiedliche Klänge anzusehen, die du mit `play` und `sample` erzeugen kannst. Wir haben auch gelernt, wie du diese Klänge mit `sleep` in der Zeit steuern kannst.
+Bislang haben wir einige Zeit damit verbracht, uns unterschiedliche 
+Klänge anzusehen, die du mit `play` und `sample` erzeugen kannst. Wir 
+haben auch gelernt, wie du diese Klänge mit `sleep` in der Zeit steuern 
+kannst.
 
-Wahrscheinlich hast du entdeckt, dass man mit diesen Grundbausteinen schon *vieles* bauen kann. Eine ganz neue Dimension eröffnet sich jedoch, wenn wir beginnen, die Musik und die Kompositionen über den Code weitergehend zu strukturieren. In den nächsten Abschnitten untersuchen wir einige wirkungsvollen neuen Werkzeuge, dies zu tun. Als erstes kommen die Iteration und die Schleife (engl. *loop*) dran.
+Wahrscheinlich hast du entdeckt, dass man mit diesen Grundbausteinen 
+schon *vieles* bauen kann. Eine ganz neue Dimension eröffnet sich 
+jedoch, wenn wir beginnen, die Musik und die Kompositionen über den 
+Code weitergehend zu strukturieren. In den nächsten Abschnitten 
+untersuchen wir einige wirkungsvollen neuen Werkzeuge, dies zu tun. Als 
+erstes kommen die Iteration und die Schleife (engl. *loop*) dran.
 
 ## Wiederholung
 
-Möchtest du Code, den du geschrieben hast, einige Male wiederholen? Zum Beispiel hast du vielleicht ungefähr so etwas:
+Möchtest du Code, den du geschrieben hast, einige Male wiederholen? Zum 
+Beispiel hast du vielleicht ungefähr so etwas:
 
 ```
 play 50
@@ -19,7 +28,9 @@ play 62
 sleep 0.25
 ```
 
-Was, wenn du das drei Mal wiederholen wolltest. Naja, du könntest das einfach so lösen, dass du den Code kopierst und drei Mal hintereinander einfügst:
+Was, wenn du das drei Mal wiederholen wolltest. Naja, du könntest das 
+einfach so lösen, dass du den Code kopierst und drei Mal hintereinander 
+einfügst:
 
 ```
 play 50
@@ -44,11 +55,23 @@ play 62
 sleep 0.25
 ```
 
-Das ist natürlich eine Menge Code! Was wäre, wenn du das Sample in `:elec_plip` umändern wolltest? Du müsstest alle Stellen mit `:elec_blub` finden und ändern. Und weiter: Was, wenn du das ursprüngliche Codestück 50 oder 1000 Mal wiederholen wolltest? Das wäre noch mehr Code, und du müsstest eine Menge Zeilen bearbeiten, wenn du etwas ändern wolltest.
+Das ist natürlich eine Menge Code! Was wäre, wenn du das Sample in 
+`:elec_plip` umändern wolltest? Du müsstest alle Stellen mit 
+`:elec_blub` finden und ändern. Und weiter: Was, wenn du das 
+ursprüngliche Codestück 50 oder 1000 Mal wiederholen wolltest? Das wäre 
+noch mehr Code, und du müsstest eine Menge Zeilen bearbeiten, wenn du 
+etwas ändern wolltest.
 
 ## Iteration
 
-Wenn man Code wiederholt ablaufen lassen wollte, müsste das eigentlich so einfach sein zu sagen, *mach' das drei Mal*. Und so ist es auch in etwa. Erinnerst du dich an unseren Freund den Codeblock? Wir können damit den Anfang und das Ende des Codes markieren, den wir drei Mal wiederholen wollen. Dann benutzen wir den speziellen Ausdruck `3.times`. Wir schreiben zwar nicht *mach' das drei Mal*, wir schreiben `3.times do` - also nicht besonders schwierig. Denk' aber daran, am Ende des Codes, den du wiederholen möchtest, ein `end` einzufügen.
+Wenn man Code wiederholt ablaufen lassen wollte, müsste das eigentlich 
+so einfach sein zu sagen, *mach' das drei Mal*. Und so ist es auch in 
+etwa. Erinnerst du dich an unseren Freund den Codeblock? Wir können 
+damit den Anfang und das Ende des Codes markieren, den wir drei Mal 
+wiederholen wollen. Dann benutzen wir den speziellen Ausdruck 
+`3.times`. Wir schreiben zwar nicht *mach' das drei Mal*, wir schreiben 
+`3.times do` - also nicht besonders schwierig. Denk' aber daran, am 
+Ende des Codes, den du wiederholen möchtest, ein `end` einzufügen.
 
 ```
 3.times do
@@ -61,7 +84,9 @@ Wenn man Code wiederholt ablaufen lassen wollte, müsste das eigentlich so einfa
 end
 ```
 
-Na, ist das nicht viel eleganter als kopieren und einfügen? Wir können das gut gebrauchen, um eine Menge sich wiederholender Strukturen zu erzeugen.
+Na, ist das nicht viel eleganter als kopieren und einfügen? Wir können 
+das gut gebrauchen, um eine Menge sich wiederholender Strukturen zu 
+erzeugen.
 
 ```
 4.times do
@@ -82,7 +107,8 @@ end
 
 ## Iterationen ineinander verschachteln
 
-Wir können Iterationen in andere Iterationen hineinpacken, um damit interessante Muster zu erzeugen. Zum Beispiel:
+Wir können Iterationen in andere Iterationen hineinpacken, um damit 
+interessante Muster zu erzeugen. Zum Beispiel:
 
 ```
 4.times do
@@ -101,7 +127,11 @@ end
 
 ## Schleifen
 
-Wenn du etwas sehr oft wiederholen möchtest, könnte es sein, dass du mit sehr hohen Zahlen arbeiten musst wie zum Beispiel `1000.times do`. In einem solchen Fall macht es mehr Sinn, Sonic Pi dazu zu bringen, den Code für immer zu wiederholen (zumindest, bis du den Stop-Button klickst!). Wiederholen wir den Amen Break unendlich oft:
+Wenn du etwas sehr oft wiederholen möchtest, könnte es sein, dass du 
+mit sehr hohen Zahlen arbeiten musst wie zum Beispiel `1000.times do`. 
+In einem solchen Fall macht es mehr Sinn, Sonic Pi dazu zu bringen, den 
+Code für immer zu wiederholen (zumindest, bis du den Stop-Button 
+klickst!). Wiederholen wir den Amen Break unendlich oft:
 
 ```
 loop do
@@ -110,7 +140,12 @@ loop do
 end
 ```
 
-Eine wichtige Sache bei Schleifen ist, dass sie für den Code wie schwarze Löcher sind. Wenn der Code einmal in einer Schleife läuft, kann er diese nicht mehr verlassen, bis du auf Stopp klickst - ansonsten wird er für immer weiterlaufen. Das bedeutet, wenn hinter deiner Schleife noch weiterer Code steht, wirst du diesen *nie* hören. Zum Beispiel wird das Becken hinter dieser Schleife nie spielen:
+Eine wichtige Sache bei Schleifen ist, dass sie für den Code wie 
+schwarze Löcher sind. Wenn der Code einmal in einer Schleife läuft, 
+kann er diese nicht mehr verlassen, bis du auf Stopp klickst - 
+ansonsten wird er für immer weiterlaufen. Das bedeutet, wenn hinter 
+deiner Schleife noch weiterer Code steht, wirst du diesen *nie* hören. 
+Zum Beispiel wird das Becken hinter dieser Schleife nie spielen:
 
 ```
 loop do
@@ -120,5 +155,7 @@ end
 
 sample :drum_cymbal_open
 ```
-Jetzt fang' an und strukturiere deine Code mit Wiederholungen und Schleifen!
+
+Jetzt fang' an und strukturiere deine Code mit Wiederholungen und 
+Schleifen!
 

--- a/etc/doc/tutorial/de/05.3-Conditionals.md
+++ b/etc/doc/tutorial/de/05.3-Conditionals.md
@@ -2,11 +2,23 @@
 
 # Bedingungen
 
-Eine Sache, die du wahrscheinlich häufig tun möchtest, ist, nicht nur einen zufälligen Ton zu spielen (siehe das Kapitel über Zufallszahlen), sondern auch,  eine zufällige Entscheidung treffen: je nachdem wie diese ausfällt, möchtest du dann den einen oder anderen Code ausführen. Zum Beispiel könnte es sein, dass du zufällig entweder eine Trommel oder ein Becken anschlagen möchtest. Das können wir mit einem `if`-Ausdruck erreichen.
+Eine Sache, die du wahrscheinlich häufig tun möchtest, ist, nicht nur 
+einen zufälligen Ton zu spielen (siehe das Kapitel über Zufallszahlen), 
+sondern auch,  eine zufällige Entscheidung treffen: je nachdem wie 
+diese ausfällt, möchtest du dann den einen oder anderen Code ausführen. 
+Zum Beispiel könnte es sein, dass du zufällig entweder eine Trommel 
+oder ein Becken anschlagen möchtest. Das können wir mit einem 
+`if`-Ausdruck erreichen.
 
 ## Wirf eine Münze
 
-Werfen wir also ein Münze: bei Kopf, spiele eine Trommel, bei Zahl, ein Becken. Das ist leicht. Wir können das Münzewerfen mit unserer `one_in`-Funktion nachbilden (eingeführt im Kapitel über Randomisierung), indem wir eine Wahrscheinlichkeit von 1 aus 2 angeben: `one_in(2)`. Das Ergebnis dieser Berechnung benutzen wir, um zwischen zwei Codestücken auszuwählen: den Code, der die Trommel oder den, der das Becken spielt:
+Werfen wir also ein Münze: bei Kopf, spiele eine Trommel, bei Zahl, ein 
+Becken. Das ist leicht. Wir können das Münzewerfen mit unserer 
+`one_in`-Funktion nachbilden (eingeführt im Kapitel über 
+Randomisierung), indem wir eine Wahrscheinlichkeit von 1 aus 2 angeben: 
+`one_in(2)`. Das Ergebnis dieser Berechnung benutzen wir, um zwischen 
+zwei Codestücken auszuwählen: den Code, der die Trommel oder den, der 
+das Becken spielt:
 
 ```
 loop do
@@ -28,9 +40,15 @@ Denke daran, dass `if`-Anweisungen drei Teile haben:
 * die erste Wahl des Codes, der ablaufen soll (wenn die Antwort auf die Frage ein Ja ist),
 * die zweite Wahl des Codes, der ablaufen soll (wenn die Antwort auf die Frage ein Nein ist).
 
-Für Programmiersprachen typisch wird das Ja durch den Ausdruck `true` (wahr) dargestellt und das Nein durch den Ausdruck `false` (falsch). Also müssen wir eine Frage finden, die uns eine Antwort gibt, die entweder wahr oder falsch ist; genau das erledigt `one_in`.
+Für Programmiersprachen typisch wird das Ja durch den Ausdruck `true` 
+(wahr) dargestellt und das Nein durch den Ausdruck `false` (falsch). 
+Also müssen wir eine Frage finden, die uns eine Antwort gibt, die 
+entweder wahr oder falsch ist; genau das erledigt `one_in`.
 
-Beachte, dass die erste Wahl zwischen `if` und `else` und die zweite Wahl zwischen `else` und `end` eingeschlossen wird. So wie bei den do/end-Blöcken kannst du beliebig viele Codezeilen an beide Stellen schreiben. Zum Beispiel:
+Beachte, dass die erste Wahl zwischen `if` und `else` und die zweite 
+Wahl zwischen `else` und `end` eingeschlossen wird. So wie bei den 
+do/end-Blöcken kannst du beliebig viele Codezeilen an beide Stellen 
+schreiben. Zum Beispiel:
 
 ```
 loop do
@@ -46,11 +64,14 @@ loop do
 end
 ```
 
-Dieses Mal schläft der Klang unterschiedlich lange, je nachdem, welche Auswahl getroffen wird.
+Dieses Mal schläft der Klang unterschiedlich lange, je nachdem, welche 
+Auswahl getroffen wird.
 
 ## Einfaches if
 
-Manchmal möchtest du wahlweise nur eine Codezeile ausführen. Das kannst du machen, indem du ein `if` schreibst und die Frage an das Ende stellst. Zum Beispiel: 
+Manchmal möchtest du wahlweise nur eine Codezeile ausführen. Das kannst 
+du machen, indem du ein `if` schreibst und die Frage an das Ende 
+stellst. Zum Beispiel: 
 
 ```
 use_synth :dsaw
@@ -64,4 +85,6 @@ loop do
 end
 ```
 
-In diesem Beispiel wird ein Akkord aus verschiedenen Zahlen zusammengesetzt, wobei die Chance, dass bestimmte Noten gespielt werden, eine unterschiedliche Wahrscheinlichkeit hat.
+In diesem Beispiel wird ein Akkord aus verschiedenen Zahlen 
+zusammengesetzt, wobei die Chance, dass bestimmte Noten gespielt 
+werden, eine unterschiedliche Wahrscheinlichkeit hat.

--- a/etc/doc/tutorial/de/05.4-Threads.md
+++ b/etc/doc/tutorial/de/05.4-Threads.md
@@ -2,13 +2,22 @@
 
 # Threads[^1]
 
-Mal angenommen, du hast eine Killer-Basslinie und einen krassen Beat gebaut. Wie kannst du beides zur selben Zeit spielen lassen? Eine Möglichkeit ist es, beide Sounds per Hand ineinanderzuweben - erst spielt der Bass ein bisschen, dann das Schlagzeug, dann der Bass etwas mehr... Beides aufeinander zeitlich abzustimmen wird jedoch immer schwieriger, vor allem, wenn noch mehr Sounds dazukommen sollen.
+Mal angenommen, du hast eine Killer-Basslinie und einen krassen Beat 
+gebaut. Wie kannst du beides zur selben Zeit spielen lassen? Eine 
+Möglichkeit ist es, beide Sounds per Hand ineinanderzuweben - erst 
+spielt der Bass ein bisschen, dann das Schlagzeug, dann der Bass etwas 
+mehr... Beides aufeinander zeitlich abzustimmen wird jedoch immer 
+schwieriger, vor allem, wenn noch mehr Sounds dazukommen sollen.
 
-Was, wenn Sonic Pi Sounds automatisch für dich ineinanderflechten könnte? Kann es auch, und zwar mit einem besonderen Ding, welches *Thread* heisst.
+Was, wenn Sonic Pi Sounds automatisch für dich ineinanderflechten 
+könnte? Kann es auch, und zwar mit einem besonderen Ding, welches 
+*Thread* heisst.
 
 ## Unendliche Schleifen
 
-Damit das nächste Beispiel nicht zu kompliziert wird, musst du dir einfach vorstellen, dass dies deine Killer-Basslinie und dein krasser Beat sind.
+Damit das nächste Beispiel nicht zu kompliziert wird, musst du dir 
+einfach vorstellen, dass dies deine Killer-Basslinie und dein krasser 
+Beat sind.
 
 ```
 loop do
@@ -23,7 +32,12 @@ loop do
 end
 ```
 
-Wir haben das früher schon besprochen, Schleifen sind wie *schwarze Löcher* für ein Programm; läuft es einmal in die Schleife, dann kommt es nicht mehr da raus,  bis du den Stopp-Button klickst. Wie also können wir beide Schleifen zur selben Zeit abspielen? Wir müssen Sonic Pi sagen, dass wir einen bestimmten Codeteil  gleichzeitig mit dem Rest des Codes starten möchten. Hierbei helfen uns Threads.
+Wir haben das früher schon besprochen, Schleifen sind wie *schwarze 
+Löcher* für ein Programm; läuft es einmal in die Schleife, dann kommt 
+es nicht mehr da raus,  bis du den Stopp-Button klickst. Wie also 
+können wir beide Schleifen zur selben Zeit abspielen? Wir müssen Sonic 
+Pi sagen, dass wir einen bestimmten Codeteil  gleichzeitig mit dem Rest 
+des Codes starten möchten. Hierbei helfen uns Threads.
 
 ## Threads kommen zur Hilfe
 
@@ -42,9 +56,14 @@ loop do
 end
 ```
 
-Indem wir die erste Schleife in einen `in_thread`-do/end-Block hineinpacken, sagen wir Sonic Pi, es soll den Inhalt dieses do/end-Blocks *genau zur selben Zeit* wie die nachfolgende Anweisung ausführen (und das ist in diesem Fall die zweite Schleife). Probier's aus, und du wirst den Beat zusammen mit der Basslinie hören!
+Indem wir die erste Schleife in einen `in_thread`-do/end-Block 
+hineinpacken, sagen wir Sonic Pi, es soll den Inhalt dieses 
+do/end-Blocks *genau zur selben Zeit* wie die nachfolgende Anweisung 
+ausführen (und das ist in diesem Fall die zweite Schleife). Probier's 
+aus, und du wirst den Beat zusammen mit der Basslinie hören!
 
-Was nun, wenn wir obendrauf noch einen Synth legen wollten. Ungefähr so:
+Was nun, wenn wir obendrauf noch einen Synth legen wollten. Ungefähr 
+so:
 
 ```
 in_thread do
@@ -67,7 +86,10 @@ loop do
 end
 ```
 
-Jetzt haben wir das gleiche Problem wir vorhin. Die erste Schleife wird durch das `in_thread` zur selben Zeit wie die zweite gespielt. Aber *die dritte Schleife wird nie erreicht*. Also brauchen wir einen weiteren Tread:
+Jetzt haben wir das gleiche Problem wir vorhin. Die erste Schleife wird 
+durch das `in_thread` zur selben Zeit wie die zweite gespielt. Aber 
+*die dritte Schleife wird nie erreicht*. Also brauchen wir einen 
+weiteren Tread:
 
 ```
 in_thread do
@@ -94,11 +116,22 @@ end
 
 ## Ablauf in Threads
 
-Was dich vielleicht erstaunt: Wenn du den Ausführen-Button klickst, erzeugst du tatsächlich einen neuen Thread, innerhalb dessen der Code abläuft. Deshalb werden immer neue Soundschichten erzeugt, wenn du den Ausführen-Button wiederholt klickst. Weil die Abläufe Threads sind, werden sie automatisch die Sounds verflechten.
+Was dich vielleicht erstaunt: Wenn du den Ausführen-Button klickst, 
+erzeugst du tatsächlich einen neuen Thread, innerhalb dessen der Code 
+abläuft. Deshalb werden immer neue Soundschichten erzeugt, wenn du den 
+Ausführen-Button wiederholt klickst. Weil die Abläufe Threads sind, 
+werden sie automatisch die Sounds verflechten.
 
 ## Geltungsbereich[^2]
 
-Wenn du dich besser mit Sonic Pi auskennst, wirst du herausfinden, dass Threads die wichtigsten Bausteine für deine Musik sind. Eine wesentliche Funktion, die Threads haben, ist es, *aktuelle Einstellungen*, die für einen Thread gelten, von anderen Threads zu isolieren. Was genau bedeutet das? Wenn du etwa einen Synths mit `use_synth` durch einen anderen austauschst, dann veränderst du den Synth lediglich für den *aktuellen Tread* - kein anderer der laufenden Treads bekommt den neuen Synth. Sehen wir uns das mal in der Praxis an:
+Wenn du dich besser mit Sonic Pi auskennst, wirst du herausfinden, dass 
+Threads die wichtigsten Bausteine für deine Musik sind. Eine 
+wesentliche Funktion, die Threads haben, ist es, *aktuelle 
+Einstellungen*, die für einen Thread gelten, von anderen Threads zu 
+isolieren. Was genau bedeutet das? Wenn du etwa einen Synths mit 
+`use_synth` durch einen anderen austauschst, dann veränderst du den 
+Synth lediglich für den *aktuellen Tread* - kein anderer der laufenden 
+Treads bekommt den neuen Synth. Sehen wir uns das mal in der Praxis an:
 
 
 ```
@@ -112,14 +145,17 @@ end
 
 sleep 1
 play 50
-
 ```
 
-Hast du gehört, dass sich der mittlere Klang von den anderen beiden unterschied? Die `use_synth`-Anweisung hat sich nur auf den Thread ausgewirkt, in dem sie auch stand und nicht auf den äußeren Haupt-Thread.
+Hast du gehört, dass sich der mittlere Klang von den anderen beiden 
+unterschied? Die `use_synth`-Anweisung hat sich nur auf den Thread 
+ausgewirkt, in dem sie auch stand und nicht auf den äußeren 
+Haupt-Thread.
 
 ## Vererbung
 
-Wenn du einen neuen Thread mit `in_thread` erzeugst, wird dieser vom vorherigen alle Einstellungen automatisch erben. Sehen wir uns das an:
+Wenn du einen neuen Thread mit `in_thread` erzeugst, wird dieser vom 
+vorherigen alle Einstellungen automatisch erben. Sehen wir uns das an:
 
 ```
 use_synth :tb303
@@ -131,9 +167,14 @@ in_thread do
 end
 ```
 
-Hast du bemerkt, dass der zweite Ton mit dem `:tb303`-Synth gespielt wird, obwohl er in einem anderen Thread läuft? Jede der Einstellungen, die mit den unterschiedlichen `use_*`-Ausdrücken vorgenommen wird, verhält sich genauso.
+Hast du bemerkt, dass der zweite Ton mit dem `:tb303`-Synth gespielt 
+wird, obwohl er in einem anderen Thread läuft? Jede der Einstellungen, 
+die mit den unterschiedlichen `use_*`-Ausdrücken vorgenommen wird, 
+verhält sich genauso.
 
-Wenn neue Threads erzeugt werden, dann erben sie alle Einstellungen von ihren Eltern; wenn du aber Einstellungen innerhalb dieser neuen Threads änderst, haben diese keine Einfluss auf die Eltern-Threads.
+Wenn neue Threads erzeugt werden, dann erben sie alle Einstellungen von 
+ihren Eltern; wenn du aber Einstellungen innerhalb dieser neuen Threads 
+änderst, haben diese keine Einfluss auf die Eltern-Threads.
 
 ## Threads benennen
 
@@ -156,7 +197,8 @@ in_thread(name: :drums) do
 end
 ```
 
-Sieh dir das Protokoll-Fenster an, wenn du diesen Code laufen läßt. Siehst du, wie die  Namen der Threads ausgeben werden?
+Sieh dir das Protokoll-Fenster an, wenn du diesen Code laufen läßt. 
+Siehst du, wie die  Namen der Threads ausgeben werden?
 
 ```
 [Run 36, Time 4.0, Thread :bass]
@@ -165,7 +207,9 @@ Sieh dir das Protokoll-Fenster an, wenn du diesen Code laufen läßt. Siehst du,
 
 ## Nur ein Name pro Thread erlaubt
 
-Eine letzte Anmerkungen zu Threads mit Namen: Ein mit einem bestimmten Namen benannter Thread kann zur Zeit nur einmal laufen. Probieren wir das aus. Sieh dir den folgenden Code an:
+Eine letzte Anmerkungen zu Threads mit Namen: Ein mit einem bestimmten 
+Namen benannter Thread kann zur Zeit nur einmal laufen. Probieren wir 
+das aus. Sieh dir den folgenden Code an:
 
 ```
 in_thread do
@@ -176,9 +220,16 @@ in_thread do
 end
 ```
 
-Kopiere das einmal in ein Arbeitsfenster und klicke den Ausführen-Button. Klick' in noch ein paarmal. Hör' dir diese Kakophonie mehrerer Amen Breaks an, die ryhtmisch nicht unbedingt passend zueinander ablaufen. Ok, jetzt kannst du auf Stopp klicken.
+Kopiere das einmal in ein Arbeitsfenster und klicke den 
+Ausführen-Button. Klick' in noch ein paarmal. Hör' dir diese Kakophonie 
+mehrerer Amen Breaks an, die ryhtmisch nicht unbedingt passend 
+zueinander ablaufen. Ok, jetzt kannst du auf Stopp klicken.
 
-Dieses Verhalten konnten wir schon woanders sehen - wenn du den Ausführen-Button klickst, legen sich die neuen Klänge über die schon laufenden. Wenn eine Schleife abläuft, und du den Ausführen-Button dreimal klickst, bekommst du drei Ebenen mit Schleifen, die simultan ablaufen.
+Dieses Verhalten konnten wir schon woanders sehen - wenn du den 
+Ausführen-Button klickst, legen sich die neuen Klänge über die schon 
+laufenden. Wenn eine Schleife abläuft, und du den Ausführen-Button 
+dreimal klickst, bekommst du drei Ebenen mit Schleifen, die simultan 
+ablaufen.
 
 Mit benannten Treads ist das jedoch anders:
 
@@ -191,16 +242,29 @@ in_thread(name: :amen) do
 end
 ```
 
-Versuche mit diesem Code den Ausführen-Button mehrmals zu klicken. Du wirst immer nur eine Amen Break-Schleife hören. Das kannst du auch im Protokoll sehen:
+Versuche mit diesem Code den Ausführen-Button mehrmals zu klicken. Du 
+wirst immer nur eine Amen Break-Schleife hören. Das kannst du auch im 
+Protokoll sehen:
 
 ```
 ==> Skipping thread creation: thread with name :amen already exists.
 ```
 
-Sonic Pi sagt dir, dass ein Thread mit dem Namen `:amen` bereits läuft und es deshalb keinen neuen erzeugt.
+Sonic Pi sagt dir, dass ein Thread mit dem Namen `:amen` bereits läuft 
+und es deshalb keinen neuen erzeugt.
 
-Vielleicht erscheint dir dieses Verhalten im Moment noch nicht sinnvoll - aber es wird sehr nützlich sein, wenn wir ins Live-Coding einsteigen...
+Vielleicht erscheint dir dieses Verhalten im Moment noch nicht sinnvoll 
+- aber es wird sehr nützlich sein, wenn wir ins Live-Coding 
+einsteigen...
 
-[^1]: Im Deutschen bedeutet *thread* *Kette*, *Faden* oder *Strang*. Der *Thread* ist jedoch für Programmiersprachen eine so typische Idee, dass eine Übersetzung nur insoweit Sinn macht, dass du dir die Idee, die hinter diesem Begriff steht, besser merken kannst. Weil niemand beim Programmieren über eine Kette oder einen Faden spricht, werden wir hier nur den englischen Begriff benutzen.
+[^1]: Im Deutschen bedeutet *thread* *Kette*, *Faden* oder *Strang*. 
+Der *Thread* ist jedoch für Programmiersprachen eine so typische Idee, 
+dass eine Übersetzung nur insoweit Sinn macht, dass du dir die Idee, 
+die hinter diesem Begriff steht, besser merken kannst. Weil niemand 
+beim Programmieren über eine Kette oder einen Faden spricht, werden wir 
+hier nur den englischen Begriff benutzen.
 
-[^2]: *Scope* bedeutet ins Deutsche übersetzt soviel wie *Geltungsbereich*. Für die Zukunft ist es aber ganz gut, sich den englischen Begriff zu merken, da auch dieser im Programmierbereich häufig vorkommt.
+[^2]: *Scope* bedeutet ins Deutsche übersetzt soviel wie 
+*Geltungsbereich*. Für die Zukunft ist es aber ganz gut, sich den 
+englischen Begriff zu merken, da auch dieser im Programmierbereich 
+häufig vorkommt.

--- a/etc/doc/tutorial/de/05.5-Functions.md
+++ b/etc/doc/tutorial/de/05.5-Functions.md
@@ -2,7 +2,12 @@
 
 # Funktionen
 
-Wenn du einmal damit angefangen hast, mehr Code zu schreiben, dann wirst du nach Wegen suchen, wie du die Dinge organisieren und strukturieren kannst, damit alles ordentlicher wird und einfacher zu verstehen ist. Funktionen sind sehr geeignet, um das zu erreichen. Sie geben uns die Möglichkeit, einem Bündel von Codezeilen einen Namen zu geben. Sehen wir uns das an.
+Wenn du einmal damit angefangen hast, mehr Code zu schreiben, dann 
+wirst du nach Wegen suchen, wie du die Dinge organisieren und 
+strukturieren kannst, damit alles ordentlicher wird und einfacher zu 
+verstehen ist. Funktionen sind sehr geeignet, um das zu erreichen. Sie 
+geben uns die Möglichkeit, einem Bündel von Codezeilen einen Namen zu 
+geben. Sehen wir uns das an.
 
 ## Funktionen definieren
 
@@ -15,13 +20,21 @@ define :foo do
 end
 ```
 
-Hier haben wir eine neue Funktion mit dem Namen `foo` definiert. Wir machen das mit unserem alten Freund, dem do/end-Block und dem Zauberwort `define` gefolgt von dem Namen, den wir unserer Funktion geben möchten. Wir müssen die Funktion  nicht unbedingt `foo` nennen, wir können sie auch irgendwie anders nennen; zum Beispiel `bar`, `baz` oder idealerweise einen für dich bedeutsamen Namen wie `main_section` (etwa: *Hauptteil*) oder `lead_riff` (etwa: *Leitfigur*).
+Hier haben wir eine neue Funktion mit dem Namen `foo` definiert. Wir 
+machen das mit unserem alten Freund, dem do/end-Block und dem 
+Zauberwort `define` gefolgt von dem Namen, den wir unserer Funktion 
+geben möchten. Wir müssen die Funktion  nicht unbedingt `foo` nennen, 
+wir können sie auch irgendwie anders nennen; zum Beispiel `bar`, `baz` 
+oder idealerweise einen für dich bedeutsamen Namen wie `main_section` 
+(etwa: *Hauptteil*) oder `lead_riff` (etwa: *Leitfigur*).
 
-Denk' daran, vor den Funktionsnamen einen Doppelpunkt `:` zu stellen, wenn du sie definierst.
+Denk' daran, vor den Funktionsnamen einen Doppelpunkt `:` zu stellen, 
+wenn du sie definierst.
 
 ## Funktionen aufrufen
 
-Wenn wir unsere Funktion definiert haben, können wir sie einfach über ihren Namen aufrufen:
+Wenn wir unsere Funktion definiert haben, können wir sie einfach über 
+ihren Namen aufrufen:
 
 ```
 define :foo do
@@ -40,21 +53,38 @@ sleep 1
 end
 ```
 
-Wir können `foo` sogar in Iterations-Blocks aufrufen und überall da, wo wir auch `play` oder `sample` hätten benutzen können. Das gibt uns ein große Ausdrucksfreiheit und wir können sinnvolle Worte bilden, die wir in unseren Kompositionen verwenden.
+Wir können `foo` sogar in Iterations-Blocks aufrufen und überall da, wo 
+wir auch `play` oder `sample` hätten benutzen können. Das gibt uns ein 
+große Ausdrucksfreiheit und wir können sinnvolle Worte bilden, die wir 
+in unseren Kompositionen verwenden.
 
 ## Funktionen werden in unterschiedlichen Abläufen erinnert
 
-Wenn du bislang den Ausführen-Button geklickt hast, startete Sonic Pi jedesmal aufs Neue ohne irgendwelche Vorgaben. Es berücksichtigt nichs, außer dem, was im jeweiligen Arbeitsfenster steht. Du kannst dich nicht auf irgendwelchen Code beziehen, der in einem anderen Arbeitsfenster oder einem anderen Thread steht. Funktionen ändern das jedoch. Wenn du eine Funktion definierst, dann erinnert sich Sonic Pi daran. Probieren wir das aus. Ersetzte den den gesamten Code in deinem Arbeitsfenster durch:
+Wenn du bislang den Ausführen-Button geklickt hast, startete Sonic Pi 
+jedesmal aufs Neue ohne irgendwelche Vorgaben. Es berücksichtigt nichs, 
+außer dem, was im jeweiligen Arbeitsfenster steht. Du kannst dich nicht 
+auf irgendwelchen Code beziehen, der in einem anderen Arbeitsfenster 
+oder einem anderen Thread steht. Funktionen ändern das jedoch. Wenn du 
+eine Funktion definierst, dann erinnert sich Sonic Pi daran. Probieren 
+wir das aus. Ersetzte den den gesamten Code in deinem Arbeitsfenster 
+durch:
 
 ```
 foo
 ```
 
-Klick' den Ausführen-Button und höre, wie deine Funktion spielt. Wo wurde dieser Code gespeichert? Woher weiss Sonic Pi, was es zu spielen hat? Sonic Pi hat deine Funktion einfach erinnert - also sogar nachdem du den Code aus dem Arbeitsfenster gelöscht hast, wusste Sonic Pi, was du geschrieben hattest. Dies funktioniert nur mit Funktionen, die du mit `define` (und `defonce`) definiert hast.
+Klick' den Ausführen-Button und höre, wie deine Funktion spielt. Wo 
+wurde dieser Code gespeichert? Woher weiss Sonic Pi, was es zu spielen 
+hat? Sonic Pi hat deine Funktion einfach erinnert - also sogar nachdem 
+du den Code aus dem Arbeitsfenster gelöscht hast, wusste Sonic Pi, was 
+du geschrieben hattest. Dies funktioniert nur mit Funktionen, die du 
+mit `define` (und `defonce`) definiert hast.
 
 ## Funktionen parametrisieren
 
-Vielleicht interessiert dich, dass du deinen Funktionen beibringen kannst, Argumente zu übernehmen, genauso, wie du z.B. `rrand` einen Minimal- und einen Maximalwert übergeben kannst. Sehen wir uns das an:
+Vielleicht interessiert dich, dass du deinen Funktionen beibringen 
+kannst, Argumente zu übernehmen, genauso, wie du z.B. `rrand` einen 
+Minimal- und einen Maximalwert übergeben kannst. Sehen wir uns das an:
 
 ```
 define :my_player do |n|
@@ -66,11 +96,27 @@ sleep 0.5
 my_player 90
 ```
 
-Das ist jetzt nicht besonders aufregend, zeigt aber, worum es hier geht. Wir haben unsere eigene Version von `play` mit dem Namen `my_player` erschaffen, die parametrisiert ist - also Argumente akzeptiert.
+Das ist jetzt nicht besonders aufregend, zeigt aber, worum es hier 
+geht. Wir haben unsere eigene Version von `play` mit dem Namen 
+`my_player` erschaffen, die parametrisiert ist - also Argumente 
+akzeptiert.
 
-Die Parameter müssen nach dem `do` stehen, welches zum `define` des do/end-Blocks gehört; sie werden von senkrechten Strichen (auch: Verkettungszeichen) umgeben und durch Kommata getrennt. Du kannst beliebige Worte als Parameternamen verwenden.
+Die Parameter müssen nach dem `do` stehen, welches zum `define` des 
+do/end-Blocks gehört; sie werden von senkrechten Strichen (auch: 
+Verkettungszeichen) umgeben und durch Kommata getrennt. Du kannst 
+beliebige Worte als Parameternamen verwenden.
 
-Die Zauberei findet innerhalb des `define`-do/end-Blocks statt. Du kannst die Parameternamen so benutzen, als wären sie wirkliche Werte. In diesem Beispiel spiele ich den Ton `n`. Du kannst die Parameter als eine Art Versprechen ansehen, dass sie durch wirkliche Werte ersetzt werden, wenn der Code läuft. Das machst du, indem du der Funktion einen Parameter mitgibst, wenn du sie aufrufst. Ich tue das hier mit `my_player 80`, um den Ton 80 zu spielen. Innerhalb der Funktionsdefinition wird `n` nun durch 80 ersetzt, sodass `play n` sich in `play 80` verwandelt. Wenn ich die Funktion erneut mit `my_player 90` aufrufe, wird `n` durch 90 ersetzt, sodass sich `play n` in `play 90` verwandelt.
+Die Zauberei findet innerhalb des `define`-do/end-Blocks statt. Du 
+kannst die Parameternamen so benutzen, als wären sie wirkliche Werte. 
+In diesem Beispiel spiele ich den Ton `n`. Du kannst die Parameter als 
+eine Art Versprechen ansehen, dass sie durch wirkliche Werte ersetzt 
+werden, wenn der Code läuft. Das machst du, indem du der Funktion einen 
+Parameter mitgibst, wenn du sie aufrufst. Ich tue das hier mit 
+`my_player 80`, um den Ton 80 zu spielen. Innerhalb der 
+Funktionsdefinition wird `n` nun durch 80 ersetzt, sodass `play n` sich 
+in `play 80` verwandelt. Wenn ich die Funktion erneut mit `my_player 
+90` aufrufe, wird `n` durch 90 ersetzt, sodass sich `play n` in `play 
+90` verwandelt.
 
 Sehen wir uns interessantere Beispiele an:
 
@@ -88,9 +134,12 @@ chord_player :a3, 3
 chord_player :g3, 4
 sleep 0.5
 chord_player :e3, 3
-
 ```
 
-Hier habe ich `repeats` so benutzt, als ob es eine Zahl in der Zeile `repeats.times do` wäre. Zusätzlich habe ich `roots` so verwendet, als ob es ein Notenname im Aufruf `play` wäre.
+Hier habe ich `repeats` so benutzt, als ob es eine Zahl in der Zeile 
+`repeats.times do` wäre. Zusätzlich habe ich `roots` so verwendet, als 
+ob es ein Notenname im Aufruf `play` wäre.
 
-Hier kannst du sehen, wie wir sehr aussagekräftig und leicht lesbar schreiben können, indem wir eine Menge der Logik in eine Funktion verschieben.
+Hier kannst du sehen, wie wir sehr aussagekräftig und leicht lesbar 
+schreiben können, indem wir eine Menge der Logik in eine Funktion 
+verschieben.

--- a/etc/doc/tutorial/de/05.6-Variables.md
+++ b/etc/doc/tutorial/de/05.6-Variables.md
@@ -2,13 +2,18 @@
 
 # Variablen
 
-Es ist sehr nützlich beim Coden, Namen für Dinge zu vergeben. Sonic Pi macht es dir hier sehr leicht: schreib' einfach den Namen, den du gerne verwenden möchtest, dann ein Gleichheitszeichen (`=`) und dann das Ding, welches du dir merken möchtest.
+Es ist sehr nützlich beim Coden, Namen für Dinge zu vergeben. Sonic Pi 
+macht es dir hier sehr leicht: schreib' einfach den Namen, den du gerne 
+verwenden möchtest, dann ein Gleichheitszeichen (`=`) und dann das 
+Ding, welches du dir merken möchtest.
 
 ```
 sample_name = :loop_amen
 ```
 
-Hier haben wir uns das Symbol `:loop_amen` mit der Variable `sample_name` *gemerkt*. Wir können nun `sample_name` überall da benutzen, wo wir auch `loop_amen` benutzen könnten. Zum Beispiel:
+Hier haben wir uns das Symbol `:loop_amen` mit der Variable 
+`sample_name` *gemerkt*. Wir können nun `sample_name` überall da 
+benutzen, wo wir auch `loop_amen` benutzen könnten. Zum Beispiel:
 
 
 ```
@@ -16,36 +21,53 @@ sample_name = :loop_amen
 sample sample_name
 ```
 
-Es gibt drei Hauptgründe, Variablen in Sonic Pi zu nutzen: Bedeutung vermitteln, Wiederholung steuern und Ergebnisse von Dingen speichern:
+Es gibt drei Hauptgründe, Variablen in Sonic Pi zu nutzen: Bedeutung 
+vermitteln, Wiederholung steuern und Ergebnisse von Dingen speichern:
 
 ## Bedeutung vermitteln
 
-Wenn du Code schreibst, könnest du denken, dass du einfach nur dem Computer sagst, was er tun soll - solange der Computer das versteht, ist es okay. Es ist jedoch wichtig daran zu denken, dass nicht nur der Computer den Code liest. Andere Leute könnten den Code auch lesen und versuchen zu verstehen, was da vor sich geht. Wahrscheinlich wirst du den Code auch später selbst wieder lesen und möchtest verstehen, was er bedeutet. Obwohl dir jetzt vielleicht alles offensichtlich erscheint - wahrscheinlich ist es für andere nicht ganz so offensichtlich und vielleicht nicht einmal für dich in der Zukunft!
+Wenn du Code schreibst, könnest du denken, dass du einfach nur dem 
+Computer sagst, was er tun soll - solange der Computer das versteht, 
+ist es okay. Es ist jedoch wichtig daran zu denken, dass nicht nur der 
+Computer den Code liest. Andere Leute könnten den Code auch lesen und 
+versuchen zu verstehen, was da vor sich geht. Wahrscheinlich wirst du 
+den Code auch später selbst wieder lesen und möchtest verstehen, was er 
+bedeutet. Obwohl dir jetzt vielleicht alles offensichtlich erscheint - 
+wahrscheinlich ist es für andere nicht ganz so offensichtlich und 
+vielleicht nicht einmal für dich in der Zukunft!
 
-Kommentare sind eine Möglichkeit, anderen dabei zu helfen, deinen Code zu verstehen. Weiterhin kannst du sinnvolle Variablennamen verwenden. Sie dir diesen Code an:
+Kommentare sind eine Möglichkeit, anderen dabei zu helfen, deinen Code 
+zu verstehen. Weiterhin kannst du sinnvolle Variablennamen verwenden. 
+Sie dir diesen Code an:
 
 ```
 sleep 1.7533
 ```
 
-Warum steht hier die Zahl `1.7533`. Woher kommt diese Zahl? Was bedeutet sie? Sieh dir zum Vergleich diesen Code an:
+Warum steht hier die Zahl `1.7533`. Woher kommt diese Zahl? Was 
+bedeutet sie? Sieh dir zum Vergleich diesen Code an:
 
 ```
 loop_amen_duration = 1.7533
 sleep loop_amen_duration
 ```
 
-Aha, jetzt ist viel klarer, was `1.7533` bedeutet: Es ist die Dauer des Sample `loop_amen`! Natürlich kannst du jetzt sagen, warum nicht einfach schreiben:
+Aha, jetzt ist viel klarer, was `1.7533` bedeutet: Es ist die Dauer des 
+Sample `loop_amen`! Natürlich kannst du jetzt sagen, warum nicht 
+einfach schreiben:
 
 ```
 sleep sample_duration(:loop_amen)
 ```
 
-Das ist natürlich auch ein sehr guter Weg, die Absicht mitzuteilen, die hinter dem Code steht.
+Das ist natürlich auch ein sehr guter Weg, die Absicht mitzuteilen, die 
+hinter dem Code steht.
 
 ## Wiederholungen steuern
 
-Oftmals begegnest du in deinem Code vielen Wiederholungen, und wenn du irgendwo etwas ändern willst, musst du das an vielen Stellen tun. Schau dir mal diesen Code an:
+Oftmals begegnest du in deinem Code vielen Wiederholungen, und wenn du 
+irgendwo etwas ändern willst, musst du das an vielen Stellen tun. Schau 
+dir mal diesen Code an:
 
 ```
 sample :loop_amen
@@ -56,7 +78,13 @@ sample :loop_amen
 sleep sample_duration(:loop_amen)
 ```
 
-Hier machen wir eine ganze Menge mit dem `:loop_amen`! Was wäre, wenn du das Ganze mit einem anderen Loop-Sample wie zum Beispiel `:loop_garzul` hören wollten? Wir müssten alle `:loop_amen` suchen und mit `:loop_garzul` ersetzen. Das mag in Ordnung sein, wenn du viel Zeit hast - aber was, wenn du gerade auf einer Bühne stehst? Manchmal hast du nicht den Luxus, Zeit zu haben - vor allem dann nicht, wenn du willst, dass die Leute weitertanzen.
+Hier machen wir eine ganze Menge mit dem `:loop_amen`! Was wäre, wenn 
+du das Ganze mit einem anderen Loop-Sample wie zum Beispiel 
+`:loop_garzul` hören wollten? Wir müssten alle `:loop_amen` suchen und 
+mit `:loop_garzul` ersetzen. Das mag in Ordnung sein, wenn du viel Zeit 
+hast - aber was, wenn du gerade auf einer Bühne stehst? Manchmal hast 
+du nicht den Luxus, Zeit zu haben - vor allem dann nicht, wenn du 
+willst, dass die Leute weitertanzen.
 
 Was wäre, wenn du den Code so geschrieben hättest:
 
@@ -70,25 +98,34 @@ sample sample_name
 sleep sample_duration(sample_name)
 ```
 
-Das tut genau dasselbe wie der Code weiter oben (probier's aus). Außerdem bekommen wir die Möglichkeit, durch die Änderung der einen Zeile `sample_name = :loop_amen` in `sample_name = :loop_garzul` die vielen anderen Stellen durch die Magie der Variablen zu verändern.
+Das tut genau dasselbe wie der Code weiter oben (probier's aus). 
+Außerdem bekommen wir die Möglichkeit, durch die Änderung der einen 
+Zeile `sample_name = :loop_amen` in `sample_name = :loop_garzul` die 
+vielen anderen Stellen durch die Magie der Variablen zu verändern.
 
 ## Ergebnisse von Dingen speichern
 
-Wenn man schließlich die Ergebnisse von irgendwelchen Dingen speichern möchte, dann ist das ebenfalls ein guter Grund dafür, Variablen zu verwenden. Du möchtest vielleicht irgendetwas mit der Dauer eines Sample anstellen:
+Wenn man schließlich die Ergebnisse von irgendwelchen Dingen speichern 
+möchte, dann ist das ebenfalls ein guter Grund dafür, Variablen zu 
+verwenden. Du möchtest vielleicht irgendetwas mit der Dauer eines 
+Sample anstellen:
 
 ```
 sd = sample_duration(:loop_amen)
 ```
 
-Wir können nun `sd` überall da einsetzen, wo wir die Länge von `:loop_amen` brauchen.
+Wir können nun `sd` überall da einsetzen, wo wir die Länge von 
+`:loop_amen` brauchen.
 
-Noch wichtiger vielleicht: Eine Variable erlaubt es uns das Ergebnis eines Aufrufs von `play` oder `sample` zu speichern:
+Noch wichtiger vielleicht: Eine Variable erlaubt es uns das Ergebnis 
+eines Aufrufs von `play` oder `sample` zu speichern:
 
 ```
 s = play 50, release: 8
 ```
 
-Jetzt haben wir `s` als Variable eingefangen und gemerkt, und das erlaubt es uns einen Synth zu steuern, während er läuft:
+Jetzt haben wir `s` als Variable eingefangen und gemerkt, und das 
+erlaubt es uns einen Synth zu steuern, während er läuft:
 
 ```
 s = play 50, release: 8

--- a/etc/doc/tutorial/de/05.7-Thread-Synchronisation.md
+++ b/etc/doc/tutorial/de/05.7-Thread-Synchronisation.md
@@ -2,21 +2,44 @@
 
 # Synchronisation von Threads
 
-Wenn du einmal genügend vertraut damit bist, live mit einer Anzahl von gleichzeitig ablaufenden Funktionen und Threads zu coden, wirst du bemerken, dass es ziemlich leicht ist, innerhalb eines Threads einen Fehler zu machen, der diesen abbricht. Das ist nicht weiter schlimm, da du den Thread ja einfach neu starten kannst, indem du Ausführen klickst. Wenn du den Thread aber neu startest, dann läuft er nicht mehr zusammen mit den anderen so wie vorher, er ist nun *aus dem Takt* mit den ursprünglichen Threads.
+Wenn du einmal genügend vertraut damit bist, live mit einer Anzahl von 
+gleichzeitig ablaufenden Funktionen und Threads zu coden, wirst du 
+bemerken, dass es ziemlich leicht ist, innerhalb eines Threads einen 
+Fehler zu machen, der diesen abbricht. Das ist nicht weiter schlimm, da 
+du den Thread ja einfach neu starten kannst, indem du Ausführen 
+klickst. Wenn du den Thread aber neu startest, dann läuft er nicht mehr 
+zusammen mit den anderen so wie vorher, er ist nun *aus dem Takt* mit 
+den ursprünglichen Threads.
 
 ## Vererbte Zeit
 
-Wir haben vorher darüber gesprochen, dass neue Threads, die mit `in_thread` erzeugt werden, alle ihre Einstellungen vom Eltern-Thread erben. Das schließt auch die aktuelle Zeit mit ein. Das bedeutet, dass Threads immer miteinander im Takt sind, wenn sie gleichzeitig gestartet werden.
+Wir haben vorher darüber gesprochen, dass neue Threads, die mit 
+`in_thread` erzeugt werden, alle ihre Einstellungen vom Eltern-Thread 
+erben. Das schließt auch die aktuelle Zeit mit ein. Das bedeutet, dass 
+Threads immer miteinander im Takt sind, wenn sie gleichzeitig gestartet 
+werden.
 
-Wenn du aber einen Thread alleine startest, spielt er in seinem eigenen Takt, der höchstwahrscheinlich nicht mit irgendeinem der anderen laufenden Threads zusammenpasst.
+Wenn du aber einen Thread alleine startest, spielt er in seinem eigenen 
+Takt, der höchstwahrscheinlich nicht mit irgendeinem der anderen 
+laufenden Threads zusammenpasst.
 
 ## Cue und Sync
 
-Sonic Pi hat mit den Funktionen `cue` und `sync` eine Lösung für dieses Problem.
+Sonic Pi hat mit den Funktionen `cue` und `sync` eine Lösung für dieses 
+Problem.
 
-`cue` erlaubt es uns, an alle anderen Threads mit einem Taktgeber regelmäßige Signale zu versenden. Standardmäßig sind die anderen Threads an solchen Signale nicht interessiert und werden sie ignorieren. Mit der `sync`-Funktion kann man jedoch erreichen, dass ein anderer Thread sich für den Taktgeber interessiert.
+`cue` erlaubt es uns, an alle anderen Threads mit einem Taktgeber 
+regelmäßige Signale zu versenden. Standardmäßig sind die anderen 
+Threads an solchen Signale nicht interessiert und werden sie 
+ignorieren. Mit der `sync`-Funktion kann man jedoch erreichen, dass ein 
+anderer Thread sich für den Taktgeber interessiert.
 
-Eine wichtige Sache, deren man sich bewusst sein sollte: `sync` ist so ähnlich `sleep`, weil es den aktuellen Thread für eine bestimmte Zeit abstopped und er nichts tut. Allerdings sagt man mit `sleep`, wie lange man warten möchte, während man bei `sync` nicht weiss, wie lange gewartet wird - denn `sync` wartet auf das nächste `cue` eines anderen Threads; das kann kürzer oder länger dauern.
+Eine wichtige Sache, deren man sich bewusst sein sollte: `sync` ist so 
+ähnlich `sleep`, weil es den aktuellen Thread für eine bestimmte Zeit 
+abstopped und er nichts tut. Allerdings sagt man mit `sleep`, wie lange 
+man warten möchte, während man bei `sync` nicht weiss, wie lange 
+gewartet wird - denn `sync` wartet auf das nächste `cue` eines anderen 
+Threads; das kann kürzer oder länger dauern.
 
 Sehen wir uns das etwas genauer an:
 
@@ -37,9 +60,15 @@ in_thread do
 end
 ```
 
-Hier haben wir zwei Threads - einer davon arbeitet wie ein Metronom; er spielt nichts, aber sendet jede Sekunde ein `:tick`-Taktgebersignal. Der zweite Thread synchronisiert sich mit den `tick`-Signalen, und wenn er eins davon erhält, übernimmt er die Zeit vom `cue`-Thread und läuft weiter.
+Hier haben wir zwei Threads - einer davon arbeitet wie ein Metronom; er 
+spielt nichts, aber sendet jede Sekunde ein `:tick`-Taktgebersignal. 
+Der zweite Thread synchronisiert sich mit den `tick`-Signalen, und wenn 
+er eins davon erhält, übernimmt er die Zeit vom `cue`-Thread und läuft 
+weiter.
 
-Als Ergebnis hören wir den `:drum_heavy_kick` Sample genau dann, wenn der andere Thread ein `:tick`-Signal sendet, auch dann, wenn beide Threads gar nicht zur selben Zeit gestartet wurden.
+Als Ergebnis hören wir den `:drum_heavy_kick` Sample genau dann, wenn 
+der andere Thread ein `:tick`-Signal sendet, auch dann, wenn beide 
+Threads gar nicht zur selben Zeit gestartet wurden.
 
 ```
 in_thread do
@@ -59,11 +88,18 @@ in_thread do
 end
 ```
 
-Dieser freche (zweite) Aufruf von `sleep` würde eigentlich den zweiten Thread gegenüber dem ersten aus dem Takt bringen. Weil wir aber `cue` und `sync` verwenden, synchronisieren wir beide Threads automatisch und umgehen dabei, dass beide in der Zeit auseinanderfallen.
+Dieser freche (zweite) Aufruf von `sleep` würde eigentlich den zweiten 
+Thread gegenüber dem ersten aus dem Takt bringen. Weil wir aber `cue` 
+und `sync` verwenden, synchronisieren wir beide Threads automatisch und 
+umgehen dabei, dass beide in der Zeit auseinanderfallen.
 
 ## Cue benennen
 
-Du kannst `cue`-Signale benennen, wie du willst - nicht nur mit `:tick`. Du musst nur sicherstellen, dass irgendein anderer Thread sich mit eben diesem Namen synchronisiert - ansonsten wartet der zweite Thread dann für immer (oder jedenfalls bis du den Stopp-Button klickst).
+Du kannst `cue`-Signale benennen, wie du willst - nicht nur mit 
+`:tick`. Du musst nur sicherstellen, dass irgendein anderer Thread sich 
+mit eben diesem Namen synchronisiert - ansonsten wartet der zweite 
+Thread dann für immer (oder jedenfalls bis du den Stopp-Button 
+klickst).
 
 Lasst uns ein paar Namen für `cue` ausprobieren:
 
@@ -97,6 +133,14 @@ in_thread do
 end
 ```
 
-Hier haben wir eine `cue`-Hauptschleife, die auf Zufallsbasis einen von drei Namen des Taktgebers `:foo`, `:bar` oder `:baz` aussendet. Wir haben auch drei Schleifen-Threads, die jeder für sich mit einem der Namen synchronisiert werden und dann jeweils einen anderen Sample spielen. Im Endeffekt hören wir alle 0.5 Sekunden einen Klang, da jeder der `synch`-Threads auf Zufallsbasis mit dem `cue`-Thread synchronisiert ist, und sein Sample spielt, wenn er dran ist.
+Hier haben wir eine `cue`-Hauptschleife, die auf Zufallsbasis einen von 
+drei Namen des Taktgebers `:foo`, `:bar` oder `:baz` aussendet. Wir 
+haben auch drei Schleifen-Threads, die jeder für sich mit einem der 
+Namen synchronisiert werden und dann jeweils einen anderen Sample 
+spielen. Im Endeffekt hören wir alle 0.5 Sekunden einen Klang, da jeder 
+der `synch`-Threads auf Zufallsbasis mit dem `cue`-Thread 
+synchronisiert ist, und sein Sample spielt, wenn er dran ist.
 
-Das funktioniert natürlich auch, wenn du Reihenfolge der Threads umkehrst, weil die `sync`-Threads einfach dasitzen und auf ihren nächsten `cue` warten.
+Das funktioniert natürlich auch, wenn du Reihenfolge der Threads 
+umkehrst, weil die `sync`-Threads einfach dasitzen und auf ihren 
+nächsten `cue` warten.

--- a/etc/doc/tutorial/de/06-FX.md
+++ b/etc/doc/tutorial/de/06-FX.md
@@ -2,14 +2,47 @@
 
 # Studio Klangeffekte
 
-Eine der lohnendsten und spannendsten Dimensionen von Sonic Pi besteht darin, dass du sehr leicht Effekte in deine Klänge einbauen kannst. Zum Beispiel kannst du zu Teilen deiner Komposition Hall ('reverb') Effekte hinzufügen, oder etwas Echo ('echo'), oder vielleicht möchtest du deine Bassmelodien verzerren ('distortion') oder schwabbeln lassen ('wobble').
+Eine der lohnendsten und spannendsten Dimensionen von Sonic Pi besteht 
+darin, dass du sehr leicht Effekte in deine Klänge einbauen kannst. Zum 
+Beispiel kannst du zu Teilen deiner Komposition Hall ('reverb') Effekte 
+hinzufügen, oder etwas Echo ('echo'), oder vielleicht möchtest du deine 
+Bassmelodien verzerren ('distortion') oder schwabbeln lassen 
+('wobble').
 
-Sonic Pi bietet dir sehr einfache, aber zugleich sehr kraftvolle Möglichkeiten, mit Klangeffekten zu arbeiten. Du kannst sie sogar miteinander verketten oder sie ineinander verschachteln (zum Beispiel könntest du einen Ton zuerst verzerren, dann Echo hinzufügen, und zum Schluss noch etwas Hall). Jede individuelle Effekteinheit lässt sich mit Parametern steuern (ganz ähnlich, wie sich auch Synths und Samples steuern lassen). Du kannst sogar die Parameter eines Klangeffektes ändern während der Effekt läuft. Zum Beispiel könntest du den Halleffekt deiner Bassmelodie im Verlauf des ganzen Stückes langsam anheben.
+Sonic Pi bietet dir sehr einfache, aber zugleich sehr kraftvolle 
+Möglichkeiten, mit Klangeffekten zu arbeiten. Du kannst sie sogar 
+miteinander verketten oder sie ineinander verschachteln (zum Beispiel 
+könntest du einen Ton zuerst verzerren, dann Echo hinzufügen, und zum 
+Schluss noch etwas Hall). Jede individuelle Effekteinheit lässt sich 
+mit Parametern steuern (ganz ähnlich, wie sich auch Synths und Samples 
+steuern lassen). Du kannst sogar die Parameter eines Klangeffektes 
+ändern während der Effekt läuft. Zum Beispiel könntest du den 
+Halleffekt deiner Bassmelodie im Verlauf des ganzen Stückes langsam 
+anheben.
 
 ## Gitarreneffekte
 
-Wenn sich das alles etwas kompliziert anhören sollte – keine Sorge! Wenn du einmal ein bisschen mit Effekten herumgespielt hast, wird dir schon alles viel einfacher vorkommen. Bevor du loslegst, könnte dieser kleine Vergleich nützlich sein: Sonic Pi Effekte funktionieren so ähnlich wie Gitarreneffektpedalen. Es gibt eine Vielzahl von solchen Effektpedalen zu kaufen. Manche Gitarristen benutzen gerne Halleffekte ('reverb'), andere bevorsugen ein Verzerrerpedal ('distortion'), etc. Als Gitarrist kann man einfach seine Gitarre bei einem Effektpedal anstecken – z.B. 'distortion' – und dann mit einem weiteren Kabel noch ein Hallpedal anhängen, um so eine Kette von Effekten zu erzeugen. Das Ausgangssignal des Halleffektpedals kann dann in einen Verstärker geleitet werden: Gitarre -> Verzerrer -> Hall -> Verstärker
+Wenn sich das alles etwas kompliziert anhören sollte – keine Sorge! 
+Wenn du einmal ein bisschen mit Effekten herumgespielt hast, wird dir 
+schon alles viel einfacher vorkommen. Bevor du loslegst, könnte dieser 
+kleine Vergleich nützlich sein: Sonic Pi Effekte funktionieren so 
+ähnlich wie Gitarreneffektpedalen. Es gibt eine Vielzahl von solchen 
+Effektpedalen zu kaufen. Manche Gitarristen benutzen gerne Halleffekte 
+('reverb'), andere bevorsugen ein Verzerrerpedal ('distortion'), etc. 
+Als Gitarrist kann man einfach seine Gitarre bei einem Effektpedal 
+anstecken – z.B. 'distortion' – und dann mit einem weiteren Kabel noch 
+ein Hallpedal anhängen, um so eine Kette von Effekten zu erzeugen. Das 
+Ausgangssignal des Halleffektpedals kann dann in einen Verstärker 
+geleitet werden: Gitarre -> Verzerrer -> Hall -> Verstärker
 
-Man nennt diese Vorgehensweise 'Effektverkettung.' Sonic Pi ermöglicht dir, solche Verkettungen zu erzeugen. Jedes Effektpedal hat normalerweise einige Drehknöpfe und Schalter, mit denen man genau steuern kann, wieviel Verzerrung, Hall, oder Echo erzeugt werden soll. Und eines noch zum Schluss: Du kannst dir sicher vorstellen, dass ein Gitarisst mit Gitarrespielen beschäftigt sein könnte, während jemand anderes die Effekte steuert. Das ist auch bei Sonic Pi möglich – aber anstatt auf jemand anderen dafür angewiesen zu sein, deine Effekte zu verketten und zu steuern, wird dir hierbei der Computer aushelfen.
+Man nennt diese Vorgehensweise 'Effektverkettung.' Sonic Pi ermöglicht 
+dir, solche Verkettungen zu erzeugen. Jedes Effektpedal hat 
+normalerweise einige Drehknöpfe und Schalter, mit denen man genau 
+steuern kann, wieviel Verzerrung, Hall, oder Echo erzeugt werden soll. 
+Und eines noch zum Schluss: Du kannst dir sicher vorstellen, dass ein 
+Gitarisst mit Gitarrespielen beschäftigt sein könnte, während jemand 
+anderes die Effekte steuert. Das ist auch bei Sonic Pi möglich – aber 
+anstatt auf jemand anderen dafür angewiesen zu sein, deine Effekte zu 
+verketten und zu steuern, wird dir hierbei der Computer aushelfen.
 
 Aber jetzt ist es höchste Zeit, die Effektfunktionen auszuprobieren!

--- a/etc/doc/tutorial/de/06.1-Adding-FX.md
+++ b/etc/doc/tutorial/de/06.1-Adding-FX.md
@@ -2,13 +2,19 @@
 
 # FX hinzufügen
 
-In diesem Abschnitt sehen wir uns zwei Effekte genauer an: Hall ('reverb') und Echo ('echo'). Wir werden lernen wie diese Effekte zu benutzen sind, wie man ihre Parameter steuern kann, und wie man sie verketten kann.
+In diesem Abschnitt sehen wir uns zwei Effekte genauer an: Hall 
+('reverb') und Echo ('echo'). Wir werden lernen wie diese Effekte zu 
+benutzen sind, wie man ihre Parameter steuern kann, und wie man sie 
+verketten kann.
 
-Das Sonic Pi FX System benutzt sogenannte Codeblöcke. Falls du Abschnitt 5.1 des Tutorials noch nicht gelesen hast, sieh es dir doch kurz an und komm dann hierher zurück.
+Das Sonic Pi FX System benutzt sogenannte Codeblöcke. Falls du 
+Abschnitt 5.1 des Tutorials noch nicht gelesen hast, sieh es dir doch 
+kurz an und komm dann hierher zurück.
 
 ## Hall ('reverb') 
 
-Um den Hall-Effekt zu benutzen, fügen wir with_fx :reverb als Spezialcode zu unserem bestehenden Codeblock hinzu, und zwar so:
+Um den Hall-Effekt zu benutzen, fügen wir with_fx :reverb als 
+Spezialcode zu unserem bestehenden Codeblock hinzu, und zwar so:
 
 ```
 with_fx :reverb do
@@ -20,9 +26,12 @@ with_fx :reverb do
 end
 ```
 
-Wenn du nun diesen Codeblock abspielst, wirst du hören, dass der Hall-Effekt hinzugefügt wurde. Hört sich gut an, nicht wahr! Mit Hall-Effekt hört sich alles immer ziemlich gut an.
+Wenn du nun diesen Codeblock abspielst, wirst du hören, dass der 
+Hall-Effekt hinzugefügt wurde. Hört sich gut an, nicht wahr! Mit 
+Hall-Effekt hört sich alles immer ziemlich gut an.
 
-Sehen wir uns jetzt an, was passiert, wenn wir den Code ausserhalb des do/end Codeblocks hinzufügen:
+Sehen wir uns jetzt an, was passiert, wenn wir den Code ausserhalb des 
+do/end Codeblocks hinzufügen:
 
 ```
 with_fx :reverb do
@@ -37,9 +46,13 @@ sleep 1
 play 55
 ```
 
-Wie du sicher bemerkt hast, wird nun die letzte Note (55) nicht mehr mit Hall-Effekt abgespielt. Der Grund dafür ist, dass sich die Note ausserhalb des do/end Codeblocks befindet, und deshalb unsere Hall-Effekt Anweisungen nicht auf sie zutreffen.
+Wie du sicher bemerkt hast, wird nun die letzte Note (55) nicht mehr 
+mit Hall-Effekt abgespielt. Der Grund dafür ist, dass sich die Note 
+ausserhalb des do/end Codeblocks befindet, und deshalb unsere 
+Hall-Effekt Anweisungen nicht auf sie zutreffen.
 
-Wenn du Noten vor dem do/end Codeblock einfügst, verhält es sich ganz ähnlich, und sie werden ebenfalls ohne Hall-Effekt abgespielt:
+Wenn du Noten vor dem do/end Codeblock einfügst, verhält es sich ganz 
+ähnlich, und sie werden ebenfalls ohne Hall-Effekt abgespielt:
 
 ```
 play 55
@@ -59,7 +72,8 @@ play 55
 
 ## Echo
 
-Es stehen noch viele weitere FX zur Auswahl. Wie wäre es zum Beispiel mit etwas Echo?
+Es stehen noch viele weitere FX zur Auswahl. Wie wäre es zum Beispiel 
+mit etwas Echo?
 
 ```
 with_fx :echo do
@@ -71,7 +85,11 @@ with_fx :echo do
 end
 ```
 
-Die Sonic Pi FX Blocks sind besonders vielfältig einsetzbar weil sie über Parameter steuerbar sind, genauso wie die 'play' und 'sample' Befehle, die wir ja schon kennen. Ein spannender Echo Parameter ist zum Beispiel 'phase': dieser Parameter stellt die Dauer des Echos in Sekunden dar. Versuchen wir, das Echo etwas langsamer zu machen:
+Die Sonic Pi FX Blocks sind besonders vielfältig einsetzbar weil sie 
+über Parameter steuerbar sind, genauso wie die 'play' und 'sample' 
+Befehle, die wir ja schon kennen. Ein spannender Echo Parameter ist zum 
+Beispiel 'phase': dieser Parameter stellt die Dauer des Echos in 
+Sekunden dar. Versuchen wir, das Echo etwas langsamer zu machen:
 
 ```
 with_fx :echo, phase: 0.5 do
@@ -95,7 +113,8 @@ with_fx :echo, phase: 0.125 do
 end
 ```
 
-Wie wäre es nun mit einem Echo, welches viel langsamer ausschwingt? Wir können dafür einfach den 'decay' Wert auf 8 Sekunden verlängern:
+Wie wäre es nun mit einem Echo, welches viel langsamer ausschwingt? Wir 
+können dafür einfach den 'decay' Wert auf 8 Sekunden verlängern:
 
 ```
 with_fx :echo, phase: 0.5, decay: 8 do
@@ -109,7 +128,11 @@ end
 
 ## FX verschachteln
 
-Einer der interessantesten Aspekte der FX Blöcke ist die Möglichkeit, sie ineinander zu verschachteln. So können eine Vielzahl verschiedener FX leicht verkettet werden. Wie wäre es zum Beispiel damit, einen Codeblock zuerst mit Echo und dann mit Hall zu versehen? Das geht ganz einfach, indem die beiden Codeblöce ineinander verschachtelt werden:
+Einer der interessantesten Aspekte der FX Blöcke ist die Möglichkeit, 
+sie ineinander zu verschachteln. So können eine Vielzahl verschiedener 
+FX leicht verkettet werden. Wie wäre es zum Beispiel damit, einen 
+Codeblock zuerst mit Echo und dann mit Hall zu versehen? Das geht ganz 
+einfach, indem die beiden Codeblöce ineinander verschachtelt werden:
 
 ```
 with_fx :reverb do
@@ -123,18 +146,29 @@ with_fx :reverb do
 end
 ```
 
-Stell dir das so vor, als ob die erzeugten Klänge von innen nach aussen fliessen würden. Der erzeugte Klang des innersten do/end Codeblocks (zum Beispiel 'play 50') wird zuerst durch den Echo FX Block gesendet, und danach noch durch den Hall FX Block.
+Stell dir das so vor, als ob die erzeugten Klänge von innen nach aussen 
+fliessen würden. Der erzeugte Klang des innersten do/end Codeblocks 
+(zum Beispiel 'play 50') wird zuerst durch den Echo FX Block gesendet, 
+und danach noch durch den Hall FX Block.
 
-Es ist ganz einfach, mit vielschichtigen Verschachtelungen verrückte Ergebnisse zu erzielen. Aber sei vorsichtig, weil FX viele Rechenkapazitäten verbrauchen, besonders dann, wenn du mehrere FX zugleich benutzt. Sei also etwas sparsam mit deinen FX, wenn du mit kapazitätsarmen Geräten wie dem Raspberry Pi arbeitest.
+Es ist ganz einfach, mit vielschichtigen Verschachtelungen verrückte 
+Ergebnisse zu erzielen. Aber sei vorsichtig, weil FX viele 
+Rechenkapazitäten verbrauchen, besonders dann, wenn du mehrere FX 
+zugleich benutzt. Sei also etwas sparsam mit deinen FX, wenn du mit 
+kapazitätsarmen Geräten wie dem Raspberry Pi arbeitest.
 
 ## Weitere FX entdecken
 
-Sonic Pi hat eine Vielzahl an FX vorinstalliert, die du ausprobieren kannst. Um herauszufinden, welche verfügbar sind, klicke auf 'FX' auf der linken Seite des Hilfe-Fensters, dort wirst du die komplette Liste verfügbarer Optionen entdecken. Hier sind einige meiner Favoriten:
+Sonic Pi hat eine Vielzahl an FX vorinstalliert, die du ausprobieren 
+kannst. Um herauszufinden, welche verfügbar sind, klicke auf 'FX' auf 
+der linken Seite des Hilfe-Fensters, dort wirst du die komplette Liste 
+verfügbarer Optionen entdecken. Hier sind einige meiner Favoriten:
 
-• wobble
-• reverb
-• echo
-• distortion
-• slicer
+* wobble
+* reverb
+* echo
+* distortion
+* slicer
 
-Jetzt aber los, mach was verücktes und baue überall in deinem Code FX ein um unglaubliche neue Klänge zu erzeugen!
+Jetzt aber los, mach was verücktes und baue überall in deinem Code FX 
+ein um unglaubliche neue Klänge zu erzeugen!

--- a/etc/doc/tutorial/de/06.2-FX-in-Practice.md
+++ b/etc/doc/tutorial/de/06.2-FX-in-Practice.md
@@ -2,7 +2,14 @@
 
 # FX Praxis
 
-Die Sonic Pi FX mögen auf den ersten Blick sehr einfach aussehen, aber in Wirklichkeit sind sie höchst komplexe Gebilde. Ihre scheinbare Einfachheit verleitet viele Benutzer dazu, zu viele FX in ihre Projekte einzubauen. Das kann durchaus Spass machen, wenn du über einen sehr starken Computer verfügst, aber falls du – so wie ich – einen einfachen Raspberry Pi zum Musikmachen benutzt, dann solltest du darauf achten, die Maschine nicht zu überlasten. Nur so kannst du sicher gehen, dass Sonic Pi ordentlich funktioniert und im Takt bleibt.
+Die Sonic Pi FX mögen auf den ersten Blick sehr einfach aussehen, aber 
+in Wirklichkeit sind sie höchst komplexe Gebilde. Ihre scheinbare 
+Einfachheit verleitet viele Benutzer dazu, zu viele FX in ihre Projekte 
+einzubauen. Das kann durchaus Spass machen, wenn du über einen sehr 
+starken Computer verfügst, aber falls du – so wie ich – einen einfachen 
+Raspberry Pi zum Musikmachen benutzt, dann solltest du darauf achten, 
+die Maschine nicht zu überlasten. Nur so kannst du sicher gehen, dass 
+Sonic Pi ordentlich funktioniert und im Takt bleibt.
 
 Sie dir den folgenden Code an:
 
@@ -15,11 +22,28 @@ loop do
 end
 ```
 
-Hier spielen wir die Note 60 mit sehr kurzem 'release' Wert, und erzeugen so einen sehr kurzen Ton. Wir wollen ausserdem einen Hall-Effekt, und haben deshalb den notewending Codeblock integriert. Soweit sieht alles gut aus. Oder doch nicht?
+Hier spielen wir die Note 60 mit sehr kurzem 'release' Wert, und 
+erzeugen so einen sehr kurzen Ton. Wir wollen ausserdem einen 
+Hall-Effekt, und haben deshalb den notewending Codeblock integriert. 
+Soweit sieht alles gut aus. Oder doch nicht?
 
-Sehen wir uns genauer an, was der Code hier macht. Zuerst einmal haben wir einen Loop, und wie wir ja schon wissen wird alles, das innerhalb des Loops geschrieben ist, für immer und ewig wiederholt. Ausserdem haben wir einen with_fx do/end Codeblock. Das bedeutet, das bei jeder Wiederholung des Loops ein neuer Hall-Effekt erzeugt wird. Das ist so, als ob wir jedesmal, wenn wir eine Gitarrenseite zupfen, ein neues Effektpedal benutzen würden. Es ist ja ganz nett, das wir das machen können, aber es ist möglicherweise nicht genau das, was wir eigentlich wollen. Ein Raspberry Pi, zum Beispiel, wird an diesem Code schwer zu arbeiten haben. Die with_fx Funktion erledigt die ganze Arbeit, bei jeder Wiederholung des Loops den Hall-Effekt zu erzeugen, dann zu warten, und dann den Effekt wieder zu entfernen, aber insgesamt werden dabei wertvolle CPU Ressourcen verbraucht.
+Sehen wir uns genauer an, was der Code hier macht. Zuerst einmal haben 
+wir einen Loop, und wie wir ja schon wissen wird alles, das innerhalb 
+des Loops geschrieben ist, für immer und ewig wiederholt. Ausserdem 
+haben wir einen with_fx do/end Codeblock. Das bedeutet, das bei jeder 
+Wiederholung des Loops ein neuer Hall-Effekt erzeugt wird. Das ist so, 
+als ob wir jedesmal, wenn wir eine Gitarrenseite zupfen, ein neues 
+Effektpedal benutzen würden. Es ist ja ganz nett, das wir das machen 
+können, aber es ist möglicherweise nicht genau das, was wir eigentlich 
+wollen. Ein Raspberry Pi, zum Beispiel, wird an diesem Code schwer zu 
+arbeiten haben. Die with_fx Funktion erledigt die ganze Arbeit, bei 
+jeder Wiederholung des Loops den Hall-Effekt zu erzeugen, dann zu 
+warten, und dann den Effekt wieder zu entfernen, aber insgesamt werden 
+dabei wertvolle CPU Ressourcen verbraucht.
 
-Wie können wir einen ähnlichen Codeblock schreiben, in dem unser Gitarrist nur ein Hall-Effektpedal zur Klangerzeugung benutzt? Ganz einfach:
+Wie können wir einen ähnlichen Codeblock schreiben, in dem unser 
+Gitarrist nur ein Hall-Effektpedal zur Klangerzeugung benutzt? Ganz 
+einfach:
 
 ```
 with_fx :reverb do
@@ -30,9 +54,13 @@ with_fx :reverb do
 end
 ```
 
-Nun haben wir unseren Loop im Inneren des with_fx Codeblocks verpackt. Dadurch wird nur ein einziger Hall-Effekt erzeugt, der auf alle Noten im Loop angewandt wird. Dieser Codeblock ist viel effizienter, und wird auf jedem Raspberry Pi gut funktionieren.
+Nun haben wir unseren Loop im Inneren des with_fx Codeblocks verpackt. 
+Dadurch wird nur ein einziger Hall-Effekt erzeugt, der auf alle Noten 
+im Loop angewandt wird. Dieser Codeblock ist viel effizienter, und wird 
+auf jedem Raspberry Pi gut funktionieren.
 
-Als Kompromiss könnten wir with_fx auch als 'iteration' innerhalb eines Loops schreiben:
+Als Kompromiss könnten wir with_fx auch als 'iteration' innerhalb eines 
+Loops schreiben:
 
 ```
 loop do
@@ -45,6 +73,13 @@ loop do
 end
 ```
 
-Somit wir die with_fx Funktion aus dem inneren des Loops geholt, und erzeugen jetzt nur mehr einen Hall-Effekt pro 16 Noten.
+Somit wir die with_fx Funktion aus dem inneren des Loops geholt, und 
+erzeugen jetzt nur mehr einen Hall-Effekt pro 16 Noten.
 
-Denk daran, man kann nichts falsch machen, dafür aber unendlich viele Varianten ausprobieren! Jede dieser Varianten wird sich jedoch ein bisschen anders anhören, und jeweils mehr oder weniger gut funktionieren. Es ist also empfehlenswert, so viel wie möglich zu experimentieren, bis du diejenige Variante gefunden hast, die am besten funktioniert und den Einschränkungen deines Computers am besten gerecht ist.
+Denk daran, man kann nichts falsch machen, dafür aber unendlich viele 
+Varianten ausprobieren! Jede dieser Varianten wird sich jedoch ein 
+bisschen anders anhören, und jeweils mehr oder weniger gut 
+funktionieren. Es ist also empfehlenswert, so viel wie möglich zu 
+experimentieren, bis du diejenige Variante gefunden hast, die am besten 
+funktioniert und den Einschränkungen deines Computers am besten gerecht 
+ist.

--- a/etc/doc/tutorial/de/07-Control.md
+++ b/etc/doc/tutorial/de/07-Control.md
@@ -2,8 +2,13 @@
 
 # Laufende Sounds steuern
 
-Bisher haben wir uns angeschaut, wie man Synthies und Samples starten und man ihre Standardeinstellungen wie Amplitude, Pan, Hüllkurven und so weiter anpassen kann. Jeder abgespielte Ton ist im Grunde genommen ein eigener Klang mit seinen eigenen Parametern für seine Abspieldauer.
+Bisher haben wir uns angeschaut, wie man Synthies und Samples starten 
+und man ihre Standardeinstellungen wie Amplitude, Pan, Hüllkurven und 
+so weiter anpassen kann. Jeder abgespielte Ton ist im Grunde genommen 
+ein eigener Klang mit seinen eigenen Parametern für seine Abspieldauer.
 
-Wäre es nicht cool, wenn man diese Parameter verändern könnte, während der Ton noch abgespielt wird, genauso wie Du eine noch schwingende Saite beim Gitarre spielen benden würdest. 
+Wäre es nicht cool, wenn man diese Parameter verändern könnte, während 
+der Ton noch abgespielt wird, genauso wie Du eine noch schwingende 
+Saite beim Gitarre spielen benden würdest. 
 
 Glück gehabt - in diesem Kapitel werden wir Dir genau das zeigen.

--- a/etc/doc/tutorial/de/07.1-Controlling-Running-Synths.md
+++ b/etc/doc/tutorial/de/07.1-Controlling-Running-Synths.md
@@ -2,15 +2,24 @@
 
 # Laufende Sythies steuern
 
-Bisher haben wir uns nur damit befasst, neue Sounds und Effekte zu starten.
-Sonic Pi gibt uns aber auch die Möglichkeit, laufende Klänge zu steuern und zu verändern. Um das zu tun, speichern wir die Referenz zu einem Synthie in einer Variable: 
+Bisher haben wir uns nur damit befasst, neue Sounds und Effekte zu 
+starten.
+
+Sonic Pi gibt uns aber auch die Möglichkeit, laufende Klänge zu steuern 
+und zu verändern. Um das zu tun, speichern wir die Referenz zu einem 
+Synthie in einer Variable: 
+
 ```
 s = play 60, release: 5
 ```
 
-Jetzt haben wir eine run-local Variable `s`, die den Synthie repräsentiert, der die Note 60 spielt. Beachte, dass diese Variable *run-local* ist - Du kannst nicht von anderen Runs, wie beispielsweise Funktionen, auf sie zugreifen.
+Jetzt haben wir eine run-local Variable `s`, die den Synthie 
+repräsentiert, der die Note 60 spielt. Beachte, dass diese Variable 
+*run-local* ist - Du kannst nicht von anderen Runs, wie beispielsweise 
+Funktionen, auf sie zugreifen.
 
-Sobald wir die Referenz in der Variable `s` haben, können wir den Synthie mit Hilfe der `control`-Funktion steuern:
+Sobald wir die Referenz in der Variable `s` haben, können wir den 
+Synthie mit Hilfe der `control`-Funktion steuern:
 
 ```
 s = play 60, release: 5
@@ -22,11 +31,19 @@ sleep 3
 control s, note: 72
 ```
 
-Wichtig ist hier, dass wir nicht vier verschiedene Synthies starten - wir starten einen einzigen und ändern danach dreimal die Tonhöhe während er noch spielt.
+Wichtig ist hier, dass wir nicht vier verschiedene Synthies starten - 
+wir starten einen einzigen und ändern danach dreimal die Tonhöhe 
+während er noch spielt.
 
-Wir können jeden der Standard-Parameter an die `control`-Funktion übergeben. Das erlaubt Dir, Dinge wie `amp:`, `cutoff:` oder `pan:` zu kontrollieren.
+Wir können jeden der Standard-Parameter an die `control`-Funktion 
+übergeben. Das erlaubt Dir, Dinge wie `amp:`, `cutoff:` oder `pan:` zu 
+kontrollieren.
 
 ## Nicht-kontrollierbare Parameter
 
-Manche Parameter können nicht mehr verändert werden, nachdem der Synthie gestartet wurde. Das trifft auf alle ADSR Hüllkurven-Parameter zu. Welche Parameter kontrollierbar sind, kannst Du in der Dokumentation im Hilfe-System herausfinden. Wenn dort *Can not be
-changed once set*, steht, weißt Du, dass es nicht möglich ist, die Parameter nach dem Synthie-Start zu kontrollieren.
+Manche Parameter können nicht mehr verändert werden, nachdem der 
+Synthie gestartet wurde. Das trifft auf alle ADSR Hüllkurven-Parameter 
+zu. Welche Parameter kontrollierbar sind, kannst Du in der 
+Dokumentation im Hilfe-System herausfinden. Wenn dort *Can not be 
+changed once set*, steht, weißt Du, dass es nicht möglich ist, die 
+Parameter nach dem Synthie-Start zu kontrollieren.

--- a/etc/doc/tutorial/de/07.2-Controlling-FX.md
+++ b/etc/doc/tutorial/de/07.2-Controlling-FX.md
@@ -2,7 +2,6 @@
 
 # Effekte steuern
 
-slightly different way:
 Man kann auch Effekte steuern, allerdings geht das ein wenig anders:
 
 ```
@@ -18,6 +17,10 @@ with_fx :reverb do |r|
 end
 ```
 
-Statt eine Variable zu verwenden, nutzen wir die "goalpost"-Parameter (deut. Torpfosten) des do/end Blocks. Innerhalb der `|` Linien, müssen wir einen eindeutigen Namen für unseren laufenden Effekt vergeben, den wir dann innerhalb des do/end blocks verwenden. Dieses Verhalten ist das gleiche wie bei parametrisierten Funktionen.
+Statt eine Variable zu verwenden, nutzen wir die "goalpost"-Parameter 
+(deut. Torpfosten) des do/end Blocks. Innerhalb der `|` Linien, müssen 
+wir einen eindeutigen Namen für unseren laufenden Effekt vergeben, den 
+wir dann innerhalb des do/end blocks verwenden. Dieses Verhalten ist 
+das gleiche wie bei parametrisierten Funktionen.
 
 Jetzt los - steuere ein paar Synthies und Effekte!

--- a/etc/doc/tutorial/de/07.3-Sliding-Parameters.md
+++ b/etc/doc/tutorial/de/07.3-Sliding-Parameters.md
@@ -2,7 +2,12 @@
 
 # Gleitende Parameter
 
-Während Du die Synthie und FX-Argumente erforscht hast, hast Du vielleicht bemerkt, dass manche Parameter mit `_slide` enden. Vielleicht hast Du sie sogar ausprobiert und keine Auswirkung gesehen. Das liegt daran, dass sie keine normalen Parameter sind, sondern besondere, die nur dann funktionieren, wenn Du Synthies wie im letzten Kapitel beschrieben steuerst.
+Während Du die Synthie und FX-Argumente erforscht hast, hast Du 
+vielleicht bemerkt, dass manche Parameter mit `_slide` enden. 
+Vielleicht hast Du sie sogar ausprobiert und keine Auswirkung gesehen. 
+Das liegt daran, dass sie keine normalen Parameter sind, sondern 
+besondere, die nur dann funktionieren, wenn Du Synthies wie im letzten 
+Kapitel beschrieben steuerst.
 
 Schau die das folgende Beispiel an:
 
@@ -16,7 +21,11 @@ sleep 3
 control s, note: 72
 ```
 
-Hier kannst Du hören, wie sich die Tonhöhe unmittelbar bei jedem Aufruf von `control` ändert. Vielleicht möchten wir aber, dass die Tonhöhe sich gleitend zwischen den Aufrufen verändert. Um dort, wo wir den Parameter `note:` verwenden, gleitende Übergänge hinzuzufügen, nutzen wir den `note_slide` Parameter des Synthies:
+Hier kannst Du hören, wie sich die Tonhöhe unmittelbar bei jedem Aufruf 
+von `control` ändert. Vielleicht möchten wir aber, dass die Tonhöhe 
+sich gleitend zwischen den Aufrufen verändert. Um dort, wo wir den 
+Parameter `note:` verwenden, gleitende Übergänge hinzuzufügen, nutzen 
+wir den `note_slide` Parameter des Synthies:
 
 ```
 s = play 60, release: 5, note_slide: 1
@@ -28,13 +37,21 @@ sleep 3
 control s, note: 72
 ```
 
-Jetzt hören, wir die Noten zwischen den `control`-Aufrufen "gezogen" werden. Hört sich gut an, oder? Du kannst den Übergang beschleunigen, indem Du eine kürzere Dauer wie beispielsweise `note_slide: 0,2` angibst oder ihn mit einer längeren Slide-Dauer verlangsamen.
+Jetzt hören, wir die Noten zwischen den `control`-Aufrufen "gezogen" 
+werden. Hört sich gut an, oder? Du kannst den Übergang beschleunigen, 
+indem Du eine kürzere Dauer wie beispielsweise `note_slide: 0,2` 
+angibst oder ihn mit einer längeren Slide-Dauer verlangsamen.
 
-Jeder steuerbare Parameter einen entsprechenden `_slide`-Parameter, mit dem Du spielen kannst.
+Jeder steuerbare Parameter einen entsprechenden `_slide`-Parameter, mit 
+dem Du spielen kannst.
 
 # Gleiten ist klebrig
 
-Nachdem Du einmal einen `_slide` Parameter auf einem laufenden Synthie angegeben hast, bleibt er bestehen und wird jedesmal genutzt, wenn Du den entsprechenden Parameter steuerst. Um das Gleiten auszuschalten, musst Du den `_slide` Wert vor dem nächsten `control`-Aufruf auf 0 setzen.
+Nachdem Du einmal einen `_slide` Parameter auf einem laufenden Synthie 
+angegeben hast, bleibt er bestehen und wird jedesmal genutzt, wenn Du 
+den entsprechenden Parameter steuerst. Um das Gleiten auszuschalten, 
+musst Du den `_slide` Wert vor dem nächsten `control`-Aufruf auf 0 
+setzen.
 
 # Gleitende Effekt Parameter
 
@@ -48,4 +65,5 @@ with_fx :wobble, phase: 1, phase_slide: 5 do |e|
 end
 ```
 
-Und jetzt viel Spaß dabei, Dinge für weiche Übergänge umher gleiten zu lassen...
+Und jetzt viel Spaß dabei, Dinge für weiche Übergänge umher gleiten zu 
+lassen...

--- a/etc/doc/tutorial/de/08-Data-Structures.md
+++ b/etc/doc/tutorial/de/08-Data-Structures.md
@@ -2,11 +2,19 @@
 
 # Datenstrukturen
 
-Ein sehr hilfreiches Werkzeug im Werkzeugkasten eines Programmierers sind Datenstrukturen.
+Ein sehr hilfreiches Werkzeug im Werkzeugkasten eines Programmierers 
+sind Datenstrukturen.
 
-Manchmal möchtest Du mehr als eine Sache darstellen oder verwenden. So könnte es beispielsweise nützlich sein, eine Reihe von Noten zu haben, die nacheinander abgespielt werden sollen. Programmiersprachen bieten Datenstrukturen, um genau das zu ermöglichen.
+Manchmal möchtest Du mehr als eine Sache darstellen oder verwenden. So 
+könnte es beispielsweise nützlich sein, eine Reihe von Noten zu haben, 
+die nacheinander abgespielt werden sollen. Programmiersprachen bieten 
+Datenstrukturen, um genau das zu ermöglichen.
 
-Es sind viele aufregende und exotische Datenstrukturen für Programmierer verfügbar - und es werden immer noch neue erfunden.
-Für unsere Zwecke benötigen wir vorerst jedoch nur eine sehr einfache Datenstruktur - die Liste.
+Es sind viele aufregende und exotische Datenstrukturen für 
+Programmierer verfügbar - und es werden immer noch neue erfunden. Für 
+unsere Zwecke benötigen wir vorerst jedoch nur eine sehr einfache 
+Datenstruktur - die Liste.
 
-Lasst uns das im Detail anschauen. Wir werden uns die Grundform einer Liste anschauen und wie sie verwendet werden kann, um Skalen und Akkorde abzubilden.
+Lasst uns das im Detail anschauen. Wir werden uns die Grundform einer 
+Liste anschauen und wie sie verwendet werden kann, um Skalen und 
+Akkorde abzubilden.

--- a/etc/doc/tutorial/de/08.1-Lists.md
+++ b/etc/doc/tutorial/de/08.1-Lists.md
@@ -2,14 +2,21 @@
 
 # Listen
 
-In diesem Abschnitt werden wir uns eine sehr nützliche Datenstruktur anschauen - die Liste. 
-Wir hatten schon einmal in dem Abschnitt über Randomization kurz mit ihr zu tun, also wir die zu spielenden Noten zufällig aus einer Liste auswählten:
+In diesem Abschnitt werden wir uns eine sehr nützliche Datenstruktur 
+anschauen - die Liste. 
+
+Wir hatten schon einmal in dem Abschnitt über Randomization kurz mit 
+ihr zu tun, also wir die zu spielenden Noten zufällig aus einer Liste 
+auswählten:
 
 ```
 play choose([50, 55, 62])
 ```
 
-In diesem Abschnitt erforschen wir, wie man Listen verwenden kann, um Akkorde und Skalen darzustellen. Rufen wir uns wieder in Erinnerung, wie wir einen Akkord spielen könnten. Wenn wir `sleep` nicht verwenden, werden alle Töne zur gleichen Zeit abgespielt: 
+In diesem Abschnitt erforschen wir, wie man Listen verwenden kann, um 
+Akkorde und Skalen darzustellen. Rufen wir uns wieder in Erinnerung, 
+wie wir einen Akkord spielen könnten. Wenn wir `sleep` nicht verwenden, 
+werden alle Töne zur gleichen Zeit abgespielt: 
 
 ```
 play 52
@@ -29,23 +36,33 @@ play [52, 55, 59]
 ```
 
 Ohh, das kann man schon viel besser lesen.
-Das Abspielen einer Liste schränkt uns aber nicht ein, die gewohnten Parameter zu verwenden:
+
+Das Abspielen einer Liste schränkt uns aber nicht ein, die gewohnten 
+Parameter zu verwenden:
 
 ```
 play [52, 55, 59], amp: 0.3
 ```
 
-Natürlich kannst du auch die traditionellen Namen der Noten anstelle der MIDI-Nummern verwenden:
+Natürlich kannst du auch die traditionellen Namen der Noten anstelle 
+der MIDI-Nummern verwenden:
 
 ```
 play [:E3, :G3, :B3]
 ```
 
-Die glücklichen unter Euch, die ein bisschen Musiktheorie gelernt haben, haben den Akkord vielleicht als *E Moll* in der dritten Oktave erkannt.
+Die glücklichen unter Euch, die ein bisschen Musiktheorie gelernt 
+haben, haben den Akkord vielleicht als *E Moll* in der dritten Oktave 
+erkannt.
 
 ## Listenzugriffe
 
-Eine weitere nützliche Funktion von Listen ist es, dass man auf die enthaltenen Informationen zugreifen kann. Das klingt vielleicht seltsam, aber es ist nicht komplizierter als beispielsweise das Öffnen eines Buches auf der Seite 23. Eine Liste fragt man einfach "Was ist das Element am Index 23?". Seltsam ist nur, dass beim programmieren die Indices normalerweise mit 0 statt mit 1 beginnen.
+Eine weitere nützliche Funktion von Listen ist es, dass man auf die 
+enthaltenen Informationen zugreifen kann. Das klingt vielleicht 
+seltsam, aber es ist nicht komplizierter als beispielsweise das Öffnen 
+eines Buches auf der Seite 23. Eine Liste fragt man einfach "Was ist 
+das Element am Index 23?". Seltsam ist nur, dass beim programmieren die 
+Indices normalerweise mit 0 statt mit 1 beginnen.
 
 Listenindices zählen wir nicht 1,2,3,... sondern 0,1,2, ...
 
@@ -55,19 +72,34 @@ Wir schauen uns das etwas genauer an. Nehmen wir diese Liste:
 [52, 55, 59]
 ```
 
-Nicht besonders beängstigend. Was ist das zweite Element dieser Liste? Natürlich, das ist `55`. Das war einfach. Jetzt versuchen wir, ob das nicht den Computer dazu bringen können, die Frage für uns zu beantworten:
+Nicht besonders beängstigend. Was ist das zweite Element dieser Liste? 
+Natürlich, das ist `55`. Das war einfach. Jetzt versuchen wir, ob das 
+nicht den Computer dazu bringen können, die Frage für uns zu 
+beantworten:
 
 ```
 puts [52, 55, 59][1]
 ```
 
-Falls Du so etwas noch nie gesehen hast, mag das ein bisschen seltsam wirken. Aber vertrau mir, das ist nicht schwierig.
+Falls Du so etwas noch nie gesehen hast, mag das ein bisschen seltsam 
+wirken. Aber vertrau mir, das ist nicht schwierig.
 
-Die Zeile oben besteht aus drei Teilen: Das Wort `puts` , unsere Liste `52, 55, 59` und unser Index `[1]`. Als Erstes sagen wir `puts`, weil wir möchten, dass Sonic Pi die Antworot für uns ins Log schreibt. Danach übergeben wir unsere Liste und am Ende den Index, mit dem wir nach dem zweiten Element der Liste fragen. Den Index müssen wir mit eckigen Klammern umschließen und da wir bei `0` zu zählen beginnen, ist der Index des zweiten Elements `1`. Wie hier unten:
+Die Zeile oben besteht aus drei Teilen: Das Wort `puts` , unsere Liste 
+`52, 55, 59` und unser Index `[1]`. Als Erstes sagen wir `puts`, weil 
+wir möchten, dass Sonic Pi die Antworot für uns ins Log schreibt. 
+Danach übergeben wir unsere Liste und am Ende den Index, mit dem wir 
+nach dem zweiten Element der Liste fragen. Den Index müssen wir mit 
+eckigen Klammern umschließen und da wir bei `0` zu zählen beginnen, ist 
+der Index des zweiten Elements `1`. Wie hier unten:
 
 ```
 # indexes:  0   1   2
            [52, 55, 59]
 ```
 
-Versuche mal, den Code `puts [52, 55, 59][1]` auszuführen, dann wirst Du sehen, dass `55` im Log erscheint. Ändere mal den Index `1` in einen anderen, probiere längere Listen aus und denke darüber nach, wie Du Listen in Deiner nächsten Code Jam verwenden könntest. Welche Strukturen aus der Musik könnte man denn als eine Reihe von Zahlen interpretieren? 
+Versuche mal, den Code `puts [52, 55, 59][1]` auszuführen, dann wirst 
+Du sehen, dass `55` im Log erscheint. Ändere mal den Index `1` in einen 
+anderen, probiere längere Listen aus und denke darüber nach, wie Du 
+Listen in Deiner nächsten Code Jam verwenden könntest. Welche 
+Strukturen aus der Musik könnte man denn als eine Reihe von Zahlen 
+interpretieren? 

--- a/etc/doc/tutorial/de/08.2-Chords.md
+++ b/etc/doc/tutorial/de/08.2-Chords.md
@@ -8,7 +8,9 @@ Sonic Pi unterstützt Akkord-Namen, die Listen zurückgeben. Versuche es selbst:
 play chord(:E3, :minor)
 ```
 
-Jetzt tut sich was. Das sieht doch schon viel schöner aus als einfache Listen (und ist für andere viel einfacher lesbar). Welche Akkorde kennt Sonic Pi noch? Naja, *viele*. Probier mal ein paar von diesen aus:
+Jetzt tut sich was. Das sieht doch schon viel schöner aus als einfache 
+Listen (und ist für andere viel einfacher lesbar). Welche Akkorde kennt 
+Sonic Pi noch? Naja, *viele*. Probier mal ein paar von diesen aus:
 
 * `chord(:E3, :m7)`
 * `chord(:E3, :minor)`
@@ -17,19 +19,25 @@ Jetzt tut sich was. Das sieht doch schon viel schöner aus als einfache Listen (
 
 ## Arpeggios
 
-Um Akkorde einfach in Arpeggios umzuwandeln, können wir die Funktion `play_pattern` verwenden:
+Um Akkorde einfach in Arpeggios umzuwandeln, können wir die Funktion 
+`play_pattern` verwenden:
 
 ```
 play_pattern chord(:E3, :m7)
 ```
 
-Ok, das war nichts besonderes - das ging wirklich langsam. `play_pattern` spielt jede Note in der Liste hintereinander, getrennt durch Aufrufe von `sleep 1` ab. Wir können die Funktion `play_pattern_timed` verwenden, um unsere eigenen Timings zu verwenden und das ganze zu beschleuigen:
+Ok, das war nichts besonderes - das ging wirklich langsam. 
+`play_pattern` spielt jede Note in der Liste hintereinander, getrennt 
+durch Aufrufe von `sleep 1` ab. Wir können die Funktion 
+`play_pattern_timed` verwenden, um unsere eigenen Timings zu verwenden 
+und das ganze zu beschleuigen:
 
 ```
 play_pattern_timed chord(:E3, :m7), 0.25
 ```
 
-Wir können sogar eine Liste von Zeiten übergeben; diese wird als ein Kreis von Zeiten behandelt:
+Wir können sogar eine Liste von Zeiten übergeben; diese wird als ein 
+Kreis von Zeiten behandelt:
 
 ```
 play_pattern_timed chord(:E3, :m13), [0.25, 0.5]

--- a/etc/doc/tutorial/de/08.3-Scales.md
+++ b/etc/doc/tutorial/de/08.3-Scales.md
@@ -2,7 +2,8 @@
 
 # Skalen
 
-Sonic Pi unterstützt eine große Anzahl von Skalen. Wie wäre es, eine C3-Dur-Skala zu spielen?
+Sonic Pi unterstützt eine große Anzahl von Skalen. Wie wäre es, eine 
+C3-Dur-Skala zu spielen?
 
 ```
 play_pattern_timed scale(:c3, :major), 0.125, release: 0.1
@@ -22,7 +23,9 @@ play_pattern_timed scale(:c3, :major_pentatonic, num_octaves: 3), 0.125, release
 
 ## Zufällige Noten
 
-Akkorde und Skalen sind gute Methoden, eine zufällige Auswahl auf etwas von Bedeutung einzugrenzen. Spiele einmal mit diesem Beispiel, das zufällige Noten aus dem Akkord A3 Moll auswählt:
+Akkorde und Skalen sind gute Methoden, eine zufällige Auswahl auf etwas 
+von Bedeutung einzugrenzen. Spiele einmal mit diesem Beispiel, das 
+zufällige Noten aus dem Akkord A3 Moll auswählt:
 
 ```
 use_synth :tb303
@@ -36,6 +39,10 @@ Probiere auch verschiedene Akkord-Namen und Cutoff-Bereiche aus.
 
 ## Akkorde und Skalen entdecken
 
-Um herauszufinden, welche Skalen und Akkorde von Sonic Pi unterstützt werden, klicke einfach auf den `Lang`-Knopf ganz auf der linke Seite dieses Tutorials und wähle entweder `chord` oder `scale` aus der API-Liste. Scrolle im Hauptfenster herunter, bist Du eine lange Liste von Akkorden oder Skalen findest.
+Um herauszufinden, welche Skalen und Akkorde von Sonic Pi unterstützt 
+werden, klicke einfach auf den `Lang`-Knopf ganz auf der linke Seite 
+dieses Tutorials und wähle entweder `chord` oder `scale` aus der 
+API-Liste. Scrolle im Hauptfenster herunter, bist Du eine lange Liste 
+von Akkorden oder Skalen findest.
 
 Viel Spaß und nicht vergessen: Es gibt keine Fehler, nur Möglichkeiten.

--- a/etc/doc/tutorial/de/08.4-Rings.md
+++ b/etc/doc/tutorial/de/08.4-Rings.md
@@ -2,47 +2,63 @@
 
 # Ringe
 
-Eine interessante Spielart von normalen Listen sind Ringe. Wenn Du ein bisschen Programmiererfahrung hast, könntest Du Ringspeicher (engl. ring buffer) oder Ring-Arrays kennen. Wir nennen die hier nur Ring - das ist kurz und einfach.
+Eine interessante Spielart von normalen Listen sind Ringe. Wenn Du ein 
+bisschen Programmiererfahrung hast, könntest Du Ringspeicher (engl. 
+ring buffer) oder Ring-Arrays kennen. Wir nennen die hier nur Ring - 
+das ist kurz und einfach.
 
-Im vorherigen Abschnitt über Listen haben wir gesehen, dass wir Element aus einer Liste über den Index holen können:
+Im vorherigen Abschnitt über Listen haben wir gesehen, dass wir Element 
+aus einer Liste über den Index holen können:
 
 ```
 puts [52, 55, 59][1]
 ```
 
-Was passiert jetzt wohl, wenn Du den Index `100` abfragen willst? Offensichtlich gibt es kein Element mit dem Index 100, da die Liste nur drei Elemente enthält. Also gibt Sonic Pi `nil` zurück, was "nichts" bedeutet. 
-Stell Dir vor, einen Zähler wie den aktuellen Takt zu haben, der kontinuierlich wächst.
-Lass uns so einen Zähler und unsere Liste anlegen:
+Was passiert jetzt wohl, wenn Du den Index `100` abfragen willst? 
+Offensichtlich gibt es kein Element mit dem Index 100, da die Liste nur 
+drei Elemente enthält. Also gibt Sonic Pi `nil` zurück, was "nichts" 
+bedeutet. Stell Dir vor, einen Zähler wie den aktuellen Takt zu haben, 
+der kontinuierlich wächst. Lass uns so einen Zähler und unsere Liste 
+anlegen:
 
 ```
 counter = 0
 notes = [52, 55, 59]
 ```
 
-Jetzt können wir unseren Zähler verwenden, um auf eine Note in unserer Liste zuzugreifen:
+Jetzt können wir unseren Zähler verwenden, um auf eine Note in unserer 
+Liste zuzugreifen:
 
 ```
 puts notes[counter]
 ```
 
-Super, da kam `52` heraus. Jetzt erhöhen (`inc` für englisch "to increment" = erhöhen) wir den Zähler und bekommen damit eine neue Note:
+Super, da kam `52` heraus. Jetzt erhöhen (`inc` für englisch "to 
+increment" = erhöhen) wir den Zähler und bekommen damit eine neue Note:
 
 ```
 counter = (inc counter)
 puts notes[counter]
 ```
 
-Ok, jetzt bekommen `55` und beim nächsten Mal `59` heraus. Wenn wir das jedoch jetzt noch einmal machen, sehen wir, dass wir nicht mehr genug Zahlen in unserer Liste haben und stattdessen `nil` zurück bekommen. Was wäre wenn wir wir dann einfach wieder vom Anfang der Liste anfangen wollten? Genau dafür gibt es Ringe.
+Ok, jetzt bekommen `55` und beim nächsten Mal `59` heraus. Wenn wir das 
+jedoch jetzt noch einmal machen, sehen wir, dass wir nicht mehr genug 
+Zahlen in unserer Liste haben und stattdessen `nil` zurück bekommen. 
+Was wäre wenn wir wir dann einfach wieder vom Anfang der Liste anfangen 
+wollten? Genau dafür gibt es Ringe.
 
 ## Ringe erzeugen
 
-Es gibt zwei Möglichkeiten, Ringe zu erzeugen. Die erste ist, die `ring` Funktion mit den gewünschten Elementen des Rings als Parameter zu verwenden:
+Es gibt zwei Möglichkeiten, Ringe zu erzeugen. Die erste ist, die 
+`ring` Funktion mit den gewünschten Elementen des Rings als Parameter 
+zu verwenden:
 
 ```
 (ring 52, 55, 59)
 ```
 
-Die zweite Möglichkeit ist es, eine normale Liste zu nehmen und sie zu einem Ring umzuwandeln, indem wir ihr die Nachricht `.ring` senden:
+Die zweite Möglichkeit ist es, eine normale Liste zu nehmen und sie zu 
+einem Ring umzuwandeln, indem wir ihr die Nachricht `.ring` senden:
 
 ```
 [52, 55, 59].ring
@@ -50,7 +66,11 @@ Die zweite Möglichkeit ist es, eine normale Liste zu nehmen und sie zu einem Ri
 
 ## Auf Ringelemente zugreifen
 
-Sobald wir einen Ring haben, können wir ihn auf die gleiche Art wie eine Liste verwenden. Die einzige Ausnahme ist, dass Du Indizes verwenden kannst, die negativ oder größer als der Ringinhalt sind. Diese fangen dann dann wieder am Anfang an, um immer auf ein Element des Rings zu zeigen:
+Sobald wir einen Ring haben, können wir ihn auf die gleiche Art wie 
+eine Liste verwenden. Die einzige Ausnahme ist, dass Du Indizes 
+verwenden kannst, die negativ oder größer als der Ringinhalt sind. 
+Diese fangen dann dann wieder am Anfang an, um immer auf ein Element 
+des Rings zu zeigen:
 
 ```
 (ring 52, 55, 59)[0] #=> 52
@@ -62,19 +82,26 @@ Sobald wir einen Ring haben, können wir ihn auf die gleiche Art wie eine Liste 
 
 ## Ringe verwenden
 
-Angenommen wir verwenden eine Variable um die Nummer des aktuellen Takts abzubilden. Diese Nummer können wir als Zugriffsindex für unseren Ring verwenden, um abzuspielende Note, Release-Zeiten oder andere sinnvolle Dinge, die wir in unserem Ring abgelegt haben, abzurufen. 
+Angenommen wir verwenden eine Variable um die Nummer des aktuellen 
+Takts abzubilden. Diese Nummer können wir als Zugriffsindex für unseren 
+Ring verwenden, um abzuspielende Note, Release-Zeiten oder andere 
+sinnvolle Dinge, die wir in unserem Ring abgelegt haben, abzurufen. 
 
 ## Skalen und Akkorde sind Ringe
 
-Es ist nützlich zu wissen, dass die Listen, die von  `scale` und `chord` zurückgegeben werden, auch Ringe sind und Dir damit erlauben, mit beliebigen Indizes auf sie zuzugreifen.
+Es ist nützlich zu wissen, dass die Listen, die von `scale` und 
+`chord` zurückgegeben werden, auch Ringe sind und Dir damit erlauben, 
+mit beliebigen Indizes auf sie zuzugreifen.
 
 ## Ring-Konstruktoren
 
-Zusätzlich zu `ring` gibt es noch eine Anzahl weiterer Funktionen die Ringe für uns erzeugen.
+Zusätzlich zu `ring` gibt es noch eine Anzahl weiterer Funktionen die 
+Ringe für uns erzeugen.
 
 * `range` lädt ein, einen Startpunkt, einen Endpunkt und eine Schrittgröße zu definieren.
 * `bools` erlaubt Dir `1`er und `0`er als prägnante Darstellung boolscher Werte zu nutzen.
 * `knit` erlaubt Dir, eine Abfolge wiederholter Werte zu "stricken" (engl. "to knit").
 
-Mehr Informationen zu diesen Funktionen findest Du in der entsprechenden Dokumentation.
+Mehr Informationen zu diesen Funktionen findest Du in der 
+entsprechenden Dokumentation.
 

--- a/etc/doc/tutorial/de/09-Live-Coding.md
+++ b/etc/doc/tutorial/de/09-Live-Coding.md
@@ -2,11 +2,18 @@
 
 # Live Coding
 
-Einer der interessantesten Aspekte von Sonic Pi ist es, das es dir die Möglichkeit gibt, Code live zu schreiben und zu verändern um Musik zu machen, so als würdest Du beispielsweise mit einer Gitarre auftreten.
+Einer der interessantesten Aspekte von Sonic Pi ist es, das es dir die 
+Möglichkeit gibt, Code live zu schreiben und zu verändern um Musik zu 
+machen, so als würdest Du beispielsweise mit einer Gitarre auftreten.
 
-Ein Vorteil dieser Herangehensweise ist, dass du direkt während dem Komponieren Rückmeldung erhältst. Starte einen einfachen Loop und spiele daran herum, bis er genau richtig klingt.
-Der größte Vorteil ist aber, dass du Sonic Pi mit auf die Bühne nehmen und damit auftreten kannst.
+Ein Vorteil dieser Herangehensweise ist, dass du direkt während dem 
+Komponieren Rückmeldung erhältst. Starte einen einfachen Loop und 
+spiele daran herum, bis er genau richtig klingt. Der größte Vorteil ist 
+aber, dass du Sonic Pi mit auf die Bühne nehmen und damit auftreten 
+kannst.
 
-Dieser Abschnitt behandelt die Grundlagen, die du benötigst um deinen Kompositionen von statischem Code in rasante Performances zu verwandeln.
+Dieser Abschnitt behandelt die Grundlagen, die du benötigst um deinen 
+Kompositionen von statischem Code in rasante Performances zu 
+verwandeln.
 
 Halt dich fest ...

--- a/etc/doc/tutorial/de/09.1-Live-Coding-Fundamentals.md
+++ b/etc/doc/tutorial/de/09.1-Live-Coding-Fundamentals.md
@@ -2,16 +2,22 @@
 
 # Live Coding
 
-Inzwischen haben wir genug gelernt, um damit anfangen zu können, wirklich Spaß zu haben.
+Inzwischen haben wir genug gelernt, um damit anfangen zu können, 
+wirklich Spaß zu haben.
 
-In diesem Abschnitt nutzen wir alles, was wir bisher in diesem Tutorial gelernt haben und zeigen dir, wie du deine Kompositionen live aufführen und in Performances verwandeln kannst. Dazu benötigen wir vor allem drei Zutaten:
+In diesem Abschnitt nutzen wir alles, was wir bisher in diesem Tutorial 
+gelernt haben und zeigen dir, wie du deine Kompositionen live aufführen 
+und in Performances verwandeln kannst. Dazu benötigen wir vor allem 
+drei Zutaten:
 
 * Die Fähigkeit, Code zu schreiben der Töne erzeugt - CHECK!
 * Die Fähigkeit, Funktionen zu schreiben - CHECK!
 * Die Fähigkeit, (named) Threads zu verwenden - CHECK!
 
-Ok, also kann es los gehen. Lass uns unsere ersten Sounds live coden.
-Zuerst brauchen wir eine Funktion, die den abzuspielenden Code enthält. Wir fangen ganz einfach an. Außerdem wollen wir diese Funktion in einer Schleife in einem Thread aufrufen:
+Ok, also kann es los gehen. Lass uns unsere ersten Sounds live coden. 
+Zuerst brauchen wir eine Funktion, die den abzuspielenden Code enthält. 
+Wir fangen ganz einfach an. Außerdem wollen wir diese Funktion in einer 
+Schleife in einem Thread aufrufen:
 
 ```
 define :my_loop do
@@ -26,21 +32,36 @@ in_thread(name: :looper) do
 end
 ```
 
-Wenn dir das ein bisschen zu kompliziert aussieht, dann lies dir noch mal die Abschnitte über Funktionen und Threads durch. Wenn du diese Dinge verstanden hast, wird es dir nicht mehr sehr kompliziert vorkommen.
+Wenn dir das ein bisschen zu kompliziert aussieht, dann lies dir noch 
+mal die Abschnitte über Funktionen und Threads durch. Wenn du diese 
+Dinge verstanden hast, wird es dir nicht mehr sehr kompliziert 
+vorkommen.
 
-Wir haben hier eine Funktion, die die Note 50 spielt und danach eine Sekunde schläft. Dann definieren wir einen benamten Thread, den wir `:looper`nennen. Dieser läuft immer wieder ab und ruft jedesmal `my_loop` auf.
+Wir haben hier eine Funktion, die die Note 50 spielt und danach eine 
+Sekunde schläft. Dann definieren wir einen benamten Thread, den wir 
+`:looper`nennen. Dieser läuft immer wieder ab und ruft jedesmal 
+`my_loop` auf.
 
-Wenn Du diesen Code ausführst, wirst Du immer und immer wieder die Note 50 hören...
+Wenn Du diesen Code ausführst, wirst Du immer und immer wieder die Note 
+50 hören...
 
 ## Hochschalten
 
-Jetzt geht es richtig los. Während der Code *noch läuft*, ändere die 50 in eine andere Zahl, zum Beispiel 55, und drücke den `Run`-Knopf erneut. Woah! Es hat sich verändert! Live!
+Jetzt geht es richtig los. Während der Code *noch läuft*, ändere die 50 
+in eine andere Zahl, zum Beispiel 55, und drücke den `Run`-Knopf 
+erneut. Woah! Es hat sich verändert! Live!
 
-Wir haben keine neue Ebene bekommen, da wir einen benannten Thread verwendet haben, was nur einen Thread pro Name zulässt. Der Ton hat sich geändert, weil wir die Funktion *redifiniert* haben. Wir haben also `:my_loop` eine neue Definition verpasst. Der `:looper`-Thread hat einfach die neue Definition aufgerufen.
+Wir haben keine neue Ebene bekommen, da wir einen benannten Thread 
+verwendet haben, was nur einen Thread pro Name zulässt. Der Ton hat 
+sich geändert, weil wir die Funktion *redifiniert* haben. Wir haben 
+also `:my_loop` eine neue Definition verpasst. Der `:looper`-Thread hat 
+einfach die neue Definition aufgerufen.
 
-Verändere die Funktion noch einmal, ändere die Note und die Pausenzeit. Wie wäre es damit, ein `use_synth`-Statement einzufügen?
+Verändere die Funktion noch einmal, ändere die Note und die Pausenzeit. 
+Wie wäre es damit, ein `use_synth`-Statement einzufügen?
 
 Ändere die Funktionsdefinition zum Beispiel in folgenden Code:
+
 ```
 define :my_loop do
   use_synth :tb303
@@ -49,7 +70,9 @@ define :my_loop do
 end
 ```
 
-Jetzt klingt es schon ganz interessant, wir können es aber noch ein bisschen aufpeppen. Anstatt immer wieder die gleiche Note zu spielen, versuche es einmal mit einem Akkord.
+Jetzt klingt es schon ganz interessant, wir können es aber noch ein 
+bisschen aufpeppen. Anstatt immer wieder die gleiche Note zu spielen, 
+versuche es einmal mit einem Akkord.
 
 ```
 define :my_loop do
@@ -91,4 +114,8 @@ end
 ```
 
 Jetzt wird es spannend!
-Trotzdem solltest du, bevor du aufspringst und mit Funktionen und Threads live codest, erst einmal eine Pause machen und das nächste Kapitel über den `live_loop` lesen. Das wird deine Art in Sonic Pi programmierst für immer verändern ...
+
+Trotzdem solltest du, bevor du aufspringst und mit Funktionen und 
+Threads live codest, erst einmal eine Pause machen und das nächste 
+Kapitel über den `live_loop` lesen. Das wird deine Art in Sonic Pi 
+programmierst für immer verändern ...

--- a/etc/doc/tutorial/de/09.2-Live-Loops.md
+++ b/etc/doc/tutorial/de/09.2-Live-Loops.md
@@ -1,6 +1,11 @@
 # Live Loops
 
-Ok, dieses Kapitel des Tutorials ist ein Juwel. Wenn du nur einen Abschnitt lesen würdest, sollte es dieser sein. `live_loop` ist ein einfacher Weg, genau das zu tun was, du im letzten Abschnitt gelernt hast, nur ohne so viel schreiben zu müssen. Falls du den letzten Abschnitt nicht gelesen hast: `live_loop` ist der beste Weg, mit Sonic Pi zu jammen.
+Ok, dieses Kapitel des Tutorials ist ein Juwel. Wenn du nur einen 
+Abschnitt lesen würdest, sollte es dieser sein. `live_loop` ist ein 
+einfacher Weg, genau das zu tun was, du im letzten Abschnitt gelernt 
+hast, nur ohne so viel schreiben zu müssen. Falls du den letzten 
+Abschnitt nicht gelesen hast: `live_loop` ist der beste Weg, mit Sonic 
+Pi zu jammen.
 
 Also los. Schreibe folgendes in einen neuen Workspace:
 
@@ -10,10 +15,14 @@ live_loop :foo do
   sleep 1
 end
 ```
-Jetzt drücke den `Run`-Knopf. Du hörst jede Sekunde ein einfaches Piepen. Kein besonderer Spaß. Drücke aber noch nicht den `Stop`-Knopf. Ändere die `60` in `65` und drücke wieder `Run`.
 
-Whoa! Es hat sich *automatisch* verändert, ohne einen Takt auszulassen. Das ist Live Coding.
-Warum es jetzt nicht ein wenig bassiger machen? Aktualisiere deinen Code während er abläuft:
+Jetzt drücke den `Run`-Knopf. Du hörst jede Sekunde ein einfaches 
+Piepen. Kein besonderer Spaß. Drücke aber noch nicht den `Stop`-Knopf. 
+Ändere die `60` in `65` und drücke wieder `Run`.
+
+Whoa! Es hat sich *automatisch* verändert, ohne einen Takt auszulassen. 
+Das ist Live Coding. Warum es jetzt nicht ein wenig bassiger machen? 
+Aktualisiere deinen Code während er abläuft:
 
 ```
 live_loop :foo do
@@ -58,4 +67,5 @@ live_loop :foo do
   sleep 8
 end
 ```
+
 Und jetzt hör auf mir zuzuhören und spiele selbst herum. Viel Spaß!

--- a/etc/doc/tutorial/de/09.3-Multiple-Live-Loops.md
+++ b/etc/doc/tutorial/de/09.3-Multiple-Live-Loops.md
@@ -9,11 +9,15 @@ live_loop :foo do
 end
 ```
 
-Vielleicht fragst du dich, warum er den Namen `:foo` braucht. Dieser Name ist wichtig, weil er sicherstellt, dass sich dieser Live Loop von allen anderen Live Loops unterscheidet.
+Vielleicht fragst du dich, warum er den Namen `:foo` braucht. Dieser 
+Name ist wichtig, weil er sicherstellt, dass sich dieser Live Loop von 
+allen anderen Live Loops unterscheidet.
 
-*Es können nie zwei Live Loops mit dem selben Namen gleichzeitig laufen*.
+*Es können nie zwei Live Loops mit dem selben Namen gleichzeitig 
+laufen*.
 
-Das bedeutet, dass wir unterschiedliche Namen vergeben müssen, um mehrere gleichzeitig laufende Live Loops zu haben zu können. 
+Das bedeutet, dass wir unterschiedliche Namen vergeben müssen, um 
+mehrere gleichzeitig laufende Live Loops zu haben zu können. 
 
 ```
 live_loop :foo do
@@ -28,13 +32,18 @@ live_loop :bar do
 end
 ```
 
-Jetzt kannst du beide Live Loops unabhängig voneinander aktualisieren und alles funktioniert - einfach so.
+Jetzt kannst du beide Live Loops unabhängig voneinander aktualisieren 
+und alles funktioniert - einfach so.
 
 ## Live Loops Synchronisieren
 
-Du hast vielleicht schon bemerkt, dass Live Loops automatisch mit dem Thread Cue Mechanismus arbeiten, den wir uns bereits angeschaut haben.
+Du hast vielleicht schon bemerkt, dass Live Loops automatisch mit dem 
+Thread Cue Mechanismus arbeiten, den wir uns bereits angeschaut haben.
 
-In jedem Durchlauf des Live Loops generiert er eine neues `Cue`-Event mit dem Namen des Loops. Anhand dieser Cues können wir unsere Loops `synchronisieren` um sicherzustellen, dass sie synchron laufen, ohne dass wir das Abspielen zwischendurch stoppen müssen.
+In jedem Durchlauf des Live Loops generiert er eine neues `Cue`-Event 
+mit dem Namen des Loops. Anhand dieser Cues können wir unsere Loops 
+`synchronisieren` um sicherzustellen, dass sie synchron laufen, ohne 
+dass wir das Abspielen zwischendurch stoppen müssen.
 
 Schau Dir diesen schlecht synchronisierten Code an:
 
@@ -49,7 +58,11 @@ live_loop :bar do
   sleep 1
 end
 ```
-Jetzt versuchen wir, das Timing zu korrigieren ohne den Loop zu stoppen. Zuerst reparieren wir den Loop `:foo` indem wir die Sleep-Dauer zu einem Faktor von 1 machen - dafür funktioniert zum Beispiel `0.5`.
+
+Jetzt versuchen wir, das Timing zu korrigieren ohne den Loop zu 
+stoppen. Zuerst reparieren wir den Loop `:foo` indem wir die 
+Sleep-Dauer zu einem Faktor von 1 machen - dafür funktioniert zum 
+Beispiel `0.5`.
 
 ```
 live_loop :foo do
@@ -63,8 +76,10 @@ live_loop :bar do
 end
 ```
 
-Damit sind wir aber noch nicht ganz fertig. Du hörst schon, dass die Beats nicht so recht zusammenpassen. Der Grund dafür ist, dass diese Loops  *out of
-phase* sind. Das können wir dadurch reparieren, dass wir einen Loop mit dem anderen synchronisieren:
+Damit sind wir aber noch nicht ganz fertig. Du hörst schon, dass die 
+Beats nicht so recht zusammenpassen. Der Grund dafür ist, dass diese 
+Loops *out of phase* sind. Das können wir dadurch reparieren, dass wir 
+einen Loop mit dem anderen synchronisieren:
 
 ```
 live_loop :foo do
@@ -79,6 +94,7 @@ live_loop :bar do
 end
 ```
 
-Wow, jetzt passt alles genau zusammen - und dass, ohne dass wir die Loops anhalten mussten.
+Wow, jetzt passt alles genau zusammen - und dass, ohne dass wir die 
+Loops anhalten mussten.
 
 Jetzt gehet hin und coded live in Live Loops!

--- a/etc/doc/tutorial/de/10-Essential-Knowledge.md
+++ b/etc/doc/tutorial/de/10-Essential-Knowledge.md
@@ -2,6 +2,10 @@
 
 # Unentbehrliche Kenntnisse
 
-Dieses Kapitel behandelt sehr nützliches - nein, *unentbehrliches* - Wissen, welches Dir hilft,  das Bestmögliche aus Deinem Sonic Pi herauszuholen.
+Dieses Kapitel behandelt sehr nützliches - nein, *unentbehrliches* - 
+Wissen, welches Dir hilft,  das Bestmögliche aus Deinem Sonic Pi 
+herauszuholen.
 
-Wir behandeln viele der verfügbaren Tastaturkürzel, zeigen, wie Du deine Ergebnisse teilen kannst und geben Dir Tipps für Auftritte mit Sonic Pi.
+Wir behandeln viele der verfügbaren Tastaturkürzel, zeigen, wie Du 
+deine Ergebnisse teilen kannst und geben Dir Tipps für Auftritte mit 
+Sonic Pi.

--- a/etc/doc/tutorial/de/10.1-Using-Shortcuts.md
+++ b/etc/doc/tutorial/de/10.1-Using-Shortcuts.md
@@ -2,46 +2,86 @@
 
 # Tastaturkürzel
 
-Sonic Pi ist zu gleichen Teilen Musikinstrument und Programmierumgebung. Tastaturkürzel helfen Dir dabei, Sonic Pi viel *effizienter und natürlicher* zu spielen - insbesondere wenn Du live vor Publikum spielst. 
+Sonic Pi ist zu gleichen Teilen Musikinstrument und 
+Programmierumgebung. Tastaturkürzel helfen Dir dabei, Sonic Pi viel 
+*effizienter und natürlicher* zu spielen - insbesondere wenn Du live 
+vor Publikum spielst. 
 
-Ein großer Teil von Sonic Pi kann mit der Tastatur gesteuert werden. Je vertrauter Du mit Sonic Pi wirst, umso mehr wirst Du die Tastaturkürzel verwenden. *Ich selbst tippe blind, ohne die Tastatur anzussehen* (überlege Dir, das auch zu lernen) und bin jedesmal frustriert, wenn ich zur Maus greifen muss, weil mich das langsam macht. Deshalb verwende ich alle diese Tastaturkürzel regelmäßig. 
+Ein großer Teil von Sonic Pi kann mit der Tastatur gesteuert werden. Je 
+vertrauter Du mit Sonic Pi wirst, umso mehr wirst Du die Tastaturkürzel 
+verwenden. *Ich selbst tippe blind, ohne die Tastatur anzussehen* 
+(überlege Dir, das auch zu lernen) und bin jedesmal frustriert, wenn 
+ich zur Maus greifen muss, weil mich das langsam macht. Deshalb 
+verwende ich alle diese Tastaturkürzel regelmäßig. 
 
-Indem Du die Tastaturkürzel lernst, lernst Du auch Deine Tastatur effektiv zu benutzen und wirst in kurzer Zeit programmieren wie ein Profi.
+Indem Du die Tastaturkürzel lernst, lernst Du auch Deine Tastatur 
+effektiv zu benutzen und wirst in kurzer Zeit programmieren wie ein 
+Profi.
 
-*Versuche aber nicht, alle auf einmal zu lernen*, merke Dir erst einmal die, die Du am häufigsten nutzt und erweitere dann nach und nach Dein Repertiore.
+*Versuche aber nicht, alle auf einmal zu lernen*, merke Dir erst einmal 
+die, die Du am häufigsten nutzt und erweitere dann nach und nach Dein 
+Repertiore.
 
 ## Konsistenz auf verschiedenen Plattformen
 
-Stell Dir vor Du lernst Klarinette. Du kannst davon ausgehen, dass alle Klarinetten aller Marken gleiche Mechaniken und Fingersätze haben. Hätten sie das nicht, könntest Du nicht ohne weiteres zwischen verschiedenen Klarinetten hin- und herwechseln sondern müsstest immer bei einer Marke.
+Stell Dir vor Du lernst Klarinette. Du kannst davon ausgehen, dass alle 
+Klarinetten aller Marken gleiche Mechaniken und Fingersätze haben. 
+Hätten sie das nicht, könntest Du nicht ohne weiteres zwischen 
+verschiedenen Klarinetten hin- und herwechseln sondern müsstest immer 
+bei einer Marke.
 
-Unglücklicherweise haben die drei wesentlichen Betriebssysteme (Linux, Mac OS X und Windows) alle ihre eigenen Standards für Aktionen wie beispielsweise Kopieren, Ausschneiden und Einfügen.
-Sonic Pi nutzt diese Standards wo immer möglich. Jedoch *liegt die Priorität auf plattformübergreifende Konsistenz* innerhalb von Sonic Pi, nicht auf dem Versuch die Standards der jeweiligen Plattform vollumfänglich zu erfüllen.
-Das bedeutet, dass die in Sonic Pi auf dem Raspberry Pi gelernten Tastaturkürzel ebenso auf einem Mac oder PC gültig funktionieren.
+Unglücklicherweise haben die drei wesentlichen Betriebssysteme (Linux, 
+Mac OS X und Windows) alle ihre eigenen Standards für Aktionen wie 
+beispielsweise Kopieren, Ausschneiden und Einfügen. Sonic Pi nutzt 
+diese Standards wo immer möglich. Jedoch *liegt die Priorität auf 
+plattformübergreifende Konsistenz* innerhalb von Sonic Pi, nicht auf 
+dem Versuch die Standards der jeweiligen Plattform vollumfänglich zu 
+erfüllen. Das bedeutet, dass die in Sonic Pi auf dem Raspberry Pi 
+gelernten Tastaturkürzel ebenso auf einem Mac oder PC gültig 
+funktionieren.
 
 ## Control und Meta
 
-Ein Teil der Herstellung dieser Konsistenz ist die Benennung von Tastaturkürzeln. In Sonic Pi verwenden wir die Namen *Control* und *Meta* für die beiden hauptsächlichen Kombinationstasten.
-*Control* (*Ctrl* oder *Strg* für "Steuerung" auf deutschen Tastaturen) ist auf allen Plattformen gleich. Auf Linux und Windows ist *Meta* die *Alt*-Taste, während *Meta* auf dem Mac die *Command*-Taste ist. Um konsistent zu bleiben, nutzen wir den Begriff *Meta* - den Du mental auf der passenden Taste Deines Betriebssystems zuordnen musst.
+Ein Teil der Herstellung dieser Konsistenz ist die Benennung von 
+Tastaturkürzeln. In Sonic Pi verwenden wir die Namen *Control* und 
+*Meta* für die beiden hauptsächlichen Kombinationstasten. *Control* 
+(*Ctrl* oder *Strg* für "Steuerung" auf deutschen Tastaturen) ist auf 
+allen Plattformen gleich. Auf Linux und Windows ist *Meta* die 
+*Alt*-Taste, während *Meta* auf dem Mac die *Command*-Taste ist. Um 
+konsistent zu bleiben, nutzen wir den Begriff *Meta* - den Du mental 
+auf der passenden Taste Deines Betriebssystems zuordnen musst.
 
 ## Abkürzungen
 
-Um die Dinge einfach und lesbar zu halten, werden wir die Abkürzungen *C-* für *Control* und eine weitere Taste sowie *M-* für *Meta* und eine weitere Taste verwenden.
+Um die Dinge einfach und lesbar zu halten, werden wir die Abkürzungen 
+*C-* für *Control* und eine weitere Taste sowie *M-* für *Meta* und 
+eine weitere Taste verwenden.
 
-Wenn ein Tastaturkürzel beispielsweise erfordert, dass Du *Meta* und *r* gleichzeitig drückst, werden wir die Abkürzung `M-r` verwenden. Der Bindestrich in der Mitte (*-*) bedeutet nur "zur gleichen Zeit".
+Wenn ein Tastaturkürzel beispielsweise erfordert, dass Du *Meta* und 
+*r* gleichzeitig drückst, werden wir die Abkürzung `M-r` verwenden. Der 
+Bindestrich in der Mitte (*-*) bedeutet nur "zur gleichen Zeit".
 
 Hier sind ein paar der Tastaturkürzel, die ich am nützlichsten finde.
 
 ## Stoppen und starten
 
-Statt immer zur Maus zu greifenm um Deinen Code auszuführen kannst Du einfach `M-r` drücken. Um die Ausführung zu stoppen, drücke `M-s`.
+Statt immer zur Maus zu greifenm um Deinen Code auszuführen kannst Du 
+einfach `M-r` drücken. Um die Ausführung zu stoppen, drücke `M-s`.
 
 ## Navigation
 
-Ohne die Tastenkürzel zur Navigation bin ich verloren. Deshalb empfehle ich dringend, die Zeit aufzuwenden sie zu lernen. Diese Kürzel funktionieren besonders gut, wenn Du schon gelernt hast, blind zu schreiben, da sie normale Buchstaben verwenden - so musst Du deine Hand nicht zur Maus oder den Pfeiltasten bewegen.
+Ohne die Tastenkürzel zur Navigation bin ich verloren. Deshalb empfehle 
+ich dringend, die Zeit aufzuwenden sie zu lernen. Diese Kürzel 
+funktionieren besonders gut, wenn Du schon gelernt hast, blind zu 
+schreiben, da sie normale Buchstaben verwenden - so musst Du deine Hand 
+nicht zur Maus oder den Pfeiltasten bewegen.
 
-Mit `C-a` springst Du an den Anfang, mit `C-e` ans Ende einer Zeile. Eine Zeile nach oben geht es mit `C-p`, eine nach unten mit `C-n`, ein Zeichen vorwärts mit `C-f` und eines nach hinten mit `C-b`.
+Mit `C-a` springst Du an den Anfang, mit `C-e` ans Ende einer Zeile. 
+Eine Zeile nach oben geht es mit `C-p`, eine nach unten mit `C-n`, ein 
+Zeichen vorwärts mit `C-f` und eines nach hinten mit `C-b`.
 
-Du kannst auch alle Zeichen von der akutellen Cursorposition bis zum Ende der Zeile mit `C-k`  löschen.
+Du kannst auch alle Zeichen von der akutellen Cursorposition bis zum 
+Ende der Zeile mit `C-k`  löschen.
 
 ## Code Aufräumen
 
@@ -49,6 +89,10 @@ Um Deinen Code sauber einzurücken, drücke `M-m`.
 
 ## Hilfesystem
 
-Um das Hilfesystem einzuschalten, drücke `M-i`. Noch hilfreicher ist allerdings `C-i`, womit das Wort, auf dem der Cursor momentan steht in der Dokumentation nachgeschlagen wird und die Ergebnisse angezeigt werden. Hilfe sofort!
+Um das Hilfesystem einzuschalten, drücke `M-i`. Noch hilfreicher ist 
+allerdings `C-i`, womit das Wort, auf dem der Cursor momentan steht in 
+der Dokumentation nachgeschlagen wird und die Ergebnisse angezeigt 
+werden. Hilfe sofort!
 
-Eine Liste aller Tastaturkürzel ist in Kapitel 10.2 Cheatsheet für Tastenkürzel enthalten.
+Eine Liste aller Tastaturkürzel ist in Kapitel 10.2 Cheatsheet für 
+Tastenkürzel enthalten.

--- a/etc/doc/tutorial/de/10.2-Shortcut-Cheatsheet.md
+++ b/etc/doc/tutorial/de/10.2-Shortcut-Cheatsheet.md
@@ -2,12 +2,14 @@
 
 # Cheatsheet für Tastaturkürzel
 
-Der folgende Abschnitt ist eine Zusammenfassung der wichtígsten Tastenkürzel, die in Sonic Pi verfügbar sind.
-Warum Du diese verwenden solltest, steht in Abschnitt 10.1.
+Der folgende Abschnitt ist eine Zusammenfassung der wichtígsten 
+Tastenkürzel, die in Sonic Pi verfügbar sind. Warum Du diese verwenden 
+solltest, steht in Abschnitt 10.1.
 
 ## Konventionen
 
-Wir verwenden die folgenden Konventionen (*Meta* ist *Alt* auf Windows und Linux und *Cmd* auf dem  Mac wie in 10.1 beschrieben):
+Wir verwenden die folgenden Konventionen (*Meta* ist *Alt* auf Windows 
+und Linux und *Cmd* auf dem  Mac wie in 10.1 beschrieben):
 
 * `C-a` bedeutet, die *Control* (*Strg* auf deutschen Tastaturen) zu drücken und zu halten, dabei *a* zu drücken und danach beide Tasten wieder loszulassen.
 * `M-r` bedeutet, *Meta* zu drücken und zu halten, dabei die *r*-Taste zu drücken und danach beide wieder loszulassen

--- a/etc/doc/tutorial/de/10.3-Sharing.md
+++ b/etc/doc/tutorial/de/10.3-Sharing.md
@@ -2,26 +2,52 @@
 
 # Teilen
 
-In Sonic Pi geht es vor allen Dingen um das Teilen und gemeinsame Lernen.
+In Sonic Pi geht es vor allen Dingen um das Teilen und gemeinsame 
+Lernen.
 
-Sobald Du gelernt hast, Musik zu programmieren, kannst Du Deine Kompositionen mit anderen teilen, indem Du ihnen einfach eine Email mit Deinem Code schickst. 
+Sobald Du gelernt hast, Musik zu programmieren, kannst Du Deine 
+Kompositionen mit anderen teilen, indem Du ihnen einfach eine Email mit 
+Deinem Code schickst. 
 
-Ich möchte Dich ermuntern, deinen Code mit anderen zu *teilen*, so dass sie von Deiner Arbeit *lernen* und Teile davon in neuen *mash-ups* verwenden können.
+Ich möchte Dich ermuntern, deinen Code mit anderen zu *teilen*, so dass 
+sie von Deiner Arbeit *lernen* und Teile davon in neuen *mash-ups* 
+verwenden können.
 
-Falls Du Dir unsicher bist, was der beste Weg ist, deine Werke mit anderen zu teilen, empfehle ich Dir, Deinen Code auf [GitHub](https://github.com) und Deine Musik auf [SoundCloud](https://soundcloud.com) zu stellen. So erreichst Du schnell ein großes Publikum.
+Falls Du Dir unsicher bist, was der beste Weg ist, deine Werke mit 
+anderen zu teilen, empfehle ich Dir, Deinen Code auf 
+[GitHub](https://github.com) und Deine Musik auf 
+[SoundCloud](https://soundcloud.com) zu stellen. So erreichst Du 
+schnell ein großes Publikum.
 
 ## Code -> GitHub
 
-[GitHub](https://github.com) ist eine Seite um Code zu teilen und damit zu arbeiten. GitHub wird von professionellen Entwicklern und auch Künstlern verwendet, um Code zu teilen und zusammenzuarbeiten. Der einfachste Weg, eine neues Stück Code (egal ob fertig oder nicht) zu teilen, ist es, ein 
-[Gist](https://gist.github.com) zu erstellen. Ein [Gist](https://gist.github.com) ist ein einfacher Weg, Code hochzuladen, so dass ihn andere sehen, kopieren und teilen können.
+[GitHub](https://github.com) ist eine Seite um Code zu teilen und damit 
+zu arbeiten. GitHub wird von professionellen Entwicklern und auch 
+Künstlern verwendet, um Code zu teilen und zusammenzuarbeiten. Der 
+einfachste Weg, eine neues Stück Code (egal ob fertig oder nicht) zu 
+teilen, ist es, ein [Gist](https://gist.github.com) zu erstellen. Ein 
+[Gist](https://gist.github.com) ist ein einfacher Weg, Code 
+hochzuladen, so dass ihn andere sehen, kopieren und teilen können.
 
 ## Audio -> SoundCloud
 
-Ein weiterer wichtiger Weg, Deine Arbeit zu teilen ist, sie aufzunehmen und auf [SoundCloud](https://soundcloud.com) hochzuladen. Sobald Du dein Stück hochgeladen hast, können andere Nutzer Kommentare dazu abgeben und es diskutieren. Zusätzlich empfehle ich, dort einen Link zu einem [Gist](https://gist.github.com), der Deinen Code enthält in die Beschreibung aufzunehmen.
+Ein weiterer wichtiger Weg, Deine Arbeit zu teilen ist, sie aufzunehmen 
+und auf [SoundCloud](https://soundcloud.com) hochzuladen. Sobald Du 
+dein Stück hochgeladen hast, können andere Nutzer Kommentare dazu 
+abgeben und es diskutieren. Zusätzlich empfehle ich, dort einen Link zu 
+einem [Gist](https://gist.github.com), der Deinen Code enthält in die 
+Beschreibung aufzunehmen.
 
-Um Dein dein Stück aufzunehmen, drücke den `Rec`-Knopf in der Werkzeugleiste, die Aufnahme startet dann sofort. Drücke `Run`, um Deinen Code zu startenm wenn er nicht bereits läuft. Wenn Du fertig bist, drücke den den blinkenden `Rec`-Knopf erneut. Du wirst dann nach einem Dateinamen gefragt, unter dem die Aufnahme als WAV-Datei gespeichert wird. Dieses Format kannst Du dann mit vielen Werkzeugen (wie zum Beispiel Audacity) in MP3 umwandeln.
+Um Dein dein Stück aufzunehmen, drücke den `Rec`-Knopf in der 
+Werkzeugleiste, die Aufnahme startet dann sofort. Drücke `Run`, um 
+Deinen Code zu startenm wenn er nicht bereits läuft. Wenn Du fertig 
+bist, drücke den den blinkenden `Rec`-Knopf erneut. Du wirst dann nach 
+einem Dateinamen gefragt, unter dem die Aufnahme als WAV-Datei 
+gespeichert wird. Dieses Format kannst Du dann mit vielen Werkzeugen 
+(wie zum Beispiel Audacity) in MP3 umwandeln.
 
 ## Hoffung
 
-Ich möchte Dich ermutigen, Deine Arbeiten zu teilen und hoffe sehr, dass wir uns gegenseitig neue Sonic Pi Tipps und Tricks beibringen werden.
-Ich bin schon sehr gespannt darauf, was Du mir zeigen wirst.
+Ich möchte Dich ermutigen, Deine Arbeiten zu teilen und hoffe sehr, 
+dass wir uns gegenseitig neue Sonic Pi Tipps und Tricks beibringen 
+werden. Ich bin schon sehr gespannt darauf, was Du mir zeigen wirst.

--- a/etc/doc/tutorial/de/10.4-Performing.md
+++ b/etc/doc/tutorial/de/10.4-Performing.md
@@ -2,28 +2,41 @@
 
 # Auftritte
 
-Einer der aufregendsten Aspekte von Sonic Pi ist, dass es Dir erlaubt, Code als *Musikinstrument* zu verwenden. Das bedeutet, dass live programmieren jetzt als neuer Weg gesehen werden kann, Musik auzuführen.
+Einer der aufregendsten Aspekte von Sonic Pi ist, dass es Dir erlaubt, 
+Code als *Musikinstrument* zu verwenden. Das bedeutet, dass live 
+programmieren jetzt als neuer Weg gesehen werden kann, Musik 
+auzuführen.
 
 Das nennen wir *Live Coding*.
 
 ## Zeig Deinen Bildschirm
 
-Wenn Du live programmierst, empfehle ich Dir, Deinem Publikum Deinen *Bildschirm zu zeigen*. Sonst ist das wie wenn Du Gitarre spielst, Deine Finger und die Saiten aber versteckst.
-Wenn ich zuhause übe, verwende ich einen Raspberry Pi und projeziere den Bildschirm mit einem kleinen Beamer an meine Wohnzimmerwand. Du könntest auch Deinen Fernseher oder einen Projektor in der Schule/Arbeit verwenden um eine kleine Show zu geben.
-Versuch es, das macht eine Menge Spaß.
+Wenn Du live programmierst, empfehle ich Dir, Deinem Publikum Deinen 
+*Bildschirm zu zeigen*. Sonst ist das wie wenn Du Gitarre spielst, 
+Deine Finger und die Saiten aber versteckst. Wenn ich zuhause übe, 
+verwende ich einen Raspberry Pi und projeziere den Bildschirm mit einem 
+kleinen Beamer an meine Wohnzimmerwand. Du könntest auch Deinen 
+Fernseher oder einen Projektor in der Schule/Arbeit verwenden um eine 
+kleine Show zu geben. Versuch es, das macht eine Menge Spaß.
 
 ## Gründe eine Band
 
-Spiele nicht nur alleine - gründe eine live coding Band! Mit anderen zu jammen macht großen Spaß. Einer könnte die Beats programmieren, ein weiter flächige Hintergrundklänge und so weiter.
-Probiert aus, welche interessanten Klangkombinationen Ihr finden könnt.
+Spiele nicht nur alleine - gründe eine live coding Band! Mit anderen zu 
+jammen macht großen Spaß. Einer könnte die Beats programmieren, ein 
+weiter flächige Hintergrundklänge und so weiter. Probiert aus, welche 
+interessanten Klangkombinationen Ihr finden könnt.
 
 ## TOPLAP
 
-Live coding ist keine ganz neue Erscheinung - eine kleine Anzahl von Leuten macht das schon seit Jahren, typischerweise mit selbstgebauten, individuellen Systemen.
+Live coding ist keine ganz neue Erscheinung - eine kleine Anzahl von 
+Leuten macht das schon seit Jahren, typischerweise mit selbstgebauten, 
+individuellen Systemen.
 
-Ein guter Platz und mehr über andere Live-Coder und -Systeme zu erfahren, ist [TOPLAP](http://toplap.org).
+Ein guter Platz und mehr über andere Live-Coder und -Systeme zu 
+erfahren, ist [TOPLAP](http://toplap.org).
 
 ## Algorave
 
-Eine weitere tolle Ressource, die bei der Entdeckung der Live-Coding Welt helfen kann, ist  
-[Algorave](http://algorave.com). Hier findest Du alles über ein spezielles Genre von Nightclub Live-Coding.
+Eine weitere tolle Ressource, die bei der Entdeckung der Live-Coding 
+Welt helfen kann, ist [Algorave](http://algorave.com). Hier findest Du 
+alles über ein spezielles Genre von Nightclub Live-Coding.

--- a/etc/doc/tutorial/de/11-Conclusions.md
+++ b/etc/doc/tutorial/de/11-Conclusions.md
@@ -2,13 +2,25 @@
 
 # Abschluss
 
-Das ist das Ende der Sonic Pi Einführung. Hoffentlich hast Du etwas dabei gelernt. Keine Angst, falls Du das Gefühl hast, nicht alles verstanden zu haben - spiele einfach weiter und hab Spaß dabei. Dann wird immer mehr hängenbleiben.Und komm einfach auf das Tutorial zurück, wenn Du eine Frage hast, die in einem der vorhergegangenen Kapitel behandelt worden sein könnte.  
+Das ist das Ende der Sonic Pi Einführung. Hoffentlich hast Du etwas 
+dabei gelernt. Keine Angst, falls Du das Gefühl hast, nicht alles 
+verstanden zu haben - spiele einfach weiter und hab Spaß dabei. Dann 
+wird immer mehr hängenbleiben.Und komm einfach auf das Tutorial zurück, 
+wenn Du eine Frage hast, die in einem der vorhergegangenen Kapitel 
+behandelt worden sein könnte.  
 
-Wenn Du Fragen hast, die über die Einführung hinausgehen, schau doch im [Sonic Pi Forum](http://groups.google.com/group/sonic-pi/) vorbei und stelle Deine Frage dort. Es gibt viele nette Menschen da, die dir gerne zur Hand gehen. 
+Wenn Du Fragen hast, die über die Einführung hinausgehen, schau doch im 
+[Sonic Pi Forum](http://groups.google.com/group/sonic-pi/) vorbei und 
+stelle Deine Frage dort. Es gibt viele nette Menschen da, die dir gerne 
+zur Hand gehen. 
 
-Du bist auch eingeladen, dir den Rest der Dokumentation im Hilfe-System genauer anzuschauen. Es gibt noch eine Reihe von Features, die in dieser Einführung nicht behandelt wurden und darauf warten, von Dir entdeckt zu werden.
+Du bist auch eingeladen, dir den Rest der Dokumentation im Hilfe-System 
+genauer anzuschauen. Es gibt noch eine Reihe von Features, die in 
+dieser Einführung nicht behandelt wurden und darauf warten, von Dir 
+entdeckt zu werden.
 
-Also: spiele, hab Spaß, teile Deine Code, tritt vor Freunden auf, zeige was Du auf dem Monitor hast und nicht vergessen:
+Also: spiele, hab Spaß, teile Deine Code, tritt vor Freunden auf, zeige 
+was Du auf dem Monitor hast und nicht vergessen:
 
 *There are no mistakes, only opportunities.*
 (Es gibt keine Fehler, nur Möglichkeiten)


### PR DESCRIPTION
Hi,

in preparation for a proofreading session, this changes the formatting of the German markdown files to follow the original English files' formatting. Also fixes some minor formatting issues. I hope @mbutz @st01c @wwerner will approve this. Thanks.

Next: The actual proofreading. :-)