### PR TITLE
Support custom colors themes

### DIFF
--- a/app/gui/qt/SonicPi.pro
+++ b/app/gui/qt/SonicPi.pro
@@ -59,7 +59,8 @@ SOURCES += main.cpp \
            oschandler.cpp \
            sonicpiserver.cpp \
            sonicpiudpserver.cpp \
-           sonicpitcpserver.cpp
+           sonicpitcpserver.cpp \
+           sonicpitheme.cpp
 win32 {
 # have to link these explicitly for some reason
   SOURCES += platform/win/moc_qsciscintilla.cpp \
@@ -76,7 +77,8 @@ HEADERS  += mainwindow.h \
             sonicpiserver.h \
             sonicpiudpserver.h \
             ruby_help.h \
-            sonicpitcpserver.h
+            sonicpitcpserver.h \
+            sonicpitheme.h
 
 TRANSLATIONS = lang/sonic-pi_de.ts
 

--- a/app/gui/qt/mainwindow.cpp
+++ b/app/gui/qt/mainwindow.cpp
@@ -154,7 +154,20 @@ MainWindow::MainWindow(QApplication &app, bool i18n, QSplashScreen* splash)
   tabs->setTabPosition(QTabWidget::South);
 
   // Syntax highlighting
-  lexer = new SonicPiLexer;
+  QFile file("/Users/josephwilk/.sonic-pi/theme.json");
+  if(file.exists()){
+    qDebug() << "[GUI] Custom colors";
+    file.open(QIODevice::ReadOnly);
+    QByteArray rawData = file.readAll();
+    QJsonDocument doc(QJsonDocument::fromJson(rawData));
+    QJsonObject json = doc.object();
+    lexer = new SonicPiLexer(json);
+  }
+  else{
+    qDebug() << "[GUI] Default colors";
+    lexer = new SonicPiLexer(QJsonObject());
+  }
+
   lexer->setAutoIndentStyle(SonicPiScintilla::AiMaintain);
 
   // create workspaces and add them to the tabs

--- a/app/gui/qt/mainwindow.cpp
+++ b/app/gui/qt/mainwindow.cpp
@@ -154,11 +154,13 @@ MainWindow::MainWindow(QApplication &app, bool i18n, QSplashScreen* splash)
   tabs->setTabPosition(QTabWidget::South);
 
   // Syntax highlighting
-  QFile file("/Users/josephwilk/.sonic-pi/theme.json");
-  if(file.exists()){
+
+  QString themeFilename = QDir::homePath() + "/.sonic-pi/theme.json";
+  QFile themeFile(themeFilename);
+  if(themeFile.exists()){
     qDebug() << "[GUI] Custom colors";
-    file.open(QIODevice::ReadOnly);
-    QByteArray rawData = file.readAll();
+    themeFile.open(QIODevice::ReadOnly);
+    QByteArray rawData = themeFile.readAll();
     QJsonDocument doc(QJsonDocument::fromJson(rawData));
     QJsonObject json = doc.object();
     lexer = new SonicPiLexer(json);

--- a/app/gui/qt/mainwindow.cpp
+++ b/app/gui/qt/mainwindow.cpp
@@ -155,7 +155,7 @@ MainWindow::MainWindow(QApplication &app, bool i18n, QSplashScreen* splash)
 
   // Syntax highlighting
 
-  QString themeFilename = QDir::homePath() + "/.sonic-pi/theme.json";
+  QString themeFilename = QDir::homePath() + QDir::separator() + ".sonic-pi" + QDir::separator() + "theme.json";
   QFile themeFile(themeFilename);
   if(themeFile.exists()){
     qDebug() << "[GUI] Custom colors";

--- a/app/gui/qt/mainwindow.cpp
+++ b/app/gui/qt/mainwindow.cpp
@@ -923,7 +923,8 @@ void MainWindow::runCode()
     ws->getCursorPosition(&currentLine, &currentIndex);
   }
   ws->setReadOnly(true);
-  ws->selectAll();
+  lexer->highlightAll();
+
   resetErrorPane();
   statusBar()->showMessage(tr("Running Code..."), 1000);
   std::string code = ((SonicPiScintilla*)tabs->currentWidget())->text().toStdString();
@@ -958,7 +959,7 @@ void MainWindow::runCode()
 void MainWindow::unhighlightCode()
 {
   SonicPiScintilla *ws = (SonicPiScintilla *)tabs->currentWidget();
-  ws->selectAll(false);
+  lexer->unhighlightAll();
   if (currentLine != 0 || currentIndex != 0) {
     ws->setCursorPosition(currentLine, currentIndex);
     currentLine = 0; currentIndex = 0;

--- a/app/gui/qt/mainwindow.cpp
+++ b/app/gui/qt/mainwindow.cpp
@@ -67,6 +67,7 @@
 #include "sonicpilexer.h"
 #include "sonicpiapis.h"
 #include "sonicpiscintilla.h"
+#include "sonicpitheme.h"
 
 #include "oschandler.h"
 #include "sonicpiudpserver.h"
@@ -157,19 +158,19 @@ MainWindow::MainWindow(QApplication &app, bool i18n, QSplashScreen* splash)
 
   QString themeFilename = QDir::homePath() + QDir::separator() + ".sonic-pi" + QDir::separator() + "theme.json";
   QFile themeFile(themeFilename);
-  QJsonObject themeSettings;
+  SonicPiTheme *theme;
   if(themeFile.exists()){
     qDebug() << "[GUI] Custom colors";
     themeFile.open(QIODevice::ReadOnly);
     QByteArray rawData = themeFile.readAll();
     QJsonDocument doc(QJsonDocument::fromJson(rawData));
-    themeSettings = doc.object();
-    lexer = new SonicPiLexer(themeSettings);
+    theme = new SonicPiTheme(this, doc.object());
+    lexer = new SonicPiLexer(theme);
   }
   else{
     qDebug() << "[GUI] Default colors";
-    themeSettings = QJsonObject();
-    lexer = new SonicPiLexer(themeSettings);
+    theme = new SonicPiTheme(this, QJsonObject());
+    lexer = new SonicPiLexer(theme);
   }
 
   lexer->setAutoIndentStyle(SonicPiScintilla::AiMaintain);
@@ -181,7 +182,7 @@ MainWindow::MainWindow(QApplication &app, bool i18n, QSplashScreen* splash)
     std::string s;
 
 
-    SonicPiScintilla *workspace = new SonicPiScintilla(lexer, themeSettings);
+    SonicPiScintilla *workspace = new SonicPiScintilla(lexer, theme);
 
     //tab completion when in list
     QShortcut *indentLine = new QShortcut(QKeySequence("Tab"), workspace);

--- a/app/gui/qt/mainwindow.cpp
+++ b/app/gui/qt/mainwindow.cpp
@@ -157,17 +157,19 @@ MainWindow::MainWindow(QApplication &app, bool i18n, QSplashScreen* splash)
 
   QString themeFilename = QDir::homePath() + QDir::separator() + ".sonic-pi" + QDir::separator() + "theme.json";
   QFile themeFile(themeFilename);
+  QJsonObject themeSettings;
   if(themeFile.exists()){
     qDebug() << "[GUI] Custom colors";
     themeFile.open(QIODevice::ReadOnly);
     QByteArray rawData = themeFile.readAll();
     QJsonDocument doc(QJsonDocument::fromJson(rawData));
-    QJsonObject json = doc.object();
-    lexer = new SonicPiLexer(json);
+    themeSettings = doc.object();
+    lexer = new SonicPiLexer(themeSettings);
   }
   else{
     qDebug() << "[GUI] Default colors";
-    lexer = new SonicPiLexer(QJsonObject());
+    themeSettings = QJsonObject();
+    lexer = new SonicPiLexer(themeSettings);
   }
 
   lexer->setAutoIndentStyle(SonicPiScintilla::AiMaintain);
@@ -179,7 +181,7 @@ MainWindow::MainWindow(QApplication &app, bool i18n, QSplashScreen* splash)
     std::string s;
 
 
-    SonicPiScintilla *workspace = new SonicPiScintilla(lexer);
+    SonicPiScintilla *workspace = new SonicPiScintilla(lexer, themeSettings);
 
     //tab completion when in list
     QShortcut *indentLine = new QShortcut(QKeySequence("Tab"), workspace);

--- a/app/gui/qt/sonicpilexer.cpp
+++ b/app/gui/qt/sonicpilexer.cpp
@@ -19,6 +19,8 @@
 
 SonicPiLexer::SonicPiLexer(SonicPiTheme *theme) : QsciLexerRuby() {
     this->theme = theme;
+    this->setDefaultColor(theme->color("Foreground"));
+    this->setDefaultPaper(theme->color("Background"));
 }
 
 #if defined(Q_OS_WIN)
@@ -131,8 +133,6 @@ QColor SonicPiLexer::defaultPaper(int style) const
       return theme->color("StdoutBackground");
     case Stderr:
       return theme->color("StderrBackground");
-    default:
-      return theme->color("DefaultBackground");
     }
 
     return QsciLexer::defaultPaper(style);

--- a/app/gui/qt/sonicpilexer.cpp
+++ b/app/gui/qt/sonicpilexer.cpp
@@ -42,12 +42,14 @@ QStringList QsciLexer::autoCompletionWordSeparators() const {
 void SonicPiLexer::highlightAll()
 {
     setPaper(QColor("deeppink"),-1);
+    setColor(QColor("white"), -1);
     this->setDefaultPaper(theme->color("Background"));
 }
 
 void SonicPiLexer::unhighlightAll()
 {
     setPaper(theme->color("DefaultBackground"),-1);
+    this->setDefaultColor(theme->color("Foreground"));
 }
 
 QColor SonicPiLexer::defaultColor(int style) const

--- a/app/gui/qt/sonicpilexer.cpp
+++ b/app/gui/qt/sonicpilexer.cpp
@@ -45,6 +45,22 @@ SonicPiLexer::SonicPiLexer(const QJsonObject& customTheme) : QsciLexerRuby() {
     defaultTheme["HereDocumentDelimiter"] = "#000000";
     defaultTheme["PercentStringr"] = "#000000";
     defaultTheme["PercentStringw"] = "#000000";
+
+    defaultTheme["CommentBackground"] = "white";
+    defaultTheme["ErrorBackground"] = "#c0xffc0";
+    defaultTheme["PODBackground"] = "#ff0000";
+    defaultTheme["RegexBackground"] = "#a0ffa0";
+    defaultTheme["PercentStringrBackground"] = "#a0ffa0";
+    defaultTheme["BackticksBackground"] = "yellow";
+    defaultTheme["PercentStringxBackground"] = "yellow";
+    defaultTheme["DataSectionBackground"] = "#fff0d8";
+    defaultTheme["HereDocumentDelimiterBackground"] = "#ddd0dd";
+    defaultTheme["HereDocumentBackground"] = "#ddd0dd";
+    defaultTheme["PercentStringwBackground"] = "#ffffe0";
+    defaultTheme["StdinBackground"] = "#ff8080";
+    defaultTheme["StdoutBackground"] = "#ff8080";
+    defaultTheme["StderrBackground"] = "#ff8080";
+
     this->theme = defaultTheme;
   }
   else{
@@ -128,43 +144,38 @@ QColor SonicPiLexer::defaultColor(int style) const
 }
 
 // Returns the background colour of the text for a style.
-QColor QsciLexerRuby::defaultPaper(int style) const
+QColor SonicPiLexer::defaultPaper(int style) const
 {
   switch (style)
     {
     case Comment:
-      //      return QColor(94,94,94);
-      return QColor("white");
-      //return QColor(202, 225, 255); // lilac
-      //      return QColor(191,239,255); //nice light blue
+       return QColor(theme["CommentBackground"].toString());
     case Error:
-        return QColor(0xff,0x00,0x00);
-
+      return QColor(theme["ErrorBackground"].toString());
     case POD:
-        return QColor(0xc0,0xff,0xc0);
-
+      return QColor(theme["PODBackground"].toString());
     case Regex:
+      return QColor(theme["RegexBackground"].toString());
     case PercentStringr:
-        return QColor(0xa0,0xff,0xa0);
-
+      return QColor(theme["PercentStringrBackground"].toString());
     case Backticks:
+      return QColor(theme["BackticksBackground"].toString());
     case PercentStringx:
-        return QColor("yellow");
-
+      return QColor(theme["PercentStringxBackground"].toString());
     case DataSection:
-        return QColor(0xff,0xf0,0xd8);
-
+      return QColor(theme["DataSectionBackground"].toString());
     case HereDocumentDelimiter:
+      return QColor(theme["DocumentDelimiterBackground"].toString());
     case HereDocument:
-        return QColor(0xdd,0xd0,0xdd);
-
+      return QColor(theme["HereDocumentBackground"].toString());
     case PercentStringw:
-        return QColor(0xff,0xff,0xe0);
-
+      return QColor(theme["PercentStringwBackground"].toString());
     case Stdin:
+      return QColor(theme["StdinBackground"].toString());
     case Stdout:
+      return QColor(theme["StdoutBackground"].toString());
     case Stderr:
-        return QColor(0xff,0x80,0x80);
+      return QColor(theme["StderrBackground"].toString());
     }
 
     return QsciLexer::defaultPaper(style);

--- a/app/gui/qt/sonicpilexer.cpp
+++ b/app/gui/qt/sonicpilexer.cpp
@@ -16,6 +16,42 @@
 #include <qfont.h>
 
 
+
+SonicPiLexer::SonicPiLexer(const QJsonObject& customTheme) : QsciLexerRuby() {
+  if(customTheme.empty()){
+    QJsonObject defaultTheme = QJsonObject();
+    defaultTheme["Default"] = "#808080";
+    defaultTheme["Comment"] = "#5e5e5e";
+    defaultTheme["POD"] = "#004000";
+    defaultTheme["Number"] = "DodgerBlue";
+    defaultTheme["FunctionMethodName"] = "LimeGreen";
+    defaultTheme["Keyword"] = "DarkOrange";
+    defaultTheme["DemotedKeyword"] = "DarkOrange";
+    defaultTheme["ClassName"] = "Lavender";
+    defaultTheme["Global"] = "Red";
+    defaultTheme["Symbol"] = "DeepPink";
+    defaultTheme["ModuleName"] = "yellow";
+    defaultTheme["InstanceVariable"] = "#b00080";
+    defaultTheme["ClassVariable"] = "#8000b0";
+    defaultTheme["Backticks"] = "Red";
+    defaultTheme["PercentStringx"] = "Red";
+    defaultTheme["DataSection"] = "#600000";
+    defaultTheme["DoubleQuotedString"] = "DarkGreen";
+    defaultTheme["SingleQuotedString"] = "DarkGreen";
+    defaultTheme["HereDocument"] = "DarkGreen";
+    defaultTheme["PercentString"] = "DarkGreen";
+    defaultTheme["PercentStringQ"] = "DarkGreen";
+    defaultTheme["Regex"] = "#000000";
+    defaultTheme["HereDocumentDelimiter"] = "#000000";
+    defaultTheme["PercentStringr"] = "#000000";
+    defaultTheme["PercentStringw"] = "#000000";
+    this->theme = defaultTheme;
+  }
+  else{
+    this->theme = customTheme;
+  }
+}
+
 #if defined(Q_OS_WIN)
 static char default_font[] = "Courier New";
 #elif defined(Q_OS_MAC)
@@ -24,6 +60,7 @@ static char default_font[] = "Menlo";
 static char default_font[] = "Bitstream Vera Sans Mono";
 #endif
 
+
 // triggers autocompletion for the next word
 QStringList QsciLexer::autoCompletionWordSeparators() const {
   QStringList seps;
@@ -31,72 +68,61 @@ QStringList QsciLexer::autoCompletionWordSeparators() const {
   return seps;
 }
 
-// Returns the foreground colour of the text for a style.
-QColor QsciLexerRuby::defaultColor(int style) const
+QColor SonicPiLexer::defaultColor(int style) const
 {
     switch (style)
     {
     case Default:
-      //        return QColor(0x80,0x80,0x80);
-      return QColor(60, 60, 60);
-
+      return QColor(theme["Default"].toString());
     case Comment:
-      //      return QColor(40, 40, 40);
-      //return QColor(60, 60, 60);
-      return QColor("#5e5e5e");
+      return QColor(theme["Comment"].toString());
     case POD:
-        return QColor(0x00,0x40,0x00);
-
+      return QColor(theme["POD"].toString());
     case Number:
-      return QColor("DodgerBlue");
-
+      return QColor(theme["Number"].toString());
     case FunctionMethodName:
-        return QColor("LimeGreen");
-
+      return QColor(theme["FunctionMethodName"].toString());
     case Keyword:
+      return QColor(theme["Keyword"].toString());
     case DemotedKeyword:
-        return QColor("DarkOrange");
-
+      return QColor(theme["DemotedKeyword"].toString());
     case DoubleQuotedString:
+      return QColor(theme["DoubleQuotedString"].toString());
     case SingleQuotedString:
+      return QColor(theme["SingleQuotedString"].toString());
     case HereDocument:
+      return QColor(theme["HereDocument"].toString());
     case PercentStringq:
+      return QColor(theme["PercentStringq"].toString());
     case PercentStringQ:
-        return QColor("DarkGreen");
-
+      return QColor(theme["PercentStringQ"].toString());
     case ClassName:
-        return QColor("Lavender");
-
+      return QColor(theme["ClassName"].toString());
     case Regex:
+      return QColor(theme["Regex"].toString());
     case HereDocumentDelimiter:
+      return QColor(theme["HereDocumentDelimiter"].toString());
     case PercentStringr:
+      return QColor(theme["PercentStringr"].toString());
     case PercentStringw:
-        return QColor(0x00,0x00,0x00);
-
+      return QColor(theme["PercentStringw"].toString());
     case Global:
-        return QColor("Red");
-
+      return QColor(theme["Global"].toString());
     case Symbol:
-      return QColor("DeepPink");
-
+      return QColor(theme["Symbol"].toString());
     case ModuleName:
-        return QColor("yellow");
-
+      return QColor(theme["ModuleName"].toString());
     case InstanceVariable:
-        return QColor(0xb0,0x00,0x80);
-
+      return QColor(theme["InstanceVariable"].toString());
     case ClassVariable:
-        return QColor(0x80,0x00,0xb0);
-
+      return QColor(theme["ClassVariable"].toString());
     case Backticks:
+      return QColor(theme["Backticks"].toString());
     case PercentStringx:
-        return QColor("Red");
-
+      return QColor(theme["PercentStringx"].toString());
     case DataSection:
-      return QColor(0x60,0x00,0x00);
-
+      return QColor(theme["DataSection"].toString());
     }
-
 
     return QsciLexer::defaultColor(style);
 }

--- a/app/gui/qt/sonicpilexer.cpp
+++ b/app/gui/qt/sonicpilexer.cpp
@@ -102,7 +102,7 @@ QColor SonicPiLexer::defaultColor(int style) const
 QColor SonicPiLexer::defaultPaper(int style) const
 {
   switch (style)
-    {
+  {
     case Default:
       return theme->color("DefaultBackground");
     case Comment:
@@ -133,9 +133,36 @@ QColor SonicPiLexer::defaultPaper(int style) const
       return theme->color("StdoutBackground");
     case Stderr:
       return theme->color("StderrBackground");
-    }
-
-    return QsciLexer::defaultPaper(style);
+    case FunctionMethodName:
+      return theme->color("FunctionMethodNameBackground");
+    case Number:
+     return theme->color("NumberBackground");
+    case Keyword:
+      return theme->color("KeywordBackground");
+    case DemotedKeyword:
+      return theme->color("DemotedKeywordBackground");
+    case DoubleQuotedString:
+      return theme->color("DoubleQuotedStringBackground");
+    case SingleQuotedString:
+      return theme->color("SingleQuotedStringBackground");
+    case PercentStringq:
+      return theme->color("PercentStringqBackground");
+    case PercentStringQ:
+      return theme->color("PercentStringQBackground");
+    case ClassName:
+      return theme->color("ClassNameBackground");
+    case Global:
+      return theme->color("GlobalBackground");
+    case Symbol:
+      return theme->color("SymbolBackground");
+    case ModuleName:
+      return theme->color("ModuleNameBackground");
+    case InstanceVariable:
+      return theme->color("InstanceVariableBackground");
+    case ClassVariable:
+      return theme->color("ClassVariableBackground");
+  }
+  return QsciLexer::defaultPaper(style);
 }
 
 

--- a/app/gui/qt/sonicpilexer.cpp
+++ b/app/gui/qt/sonicpilexer.cpp
@@ -39,6 +39,17 @@ QStringList QsciLexer::autoCompletionWordSeparators() const {
   return seps;
 }
 
+void SonicPiLexer::highlightAll()
+{
+    setPaper(QColor("deeppink"),-1);
+    this->setDefaultPaper(theme->color("Background"));
+}
+
+void SonicPiLexer::unhighlightAll()
+{
+    setPaper(theme->color("DefaultBackground"),-1);
+}
+
 QColor SonicPiLexer::defaultColor(int style) const
 {
     switch (style)

--- a/app/gui/qt/sonicpilexer.cpp
+++ b/app/gui/qt/sonicpilexer.cpp
@@ -46,6 +46,7 @@ SonicPiLexer::SonicPiLexer(const QJsonObject& customTheme) : QsciLexerRuby() {
     defaultTheme["PercentStringr"] = "#000000";
     defaultTheme["PercentStringw"] = "#000000";
 
+    defaultTheme["DefaultBackground"] = "white";
     defaultTheme["CommentBackground"] = "white";
     defaultTheme["ErrorBackground"] = "#c0xffc0";
     defaultTheme["PODBackground"] = "#ff0000";
@@ -148,6 +149,8 @@ QColor SonicPiLexer::defaultPaper(int style) const
 {
   switch (style)
     {
+    case Default:
+      return QColor(theme["DefaultBackground"].toString());
     case Comment:
        return QColor(theme["CommentBackground"].toString());
     case Error:
@@ -176,6 +179,8 @@ QColor SonicPiLexer::defaultPaper(int style) const
       return QColor(theme["StdoutBackground"].toString());
     case Stderr:
       return QColor(theme["StderrBackground"].toString());
+    default:
+      return QColor(theme["DefaultBackground"].toString());
     }
 
     return QsciLexer::defaultPaper(style);

--- a/app/gui/qt/sonicpilexer.cpp
+++ b/app/gui/qt/sonicpilexer.cpp
@@ -18,55 +18,57 @@
 
 
 SonicPiLexer::SonicPiLexer(const QJsonObject& customTheme) : QsciLexerRuby() {
-  if(customTheme.empty()){
-    QJsonObject defaultTheme = QJsonObject();
-    defaultTheme["Default"] = "#808080";
-    defaultTheme["Comment"] = "#5e5e5e";
-    defaultTheme["POD"] = "#004000";
-    defaultTheme["Number"] = "DodgerBlue";
-    defaultTheme["FunctionMethodName"] = "LimeGreen";
-    defaultTheme["Keyword"] = "DarkOrange";
-    defaultTheme["DemotedKeyword"] = "DarkOrange";
-    defaultTheme["ClassName"] = "Lavender";
-    defaultTheme["Global"] = "Red";
-    defaultTheme["Symbol"] = "DeepPink";
-    defaultTheme["ModuleName"] = "yellow";
-    defaultTheme["InstanceVariable"] = "#b00080";
-    defaultTheme["ClassVariable"] = "#8000b0";
-    defaultTheme["Backticks"] = "Red";
-    defaultTheme["PercentStringx"] = "Red";
-    defaultTheme["DataSection"] = "#600000";
-    defaultTheme["DoubleQuotedString"] = "DarkGreen";
-    defaultTheme["SingleQuotedString"] = "DarkGreen";
-    defaultTheme["HereDocument"] = "DarkGreen";
-    defaultTheme["PercentString"] = "DarkGreen";
-    defaultTheme["PercentStringQ"] = "DarkGreen";
-    defaultTheme["Regex"] = "#000000";
-    defaultTheme["HereDocumentDelimiter"] = "#000000";
-    defaultTheme["PercentStringr"] = "#000000";
-    defaultTheme["PercentStringw"] = "#000000";
+  QJsonObject themeSettings = QJsonObject();
+  themeSettings["Default"] = "#808080";
+  themeSettings["Comment"] = "#5e5e5e";
+  themeSettings["POD"] = "#004000";
+  themeSettings["Number"] = "DodgerBlue";
+  themeSettings["FunctionMethodName"] = "LimeGreen";
+  themeSettings["Keyword"] = "DarkOrange";
+  themeSettings["DemotedKeyword"] = "DarkOrange";
+  themeSettings["ClassName"] = "Lavender";
+  themeSettings["Global"] = "Red";
+  themeSettings["Symbol"] = "DeepPink";
+  themeSettings["ModuleName"] = "yellow";
+  themeSettings["InstanceVariable"] = "#b00080";
+  themeSettings["ClassVariable"] = "#8000b0";
+  themeSettings["Backticks"] = "Red";
+  themeSettings["PercentStringx"] = "Red";
+  themeSettings["DataSection"] = "#600000";
+  themeSettings["DoubleQuotedString"] = "DarkGreen";
+  themeSettings["SingleQuotedString"] = "DarkGreen";
+  themeSettings["HereDocument"] = "DarkGreen";
+  themeSettings["PercentString"] = "DarkGreen";
+  themeSettings["PercentStringQ"] = "DarkGreen";
+  themeSettings["Regex"] = "#000000";
+  themeSettings["HereDocumentDelimiter"] = "#000000";
+  themeSettings["PercentStringr"] = "#000000";
+  themeSettings["PercentStringw"] = "#000000";
 
-    defaultTheme["DefaultBackground"] = "white";
-    defaultTheme["CommentBackground"] = "white";
-    defaultTheme["ErrorBackground"] = "#c0xffc0";
-    defaultTheme["PODBackground"] = "#ff0000";
-    defaultTheme["RegexBackground"] = "#a0ffa0";
-    defaultTheme["PercentStringrBackground"] = "#a0ffa0";
-    defaultTheme["BackticksBackground"] = "yellow";
-    defaultTheme["PercentStringxBackground"] = "yellow";
-    defaultTheme["DataSectionBackground"] = "#fff0d8";
-    defaultTheme["HereDocumentDelimiterBackground"] = "#ddd0dd";
-    defaultTheme["HereDocumentBackground"] = "#ddd0dd";
-    defaultTheme["PercentStringwBackground"] = "#ffffe0";
-    defaultTheme["StdinBackground"] = "#ff8080";
-    defaultTheme["StdoutBackground"] = "#ff8080";
-    defaultTheme["StderrBackground"] = "#ff8080";
+  themeSettings["DefaultBackground"] = "white";
+  themeSettings["CommentBackground"] = "white";
+  themeSettings["ErrorBackground"] = "#c0xffc0";
+  themeSettings["PODBackground"] = "#ff0000";
+  themeSettings["RegexBackground"] = "#a0ffa0";
+  themeSettings["PercentStringrBackground"] = "#a0ffa0";
+  themeSettings["BackticksBackground"] = "yellow";
+  themeSettings["PercentStringxBackground"] = "yellow";
+  themeSettings["DataSectionBackground"] = "#fff0d8";
+  themeSettings["HereDocumentDelimiterBackground"] = "#ddd0dd";
+  themeSettings["HereDocumentBackground"] = "#ddd0dd";
+  themeSettings["PercentStringwBackground"] = "#ffffe0";
+  themeSettings["StdinBackground"] = "#ff8080";
+  themeSettings["StdoutBackground"] = "#ff8080";
+  themeSettings["StderrBackground"] = "#ff8080";
 
-    this->theme = defaultTheme;
+    //this->theme = themeSettings;
+
+  QStringList customSettings = customTheme.keys();
+  for(int idx=0; idx < customSettings.size(); idx++){
+    themeSettings[customSettings[idx]] = customTheme[customSettings[idx]];
   }
-  else{
-    this->theme = customTheme;
-  }
+
+  this->theme = themeSettings;
 }
 
 #if defined(Q_OS_WIN)

--- a/app/gui/qt/sonicpilexer.cpp
+++ b/app/gui/qt/sonicpilexer.cpp
@@ -17,58 +17,8 @@
 
 
 
-SonicPiLexer::SonicPiLexer(const QJsonObject& customTheme) : QsciLexerRuby() {
-  QJsonObject themeSettings = QJsonObject();
-  themeSettings["Default"] = "#808080";
-  themeSettings["Comment"] = "#5e5e5e";
-  themeSettings["POD"] = "#004000";
-  themeSettings["Number"] = "DodgerBlue";
-  themeSettings["FunctionMethodName"] = "LimeGreen";
-  themeSettings["Keyword"] = "DarkOrange";
-  themeSettings["DemotedKeyword"] = "DarkOrange";
-  themeSettings["ClassName"] = "Lavender";
-  themeSettings["Global"] = "Red";
-  themeSettings["Symbol"] = "DeepPink";
-  themeSettings["ModuleName"] = "yellow";
-  themeSettings["InstanceVariable"] = "#b00080";
-  themeSettings["ClassVariable"] = "#8000b0";
-  themeSettings["Backticks"] = "Red";
-  themeSettings["PercentStringx"] = "Red";
-  themeSettings["DataSection"] = "#600000";
-  themeSettings["DoubleQuotedString"] = "DarkGreen";
-  themeSettings["SingleQuotedString"] = "DarkGreen";
-  themeSettings["HereDocument"] = "DarkGreen";
-  themeSettings["PercentString"] = "DarkGreen";
-  themeSettings["PercentStringQ"] = "DarkGreen";
-  themeSettings["Regex"] = "#000000";
-  themeSettings["HereDocumentDelimiter"] = "#000000";
-  themeSettings["PercentStringr"] = "#000000";
-  themeSettings["PercentStringw"] = "#000000";
-
-  themeSettings["DefaultBackground"] = "white";
-  themeSettings["CommentBackground"] = "white";
-  themeSettings["ErrorBackground"] = "#c0xffc0";
-  themeSettings["PODBackground"] = "#ff0000";
-  themeSettings["RegexBackground"] = "#a0ffa0";
-  themeSettings["PercentStringrBackground"] = "#a0ffa0";
-  themeSettings["BackticksBackground"] = "yellow";
-  themeSettings["PercentStringxBackground"] = "yellow";
-  themeSettings["DataSectionBackground"] = "#fff0d8";
-  themeSettings["HereDocumentDelimiterBackground"] = "#ddd0dd";
-  themeSettings["HereDocumentBackground"] = "#ddd0dd";
-  themeSettings["PercentStringwBackground"] = "#ffffe0";
-  themeSettings["StdinBackground"] = "#ff8080";
-  themeSettings["StdoutBackground"] = "#ff8080";
-  themeSettings["StderrBackground"] = "#ff8080";
-
-    //this->theme = themeSettings;
-
-  QStringList customSettings = customTheme.keys();
-  for(int idx=0; idx < customSettings.size(); idx++){
-    themeSettings[customSettings[idx]] = customTheme[customSettings[idx]];
-  }
-
-  this->theme = themeSettings;
+SonicPiLexer::SonicPiLexer(SonicPiTheme *theme) : QsciLexerRuby() {
+    this->theme = theme;
 }
 
 #if defined(Q_OS_WIN)
@@ -92,55 +42,55 @@ QColor SonicPiLexer::defaultColor(int style) const
     switch (style)
     {
     case Default:
-      return QColor(theme["Default"].toString());
+      return theme->color("DefaultForeground");
     case Comment:
-      return QColor(theme["Comment"].toString());
+      return theme->color("CommentForeground");
     case POD:
-      return QColor(theme["POD"].toString());
+      return theme->color("PODForeground");
     case Number:
-      return QColor(theme["Number"].toString());
+      return theme->color("NumberForeground");
     case FunctionMethodName:
-      return QColor(theme["FunctionMethodName"].toString());
+      return theme->color("FunctionMethodNameForeground");
     case Keyword:
-      return QColor(theme["Keyword"].toString());
+      return theme->color("KeywordForeground");
     case DemotedKeyword:
-      return QColor(theme["DemotedKeyword"].toString());
+      return theme->color("DemotedKeywordForeground");
     case DoubleQuotedString:
-      return QColor(theme["DoubleQuotedString"].toString());
+      return theme->color("DoubleQuotedStringForeground");
     case SingleQuotedString:
-      return QColor(theme["SingleQuotedString"].toString());
+      return theme->color("SingleQuotedStringForeground");
     case HereDocument:
-      return QColor(theme["HereDocument"].toString());
+      return theme->color("HereDocumentForeground");
     case PercentStringq:
-      return QColor(theme["PercentStringq"].toString());
+      return theme->color("PercentStringqForeground");
     case PercentStringQ:
-      return QColor(theme["PercentStringQ"].toString());
+      return theme->color("PercentStringQForeground");
     case ClassName:
-      return QColor(theme["ClassName"].toString());
+      return theme->color("ClassNameForeground");
     case Regex:
-      return QColor(theme["Regex"].toString());
+      return theme->color("RegexForeground");
     case HereDocumentDelimiter:
-      return QColor(theme["HereDocumentDelimiter"].toString());
+      return theme->color("HereDocumentDelimiterForeground");
     case PercentStringr:
-      return QColor(theme["PercentStringr"].toString());
+      return theme->color("PercentStringrForeground");
     case PercentStringw:
-      return QColor(theme["PercentStringw"].toString());
+      return theme->color("PercentStringwForeground");
     case Global:
-      return QColor(theme["Global"].toString());
+      return theme->color("GlobalForeground");
     case Symbol:
-      return QColor(theme["Symbol"].toString());
+      return theme->color("SymbolForeground");
     case ModuleName:
-      return QColor(theme["ModuleName"].toString());
+      return theme->color("ModuleNameForeground");
     case InstanceVariable:
-      return QColor(theme["InstanceVariable"].toString());
+      return theme->color("InstanceVariableForeground");
     case ClassVariable:
-      return QColor(theme["ClassVariable"].toString());
+      return theme->color("ClassVariableForeground");
     case Backticks:
-      return QColor(theme["Backticks"].toString());
+      return theme->color("BackticksForeground");
     case PercentStringx:
-      return QColor(theme["PercentStringx"].toString());
+      return theme->color("PercentStringxForeground");
     case DataSection:
-      return QColor(theme["DataSection"].toString());
+      return theme->color("DataSectionForeground");
     }
 
     return QsciLexer::defaultColor(style);
@@ -152,37 +102,37 @@ QColor SonicPiLexer::defaultPaper(int style) const
   switch (style)
     {
     case Default:
-      return QColor(theme["DefaultBackground"].toString());
+      return theme->color("DefaultBackground");
     case Comment:
-       return QColor(theme["CommentBackground"].toString());
+       return theme->color("CommentBackground");
     case Error:
-      return QColor(theme["ErrorBackground"].toString());
+      return theme->color("ErrorBackground");
     case POD:
-      return QColor(theme["PODBackground"].toString());
+      return theme->color("PODBackground");
     case Regex:
-      return QColor(theme["RegexBackground"].toString());
+      return theme->color("RegexBackground");
     case PercentStringr:
-      return QColor(theme["PercentStringrBackground"].toString());
+      return theme->color("PercentStringrBackground");
     case Backticks:
-      return QColor(theme["BackticksBackground"].toString());
+      return theme->color("BackticksBackground");
     case PercentStringx:
-      return QColor(theme["PercentStringxBackground"].toString());
+      return theme->color("PercentStringxBackground");
     case DataSection:
-      return QColor(theme["DataSectionBackground"].toString());
+      return theme->color("DataSectionBackground");
     case HereDocumentDelimiter:
-      return QColor(theme["DocumentDelimiterBackground"].toString());
+      return theme->color("DocumentDelimiterBackground");
     case HereDocument:
-      return QColor(theme["HereDocumentBackground"].toString());
+      return theme->color("HereDocumentBackground");
     case PercentStringw:
-      return QColor(theme["PercentStringwBackground"].toString());
+      return theme->color("PercentStringwBackground");
     case Stdin:
-      return QColor(theme["StdinBackground"].toString());
+      return theme->color("StdinBackground");
     case Stdout:
-      return QColor(theme["StdoutBackground"].toString());
+      return theme->color("StdoutBackground");
     case Stderr:
-      return QColor(theme["StderrBackground"].toString());
+      return theme->color("StderrBackground");
     default:
-      return QColor(theme["DefaultBackground"].toString());
+      return theme->color("DefaultBackground");
     }
 
     return QsciLexer::defaultPaper(style);

--- a/app/gui/qt/sonicpilexer.cpp
+++ b/app/gui/qt/sonicpilexer.cpp
@@ -48,8 +48,34 @@ void SonicPiLexer::highlightAll()
 
 void SonicPiLexer::unhighlightAll()
 {
-    setPaper(theme->color("DefaultBackground"),-1);
-    this->setDefaultColor(theme->color("Foreground"));
+    setPaper(theme->color("Background"));
+    setColor(theme->color("Foreground"));
+
+    setColor(theme->color("DefaultForeground"), Default);
+    setColor(theme->color("CommentForeground"),Comment);
+    setColor(theme->color("PODForeground"),POD);
+    setColor(theme->color("NumberForeground"),Number);
+    setColor(theme->color("FunctionMethodNameForeground"),FunctionMethodName);
+    setColor(theme->color("KeywordForeground"),Keyword);
+    setColor(theme->color("DemotedKeywordForeground"),DemotedKeyword);
+    setColor(theme->color("DoubleQuotedStringForeground"),DoubleQuotedString);
+    setColor(theme->color("SingleQuotedStringForeground"),SingleQuotedString);
+    setColor(theme->color("HereDocumentForeground"),HereDocument);
+    setColor(theme->color("PercentStringqForeground"),PercentStringq);
+    setColor(theme->color("PercentStringQForeground"),PercentStringQ);
+    setColor(theme->color("ClassNameForeground"),ClassName);
+    setColor(theme->color("RegexForeground"),Regex);
+    setColor(theme->color("HereDocumentDelimiterForeground"),HereDocumentDelimiter);
+    setColor(theme->color("PercentStringrForeground"),PercentStringr);
+    setColor(theme->color("PercentStringwForeground"),PercentStringw);
+    setColor(theme->color("GlobalForeground"),Global);
+    setColor(theme->color("SymbolForeground"),Symbol);
+    setColor(theme->color("ModuleNameForeground"),ModuleName);
+    setColor(theme->color("InstanceVariableForeground"),InstanceVariable);
+    setColor(theme->color("ClassVariableForeground"),ClassVariable);
+    setColor(theme->color("BackticksForeground"),Backticks);
+    setColor(theme->color("PercentStringxForeground"),PercentStringx);
+    setColor(theme->color("DataSectionForeground"),DataSection);
 }
 
 QColor SonicPiLexer::defaultColor(int style) const

--- a/app/gui/qt/sonicpilexer.h
+++ b/app/gui/qt/sonicpilexer.h
@@ -13,8 +13,16 @@
 
 
 #include  <Qsci/qscilexerruby.h>
+#include <QJsonObject>
 
 class SonicPiLexer : public QsciLexerRuby
 {
+public:
+  SonicPiLexer(const QJsonObject& customTheme);
+  QColor defaultColor(int style) const;
 
+private:
+  QJsonObject theme;
 };
+
+

--- a/app/gui/qt/sonicpilexer.h
+++ b/app/gui/qt/sonicpilexer.h
@@ -15,15 +15,18 @@
 #include  <Qsci/qscilexerruby.h>
 #include <QJsonObject>
 
+#include "sonicpitheme.h"
+
 class SonicPiLexer : public QsciLexerRuby
 {
 public:
-  SonicPiLexer(const QJsonObject& customTheme);
+  SonicPiLexer(SonicPiTheme *customTheme);
   QColor defaultColor(int style) const;
   QColor defaultPaper(int style) const;
 
 private:
-  QJsonObject theme;
+  SonicPiTheme *theme;
+
 };
 
 

--- a/app/gui/qt/sonicpilexer.h
+++ b/app/gui/qt/sonicpilexer.h
@@ -20,6 +20,7 @@ class SonicPiLexer : public QsciLexerRuby
 public:
   SonicPiLexer(const QJsonObject& customTheme);
   QColor defaultColor(int style) const;
+  QColor defaultPaper(int style) const;
 
 private:
   QJsonObject theme;

--- a/app/gui/qt/sonicpilexer.h
+++ b/app/gui/qt/sonicpilexer.h
@@ -23,6 +23,8 @@ public:
   SonicPiLexer(SonicPiTheme *customTheme);
   QColor defaultColor(int style) const;
   QColor defaultPaper(int style) const;
+  void highlightAll();
+  void unhighlightAll();
 
 private:
   SonicPiTheme *theme;

--- a/app/gui/qt/sonicpiscintilla.cpp
+++ b/app/gui/qt/sonicpiscintilla.cpp
@@ -19,7 +19,7 @@
 #include <Qsci/qscicommandset.h>
 #include <Qsci/qscilexer.h>
 
-SonicPiScintilla::SonicPiScintilla(SonicPiLexer *lexer, const QJsonObject& customTheme)
+SonicPiScintilla::SonicPiScintilla(SonicPiLexer *lexer, SonicPiTheme *theme)
   : QsciScintilla()
 {
   standardCommands()->clearKeys();
@@ -34,17 +34,6 @@ SonicPiScintilla::SonicPiScintilla(SonicPiLexer *lexer, const QJsonObject& custo
   int SPi_CTRL = Qt::CTRL;
   int SPi_META = Qt::ALT;
 #endif
-
-  //Setup theme
-  QJsonObject themeSettings = QJsonObject();
-  themeSettings["MarginBackground"] = "whitesmoke";
-  themeSettings["SelectionBackground"] = "DeepPink";
-  themeSettings["MatchedBraceBackground"] = "dimgray";
-
-  QStringList customSettings = customTheme.keys();
-  for(int idx=0; idx < customSettings.size(); idx++){
-    themeSettings[customSettings[idx]] = customTheme[customSettings[idx]];
-  }
 
   // basic navigation
   addKeyBinding(settings, QsciCommand::PageDown, Qt::Key_PageDown);
@@ -118,8 +107,8 @@ SonicPiScintilla::SonicPiScintilla(SonicPiLexer *lexer, const QJsonObject& custo
 
   standardCommands()->readSettings(settings);
 
-  setMatchedBraceBackgroundColor(QColor(themeSettings["MatchedBraceBackground"].toString()));
-  setMatchedBraceForegroundColor(QColor("white"));
+  this->setMatchedBraceBackgroundColor(theme->color("MatchedBraceBackground"));
+  this->setMatchedBraceForegroundColor(theme->color("MatchedBraceForeground"));
 
   setIndentationWidth(2);
   setIndentationGuides(true);
@@ -128,11 +117,12 @@ SonicPiScintilla::SonicPiScintilla(SonicPiLexer *lexer, const QJsonObject& custo
 
   //TODO: add preference toggle for this:
   //this->setFolding(SonicPiScintilla::CircledTreeFoldStyle, 2);
+
   setCaretLineVisible(true);
   setCaretLineBackgroundColor(QColor("whitesmoke"));
   setFoldMarginColors(QColor("whitesmoke"),QColor("whitesmoke"));
   setMarginLineNumbers(0, true);
-  setMarginsBackgroundColor(QColor(themeSettings["MarginBackground"].toString()));
+  setMarginsBackgroundColor(theme->color("MarginBackground"));
   setMarginsForegroundColor(QColor("dark gray"));
   setMarginsFont(QFont("Menlo", 15, -1, true));
   setUtf8(true);
@@ -143,8 +133,8 @@ SonicPiScintilla::SonicPiScintilla(SonicPiLexer *lexer, const QJsonObject& custo
   setAutoCompletionSource(SonicPiScintilla::AcsAPIs);
   setAutoCompletionCaseSensitivity(false);
 
-  setSelectionBackgroundColor(themeSettings["SelectionBackground"].toString());
-  setSelectionForegroundColor("white");
+  setSelectionBackgroundColor(theme->color("SelectionBackground"));
+  setSelectionForegroundColor(theme->color("SelectionForeground"));
   setCaretWidth(5);
   setCaretForegroundColor("deep pink");
   setEolMode(EolUnix);

--- a/app/gui/qt/sonicpiscintilla.cpp
+++ b/app/gui/qt/sonicpiscintilla.cpp
@@ -19,7 +19,7 @@
 #include <Qsci/qscicommandset.h>
 #include <Qsci/qscilexer.h>
 
-SonicPiScintilla::SonicPiScintilla(SonicPiLexer *lexer)
+SonicPiScintilla::SonicPiScintilla(SonicPiLexer *lexer, const QJsonObject& customTheme)
   : QsciScintilla()
 {
   standardCommands()->clearKeys();
@@ -34,6 +34,17 @@ SonicPiScintilla::SonicPiScintilla(SonicPiLexer *lexer)
   int SPi_CTRL = Qt::CTRL;
   int SPi_META = Qt::ALT;
 #endif
+
+  //Setup theme
+  QJsonObject themeSettings = QJsonObject();
+  themeSettings["MarginBackground"] = "whitesmoke";
+  themeSettings["SelectionBackground"] = "DeepPink";
+  themeSettings["MatchedBraceBackground"] = "dimgray";
+
+  QStringList customSettings = customTheme.keys();
+  for(int idx=0; idx < customSettings.size(); idx++){
+    themeSettings[customSettings[idx]] = customTheme[customSettings[idx]];
+  }
 
   // basic navigation
   addKeyBinding(settings, QsciCommand::PageDown, Qt::Key_PageDown);
@@ -107,7 +118,7 @@ SonicPiScintilla::SonicPiScintilla(SonicPiLexer *lexer)
 
   standardCommands()->readSettings(settings);
 
-  setMatchedBraceBackgroundColor(QColor("dimgray"));
+  setMatchedBraceBackgroundColor(QColor(themeSettings["MatchedBraceBackground"].toString()));
   setMatchedBraceForegroundColor(QColor("white"));
 
   setIndentationWidth(2);
@@ -116,12 +127,12 @@ SonicPiScintilla::SonicPiScintilla(SonicPiLexer *lexer)
   setBraceMatching( SonicPiScintilla::SloppyBraceMatch);
 
   //TODO: add preference toggle for this:
-  //setFolding(SonicPiScintilla::CircledTreeFoldStyle, 2);
+  //this->setFolding(SonicPiScintilla::CircledTreeFoldStyle, 2);
   setCaretLineVisible(true);
   setCaretLineBackgroundColor(QColor("whitesmoke"));
   setFoldMarginColors(QColor("whitesmoke"),QColor("whitesmoke"));
   setMarginLineNumbers(0, true);
-  setMarginsBackgroundColor(QColor("whitesmoke"));
+  setMarginsBackgroundColor(QColor(themeSettings["MarginBackground"].toString()));
   setMarginsForegroundColor(QColor("dark gray"));
   setMarginsFont(QFont("Menlo", 15, -1, true));
   setUtf8(true);
@@ -132,7 +143,7 @@ SonicPiScintilla::SonicPiScintilla(SonicPiLexer *lexer)
   setAutoCompletionSource(SonicPiScintilla::AcsAPIs);
   setAutoCompletionCaseSensitivity(false);
 
-  setSelectionBackgroundColor("DeepPink");
+  setSelectionBackgroundColor(themeSettings["SelectionBackground"].toString());
   setSelectionForegroundColor("white");
   setCaretWidth(5);
   setCaretForegroundColor("deep pink");

--- a/app/gui/qt/sonicpiscintilla.cpp
+++ b/app/gui/qt/sonicpiscintilla.cpp
@@ -112,18 +112,18 @@ SonicPiScintilla::SonicPiScintilla(SonicPiLexer *lexer, SonicPiTheme *theme)
 
   setIndentationWidth(2);
   setIndentationGuides(true);
-  setIndentationGuidesForegroundColor(QColor("deep pink"));
+  setIndentationGuidesForegroundColor(theme->color("IndentationGuidesForeground"));
   setBraceMatching( SonicPiScintilla::SloppyBraceMatch);
 
   //TODO: add preference toggle for this:
   //this->setFolding(SonicPiScintilla::CircledTreeFoldStyle, 2);
-
   setCaretLineVisible(true);
-  setCaretLineBackgroundColor(QColor("whitesmoke"));
-  setFoldMarginColors(QColor("whitesmoke"),QColor("whitesmoke"));
+  setCaretLineBackgroundColor(theme->color("CaretLineBackground"));
+  setFoldMarginColors(theme->color("FoldMarginForeground"),theme->color("FoldMarginForeground"));
   setMarginLineNumbers(0, true);
+
   setMarginsBackgroundColor(theme->color("MarginBackground"));
-  setMarginsForegroundColor(QColor("dark gray"));
+  setMarginsForegroundColor(theme->color("MarginForeground"));
   setMarginsFont(QFont("Menlo", 15, -1, true));
   setUtf8(true);
   setText("#loading...");
@@ -136,7 +136,7 @@ SonicPiScintilla::SonicPiScintilla(SonicPiLexer *lexer, SonicPiTheme *theme)
   setSelectionBackgroundColor(theme->color("SelectionBackground"));
   setSelectionForegroundColor(theme->color("SelectionForeground"));
   setCaretWidth(5);
-  setCaretForegroundColor("deep pink");
+  setCaretForegroundColor(theme->color("CaretForeground"));
   setEolMode(EolUnix);
 
   addKeyBinding(settings, QsciCommand::SelectionCopy, Qt::Key_C | SPi_META);

--- a/app/gui/qt/sonicpiscintilla.h
+++ b/app/gui/qt/sonicpiscintilla.h
@@ -14,6 +14,7 @@
 
 #include <Qsci/qsciscintilla.h>
 #include <QJsonObject>
+#include "sonicpitheme.h"
 
 class SonicPiLexer;
 class QSettings;
@@ -23,7 +24,7 @@ class SonicPiScintilla : public QsciScintilla
   Q_OBJECT
 
  public:
-  SonicPiScintilla(SonicPiLexer *lexer, const QJsonObject &customTheme);
+  SonicPiScintilla(SonicPiLexer *lexer, SonicPiTheme *theme);
 
   virtual QStringList apiContext(int pos, int &context_start,
 				 int &last_word_start);

--- a/app/gui/qt/sonicpiscintilla.h
+++ b/app/gui/qt/sonicpiscintilla.h
@@ -13,6 +13,7 @@
 
 
 #include <Qsci/qsciscintilla.h>
+#include <QJsonObject>
 
 class SonicPiLexer;
 class QSettings;
@@ -22,7 +23,7 @@ class SonicPiScintilla : public QsciScintilla
   Q_OBJECT
 
  public:
-  SonicPiScintilla(SonicPiLexer *lexer);
+  SonicPiScintilla(SonicPiLexer *lexer, const QJsonObject &customTheme);
 
   virtual QStringList apiContext(int pos, int &context_start,
 				 int &last_word_start);

--- a/app/gui/qt/sonicpitheme.cpp
+++ b/app/gui/qt/sonicpitheme.cpp
@@ -48,6 +48,14 @@ SonicPiTheme::SonicPiTheme(QObject *parent, const QJsonObject& settings) : QObje
     themeSettings["StdinBackground"]                 = "#ff8080";
     themeSettings["StdoutBackground"]                = "#ff8080";
     themeSettings["StderrBackground"]                = "#ff8080";
+    themeSettings["NumberBackground"]                = "white";
+    themeSettings["DoubleQuotedStringBackground"]    = "white";
+    themeSettings["SingleQuotedStringBackground"]    = "white";
+    themeSettings["InstanceVariableBackground"]      = "white";
+    themeSettings["SymbolBackground"]                = "white";
+    themeSettings["DemotedKeywordBackground"]        = "white";
+    themeSettings["KeywordBackground"]               = "white";
+    themeSettings["FunctionMethodNameBackground"]    = "white";
 
     themeSettings["MarginBackground"]            = "whitesmoke";
     themeSettings["MarginForeground"]            = "dark gray";

--- a/app/gui/qt/sonicpitheme.cpp
+++ b/app/gui/qt/sonicpitheme.cpp
@@ -4,6 +4,9 @@
 SonicPiTheme::SonicPiTheme(QObject *parent, const QJsonObject& settings) : QObject(parent)
 {
     QJsonObject themeSettings = QJsonObject();
+    themeSettings["Foreground"] = "black";
+    themeSettings["Background"] = "white";
+
     themeSettings["DefaultForeground"]               = "#808080";
     themeSettings["CommentForeground"]               = "#5e5e5e";
     themeSettings["PODForeground"]                   = "#004000";
@@ -46,13 +49,18 @@ SonicPiTheme::SonicPiTheme(QObject *parent, const QJsonObject& settings) : QObje
     themeSettings["StdoutBackground"]                = "#ff8080";
     themeSettings["StderrBackground"]                = "#ff8080";
 
-    themeSettings["MarginBackground"]       = "whitesmoke";
-    themeSettings["MarginForeground"]       = "dark gray";
-    themeSettings["SelectionBackground"]    = "DeepPink";
-    themeSettings["SelectionForeground"]    = "white";
-    themeSettings["MatchedBraceBackground"] = "dimgray";
-    themeSettings["MatchedBraceForeground"] = "white";
-    themeSettings["BraceForeground"]        = "white";
+    themeSettings["MarginBackground"]            = "whitesmoke";
+    themeSettings["MarginForeground"]            = "dark gray";
+    themeSettings["SelectionBackground"]         = "DeepPink";
+    themeSettings["SelectionForeground"]         = "white";
+    themeSettings["MatchedBraceBackground"]      = "dimgray";
+    themeSettings["MatchedBraceForeground"]      = "white";
+    themeSettings["BraceForeground"]             = "white";
+    themeSettings["CaretForeground"]             = "deep pink";
+    themeSettings["CaretLineBackground"]         = "whitesmoke";
+    themeSettings["IndentationGuidesForeground"] = "deep pink";
+    themeSettings["FoldMarginForeground"]        = "whitesmoke";
+
 
     QStringList customSettings = settings.keys();
     for(int idx=0; idx < customSettings.size(); idx++){

--- a/app/gui/qt/sonicpitheme.cpp
+++ b/app/gui/qt/sonicpitheme.cpp
@@ -1,0 +1,70 @@
+
+#include "sonicpitheme.h"
+
+SonicPiTheme::SonicPiTheme(QObject *parent, const QJsonObject& settings) : QObject(parent)
+{
+    QJsonObject themeSettings = QJsonObject();
+    themeSettings["DefaultForeground"]               = "#808080";
+    themeSettings["CommentForeground"]               = "#5e5e5e";
+    themeSettings["PODForeground"]                   = "#004000";
+    themeSettings["NumberForeground"]                = "DodgerBlue";
+    themeSettings["FunctionMethodNameForeground"]    = "LimeGreen";
+    themeSettings["KeywordForeground"]               = "DarkOrange";
+    themeSettings["DemotedKeywordForeground"]        = "DarkOrange";
+    themeSettings["ClassNameForeground"]             = "Lavender";
+    themeSettings["GlobalForeground"]                = "Red";
+    themeSettings["SymbolForeground"]                = "DeepPink";
+    themeSettings["ModuleNameForeground"]            = "yellow";
+    themeSettings["InstanceVariableForeground"]      = "#b00080";
+    themeSettings["ClassVariableForeground"]         = "#8000b0";
+    themeSettings["BackticksForeground"]             = "Red";
+    themeSettings["PercentStringxForeground"]        = "Red";
+    themeSettings["DataSectionForeground"]           = "#600000";
+    themeSettings["DoubleQuotedStringForeground"]    = "DarkGreen";
+    themeSettings["SingleQuotedStringForeground"]    = "DarkGreen";
+    themeSettings["HereDocumentForeground"]          = "DarkGreen";
+    themeSettings["PercentStringForeground"]         = "DarkGreen";
+    themeSettings["PercentStringQForeground"]        = "DarkGreen";
+    themeSettings["RegexForeground"]                 = "#000000";
+    themeSettings["HereDocumentDelimiterForeground"] = "#000000";
+    themeSettings["PercentStringrForeground"]        = "#000000";
+    themeSettings["PercentStringwForeground"]        = "#000000";
+
+    themeSettings["DefaultBackground"]               = "white";
+    themeSettings["CommentBackground"]               = "white";
+    themeSettings["ErrorBackground"]                 = "#c0xffc0";
+    themeSettings["PODBackground"]                   = "#ff0000";
+    themeSettings["RegexBackground"]                 = "#a0ffa0";
+    themeSettings["PercentStringrBackground"]        = "#a0ffa0";
+    themeSettings["BackticksBackground"]             = "yellow";
+    themeSettings["PercentStringxBackground"]        = "yellow";
+    themeSettings["DataSectionBackground"]           = "#fff0d8";
+    themeSettings["HereDocumentDelimiterBackground"] = "#ddd0dd";
+    themeSettings["HereDocumentBackground"]          = "#ddd0dd";
+    themeSettings["PercentStringwBackground"]        = "#ffffe0";
+    themeSettings["StdinBackground"]                 = "#ff8080";
+    themeSettings["StdoutBackground"]                = "#ff8080";
+    themeSettings["StderrBackground"]                = "#ff8080";
+
+    themeSettings["MarginBackground"]       = "whitesmoke";
+    themeSettings["MarginForeground"]       = "dark gray";
+    themeSettings["SelectionBackground"]    = "DeepPink";
+    themeSettings["SelectionForeground"]    = "white";
+    themeSettings["MatchedBraceBackground"] = "dimgray";
+    themeSettings["MatchedBraceForeground"] = "white";
+    themeSettings["BraceForeground"]        = "white";
+
+    QStringList customSettings = settings.keys();
+    for(int idx=0; idx < customSettings.size(); idx++){
+      themeSettings[customSettings[idx]] = settings[customSettings[idx]];
+    }
+
+    this->theme = themeSettings;
+}
+
+QColor SonicPiTheme::color(QString key){
+    return theme[key].toString();
+}
+
+SonicPiTheme::~SonicPiTheme(){}
+

--- a/app/gui/qt/sonicpitheme.h
+++ b/app/gui/qt/sonicpitheme.h
@@ -1,0 +1,25 @@
+#ifndef SONICPITHEME_H
+#define SONICPITHEME_H
+
+#include <QtCore>
+#include <QObject>
+#include <QColor>
+#include <QJsonObject>
+
+class SonicPiTheme : public QObject
+{
+    Q_OBJECT
+public:
+    explicit SonicPiTheme(QObject *parent = 0, const QJsonObject& settings = QJsonObject());
+    ~SonicPiTheme();
+    QColor color(QString);
+
+private:
+    QJsonObject theme;
+
+signals:
+
+public slots:
+};
+
+#endif // SONICPITHEME_H


### PR DESCRIPTION
First sketch of supporting custom themes of SonicPi.

- [x] Customise Ruby font colors
- [x] Customise Ruby background colors
- [x] Customise Qscintilla colors 
- [x] Nicely find the .sonic-pi folder on every platform

- [x] Create Electric color theme as complete test.


## Example theme
```json
{
"Background": "#1B1D1E",
"MarginBackground": "#1B1D1E",
"DefaultBackground": "#1B1D1E",
"Foreground": "#EEEEEE",
"CursorForeground": "#96CBFE",
"CommentForeground": "#7B8989",
"CommentBackground": "#1B1D1E",
"KeywordForeground": "#FA2572",
"SymbolForeground": "#C036BF",
"DoubleQuotedStringForeground": "#F9ACD3",
"SingleQuotedStringForeground": "#F9ACD3",
"FunctionMethodNameForeground": "#FEDF0C",
"CaretLineBackground": "#000000",
"NumberForeground":  "#F24C1A"
}
```