### PR TITLE
compile fixes for Windows

### DIFF
--- a/app/gui/qt/SonicPi.pro
+++ b/app/gui/qt/SonicPi.pro
@@ -60,6 +60,11 @@ SOURCES += main.cpp \
            sonicpiserver.cpp \
            sonicpiudpserver.cpp \
            sonicpitcpserver.cpp
+win32 {
+# have to link these explicitly for some reason
+  SOURCES += platform/win/moc_qsciscintilla.cpp \
+             platform/win/moc_qsciscintillabase.cpp
+}
 
 HEADERS  += mainwindow.h \
             oscpkt.hh \

--- a/app/gui/qt/mainwindow.cpp
+++ b/app/gui/qt/mainwindow.cpp
@@ -1551,6 +1551,7 @@ bool MainWindow::saveFile(const QString &fileName, SonicPiScintilla* text)
   QString code = text->text();
 #if defined(Q_OS_WIN)
   code.replace("\n", "\r\n"); // CRLF for Windows users
+  code.replace("\r\r\n", "\r\n"); // don't double-replace if already encoded
 #endif
   out << code;
   QApplication::restoreOverrideCursor();

--- a/app/gui/qt/mainwindow.cpp
+++ b/app/gui/qt/mainwindow.cpp
@@ -1748,12 +1748,11 @@ void MainWindow::printAsciiArtLogo(){
   st.setCodec("UTF-8");
   s.append(st.readAll());
   std::cout << std::endl << std::endl << std::endl;
-#if defined(Q_OS_WIN) || defined(Q_OS_MAC)
+#if QT_VERSION >= 0x050400
   qDebug().noquote() << s;
   std::cout << std::endl << std::endl;
 #else
-  //Assuming Raspberry Pi which currently has Qt4
-  //TODO: remove when RPi is on Qt5
+  //noquote requires QT 5.4
   qDebug() << s;
   std::cout << std::endl;
 #endif

--- a/app/gui/qt/oscpkt.hh
+++ b/app/gui/qt/oscpkt.hh
@@ -58,20 +58,20 @@
 
 #ifndef _MSC_VER
 #include <stdint.h>
+#include <arpa/inet.h>
 #else
-namespace oscpkt {
-  typedef __int32 int32_t;
-  typedef unsigned __int32 uint32_t;
-  typedef __int64 int64_t;
-  typedef unsigned __int64 uint64_t;
-}
+#include <winsock2.h>
+typedef __int32 int32_t;
+typedef unsigned __int32 uint32_t;
+typedef __int64 int64_t;
+typedef unsigned __int64 uint64_t;
+
 #endif
 #include <cstring>
 #include <cassert>
 #include <string>
 #include <vector>
 #include <list>
-#include <arpa/inet.h>
 
 #if defined(OSCPKT_OSTREAM_OUTPUT) || defined(OSCPKT_TEST)
 #include <iostream>

--- a/app/gui/qt/platform/win/moc_qsciscintilla.cpp
+++ b/app/gui/qt/platform/win/moc_qsciscintilla.cpp
@@ -1,0 +1,809 @@
+/****************************************************************************
+** Meta object code from reading C++ file 'qsciscintilla.h'
+**
+** Created by: The Qt Meta Object Compiler version 67 (Qt 5.3.2)
+**
+** WARNING! All changes made in this file will be lost!
+*****************************************************************************/
+
+#include "../Qsci/qsciscintilla.h"
+#include <QtCore/qbytearray.h>
+#include <QtCore/qmetatype.h>
+#if !defined(Q_MOC_OUTPUT_REVISION)
+#error "The header file 'qsciscintilla.h' doesn't include <QObject>."
+#elif Q_MOC_OUTPUT_REVISION != 67
+#error "This file was generated using the moc from 5.3.2. It"
+#error "cannot be used with the include files from this version of Qt."
+#error "(The moc has changed too much.)"
+#endif
+
+QT_BEGIN_MOC_NAMESPACE
+struct qt_meta_stringdata_QsciScintilla_t {
+    QByteArrayData data[171];
+    char stringdata[2314];
+};
+#define QT_MOC_LITERAL(idx, ofs, len) \
+    Q_STATIC_BYTE_ARRAY_DATA_HEADER_INITIALIZER_WITH_OFFSET(len, \
+    qptrdiff(offsetof(qt_meta_stringdata_QsciScintilla_t, stringdata) + ofs \
+        - idx * sizeof(QByteArrayData)) \
+    )
+static const qt_meta_stringdata_QsciScintilla_t qt_meta_stringdata_QsciScintilla = {
+    {
+QT_MOC_LITERAL(0, 0, 13),
+QT_MOC_LITERAL(1, 14, 21),
+QT_MOC_LITERAL(2, 36, 0),
+QT_MOC_LITERAL(3, 37, 4),
+QT_MOC_LITERAL(4, 42, 5),
+QT_MOC_LITERAL(5, 48, 13),
+QT_MOC_LITERAL(6, 62, 3),
+QT_MOC_LITERAL(7, 66, 16),
+QT_MOC_LITERAL(8, 83, 21),
+QT_MOC_LITERAL(9, 105, 5),
+QT_MOC_LITERAL(10, 111, 17),
+QT_MOC_LITERAL(11, 129, 12),
+QT_MOC_LITERAL(12, 142, 13),
+QT_MOC_LITERAL(13, 156, 6),
+QT_MOC_LITERAL(14, 163, 21),
+QT_MOC_LITERAL(15, 185, 19),
+QT_MOC_LITERAL(16, 205, 1),
+QT_MOC_LITERAL(17, 207, 16),
+QT_MOC_LITERAL(18, 224, 11),
+QT_MOC_LITERAL(19, 236, 17),
+QT_MOC_LITERAL(20, 254, 2),
+QT_MOC_LITERAL(21, 257, 6),
+QT_MOC_LITERAL(22, 264, 6),
+QT_MOC_LITERAL(23, 271, 4),
+QT_MOC_LITERAL(24, 276, 19),
+QT_MOC_LITERAL(25, 296, 20),
+QT_MOC_LITERAL(26, 317, 24),
+QT_MOC_LITERAL(27, 342, 7),
+QT_MOC_LITERAL(28, 350, 5),
+QT_MOC_LITERAL(29, 356, 4),
+QT_MOC_LITERAL(30, 361, 3),
+QT_MOC_LITERAL(31, 365, 19),
+QT_MOC_LITERAL(32, 385, 17),
+QT_MOC_LITERAL(33, 403, 7),
+QT_MOC_LITERAL(34, 411, 8),
+QT_MOC_LITERAL(35, 420, 8),
+QT_MOC_LITERAL(36, 429, 6),
+QT_MOC_LITERAL(37, 436, 6),
+QT_MOC_LITERAL(38, 443, 8),
+QT_MOC_LITERAL(39, 452, 19),
+QT_MOC_LITERAL(40, 472, 5),
+QT_MOC_LITERAL(41, 478, 4),
+QT_MOC_LITERAL(42, 483, 18),
+QT_MOC_LITERAL(43, 502, 19),
+QT_MOC_LITERAL(44, 522, 29),
+QT_MOC_LITERAL(45, 552, 29),
+QT_MOC_LITERAL(46, 582, 9),
+QT_MOC_LITERAL(47, 592, 6),
+QT_MOC_LITERAL(48, 599, 21),
+QT_MOC_LITERAL(49, 621, 32),
+QT_MOC_LITERAL(50, 654, 2),
+QT_MOC_LITERAL(51, 657, 28),
+QT_MOC_LITERAL(52, 686, 7),
+QT_MOC_LITERAL(53, 694, 27),
+QT_MOC_LITERAL(54, 722, 6),
+QT_MOC_LITERAL(55, 729, 23),
+QT_MOC_LITERAL(56, 753, 20),
+QT_MOC_LITERAL(57, 774, 6),
+QT_MOC_LITERAL(58, 781, 26),
+QT_MOC_LITERAL(59, 808, 6),
+QT_MOC_LITERAL(60, 815, 26),
+QT_MOC_LITERAL(61, 842, 23),
+QT_MOC_LITERAL(62, 866, 13),
+QT_MOC_LITERAL(63, 880, 10),
+QT_MOC_LITERAL(64, 891, 16),
+QT_MOC_LITERAL(65, 908, 10),
+QT_MOC_LITERAL(66, 919, 2),
+QT_MOC_LITERAL(67, 922, 21),
+QT_MOC_LITERAL(68, 944, 8),
+QT_MOC_LITERAL(69, 953, 23),
+QT_MOC_LITERAL(70, 977, 3),
+QT_MOC_LITERAL(71, 981, 27),
+QT_MOC_LITERAL(72, 1009, 19),
+QT_MOC_LITERAL(73, 1029, 6),
+QT_MOC_LITERAL(74, 1036, 13),
+QT_MOC_LITERAL(75, 1050, 5),
+QT_MOC_LITERAL(76, 1056, 8),
+QT_MOC_LITERAL(77, 1065, 1),
+QT_MOC_LITERAL(78, 1067, 17),
+QT_MOC_LITERAL(79, 1085, 10),
+QT_MOC_LITERAL(80, 1096, 7),
+QT_MOC_LITERAL(81, 1104, 4),
+QT_MOC_LITERAL(82, 1109, 16),
+QT_MOC_LITERAL(83, 1126, 7),
+QT_MOC_LITERAL(84, 1134, 10),
+QT_MOC_LITERAL(85, 1145, 9),
+QT_MOC_LITERAL(86, 1155, 4),
+QT_MOC_LITERAL(87, 1160, 14),
+QT_MOC_LITERAL(88, 1175, 11),
+QT_MOC_LITERAL(89, 1187, 20),
+QT_MOC_LITERAL(90, 1208, 35),
+QT_MOC_LITERAL(91, 1244, 35),
+QT_MOC_LITERAL(92, 1280, 22),
+QT_MOC_LITERAL(93, 1303, 4),
+QT_MOC_LITERAL(94, 1308, 19),
+QT_MOC_LITERAL(95, 1328, 8),
+QT_MOC_LITERAL(96, 1337, 10),
+QT_MOC_LITERAL(97, 1348, 5),
+QT_MOC_LITERAL(98, 1354, 25),
+QT_MOC_LITERAL(99, 1380, 14),
+QT_MOC_LITERAL(100, 1395, 1),
+QT_MOC_LITERAL(101, 1397, 25),
+QT_MOC_LITERAL(102, 1423, 20),
+QT_MOC_LITERAL(103, 1444, 4),
+QT_MOC_LITERAL(104, 1449, 19),
+QT_MOC_LITERAL(105, 1469, 4),
+QT_MOC_LITERAL(106, 1474, 20),
+QT_MOC_LITERAL(107, 1495, 4),
+QT_MOC_LITERAL(108, 1500, 14),
+QT_MOC_LITERAL(109, 1515, 1),
+QT_MOC_LITERAL(110, 1517, 11),
+QT_MOC_LITERAL(111, 1529, 8),
+QT_MOC_LITERAL(112, 1538, 11),
+QT_MOC_LITERAL(113, 1550, 2),
+QT_MOC_LITERAL(114, 1553, 12),
+QT_MOC_LITERAL(115, 1566, 8),
+QT_MOC_LITERAL(116, 1575, 9),
+QT_MOC_LITERAL(117, 1585, 6),
+QT_MOC_LITERAL(118, 1592, 7),
+QT_MOC_LITERAL(119, 1600, 27),
+QT_MOC_LITERAL(120, 1628, 27),
+QT_MOC_LITERAL(121, 1656, 13),
+QT_MOC_LITERAL(122, 1670, 11),
+QT_MOC_LITERAL(123, 1682, 7),
+QT_MOC_LITERAL(124, 1690, 7),
+QT_MOC_LITERAL(125, 1698, 2),
+QT_MOC_LITERAL(126, 1701, 23),
+QT_MOC_LITERAL(127, 1725, 20),
+QT_MOC_LITERAL(128, 1746, 11),
+QT_MOC_LITERAL(129, 1758, 8),
+QT_MOC_LITERAL(130, 1767, 4),
+QT_MOC_LITERAL(131, 1772, 6),
+QT_MOC_LITERAL(132, 1779, 5),
+QT_MOC_LITERAL(133, 1785, 7),
+QT_MOC_LITERAL(134, 1793, 6),
+QT_MOC_LITERAL(135, 1800, 4),
+QT_MOC_LITERAL(136, 1805, 18),
+QT_MOC_LITERAL(137, 1824, 3),
+QT_MOC_LITERAL(138, 1828, 15),
+QT_MOC_LITERAL(139, 1844, 9),
+QT_MOC_LITERAL(140, 1854, 20),
+QT_MOC_LITERAL(141, 1875, 3),
+QT_MOC_LITERAL(142, 1879, 9),
+QT_MOC_LITERAL(143, 1889, 22),
+QT_MOC_LITERAL(144, 1912, 17),
+QT_MOC_LITERAL(145, 1930, 14),
+QT_MOC_LITERAL(146, 1945, 5),
+QT_MOC_LITERAL(147, 1951, 11),
+QT_MOC_LITERAL(148, 1963, 3),
+QT_MOC_LITERAL(149, 1967, 5),
+QT_MOC_LITERAL(150, 1973, 7),
+QT_MOC_LITERAL(151, 1981, 8),
+QT_MOC_LITERAL(152, 1990, 5),
+QT_MOC_LITERAL(153, 1996, 20),
+QT_MOC_LITERAL(154, 2017, 20),
+QT_MOC_LITERAL(155, 2038, 4),
+QT_MOC_LITERAL(156, 2043, 3),
+QT_MOC_LITERAL(157, 2047, 22),
+QT_MOC_LITERAL(158, 2070, 19),
+QT_MOC_LITERAL(159, 2090, 22),
+QT_MOC_LITERAL(160, 2113, 29),
+QT_MOC_LITERAL(161, 2143, 23),
+QT_MOC_LITERAL(162, 2167, 22),
+QT_MOC_LITERAL(163, 2190, 5),
+QT_MOC_LITERAL(164, 2196, 24),
+QT_MOC_LITERAL(165, 2221, 7),
+QT_MOC_LITERAL(166, 2229, 21),
+QT_MOC_LITERAL(167, 2251, 22),
+QT_MOC_LITERAL(168, 2274, 14),
+QT_MOC_LITERAL(169, 2289, 7),
+QT_MOC_LITERAL(170, 2297, 16)
+    },
+    "QsciScintilla\0cursorPositionChanged\0"
+    "\0line\0index\0copyAvailable\0yes\0"
+    "indicatorClicked\0Qt::KeyboardModifiers\0"
+    "state\0indicatorReleased\0linesChanged\0"
+    "marginClicked\0margin\0modificationAttempted\0"
+    "modificationChanged\0m\0selectionChanged\0"
+    "textChanged\0userListActivated\0id\0"
+    "string\0append\0text\0autoCompleteFromAll\0"
+    "autoCompleteFromAPIs\0autoCompleteFromDocument\0"
+    "callTip\0clear\0copy\0cut\0ensureCursorVisible\0"
+    "ensureLineVisible\0foldAll\0children\0"
+    "foldLine\0indent\0insert\0insertAt\0"
+    "moveToMatchingBrace\0paste\0redo\0"
+    "removeSelectedText\0replaceSelectedText\0"
+    "resetSelectionBackgroundColor\0"
+    "resetSelectionForegroundColor\0selectAll\0"
+    "select\0selectToMatchingBrace\0"
+    "setAutoCompletionCaseSensitivity\0cs\0"
+    "setAutoCompletionReplaceWord\0replace\0"
+    "setAutoCompletionShowSingle\0single\0"
+    "setAutoCompletionSource\0AutoCompletionSource\0"
+    "source\0setAutoCompletionThreshold\0"
+    "thresh\0setAutoCompletionUseSingle\0"
+    "AutoCompletionUseSingle\0setAutoIndent\0"
+    "autoindent\0setBraceMatching\0BraceMatch\0"
+    "bm\0setBackspaceUnindents\0unindent\0"
+    "setCaretForegroundColor\0col\0"
+    "setCaretLineBackgroundColor\0"
+    "setCaretLineVisible\0enable\0setCaretWidth\0"
+    "width\0setColor\0c\0setCursorPosition\0"
+    "setEolMode\0EolMode\0mode\0setEolVisibility\0"
+    "visible\0setFolding\0FoldStyle\0fold\0"
+    "setIndentation\0indentation\0"
+    "setIndentationGuides\0"
+    "setIndentationGuidesBackgroundColor\0"
+    "setIndentationGuidesForegroundColor\0"
+    "setIndentationsUseTabs\0tabs\0"
+    "setIndentationWidth\0setLexer\0QsciLexer*\0"
+    "lexer\0setMarginsBackgroundColor\0"
+    "setMarginsFont\0f\0setMarginsForegroundColor\0"
+    "setMarginLineNumbers\0lnrs\0setMarginMarkerMask\0"
+    "mask\0setMarginSensitivity\0sens\0"
+    "setMarginWidth\0s\0setModified\0setPaper\0"
+    "setReadOnly\0ro\0setSelection\0lineFrom\0"
+    "indexFrom\0lineTo\0indexTo\0"
+    "setSelectionBackgroundColor\0"
+    "setSelectionForegroundColor\0setTabIndents\0"
+    "setTabWidth\0setText\0setUtf8\0cp\0"
+    "setWhitespaceVisibility\0WhitespaceVisibility\0"
+    "setWrapMode\0WrapMode\0undo\0zoomIn\0range\0"
+    "zoomOut\0zoomTo\0size\0handleCallTipClick\0"
+    "dir\0handleCharAdded\0charadded\0"
+    "handleIndicatorClick\0pos\0modifiers\0"
+    "handleIndicatorRelease\0handleMarginClick\0"
+    "handleModified\0mtype\0const char*\0len\0"
+    "added\0foldNow\0foldPrev\0token\0"
+    "annotationLinesAdded\0handlePropertyChange\0"
+    "prop\0val\0handleSavePointReached\0"
+    "handleSavePointLeft\0handleSelectionChanged\0"
+    "handleAutoCompletionSelection\0"
+    "handleUserListSelection\0handleStyleColorChange\0"
+    "style\0handleStyleEolFillChange\0eolfill\0"
+    "handleStyleFontChange\0handleStylePaperChange\0"
+    "handleUpdateUI\0updated\0delete_selection"
+};
+#undef QT_MOC_LITERAL
+
+static const uint qt_meta_data_QsciScintilla[] = {
+
+ // content:
+       7,       // revision
+       0,       // classname
+       0,    0, // classinfo
+     109,   14, // methods
+       0,    0, // properties
+       0,    0, // enums/sets
+       0,    0, // constructors
+       0,       // flags
+      11,       // signalCount
+
+ // signals: name, argc, parameters, tag, flags
+       1,    2,  559,    2, 0x06 /* Public */,
+       5,    1,  564,    2, 0x06 /* Public */,
+       7,    3,  567,    2, 0x06 /* Public */,
+      10,    3,  574,    2, 0x06 /* Public */,
+      11,    0,  581,    2, 0x06 /* Public */,
+      12,    3,  582,    2, 0x06 /* Public */,
+      14,    0,  589,    2, 0x06 /* Public */,
+      15,    1,  590,    2, 0x06 /* Public */,
+      17,    0,  593,    2, 0x06 /* Public */,
+      18,    0,  594,    2, 0x06 /* Public */,
+      19,    2,  595,    2, 0x06 /* Public */,
+
+ // slots: name, argc, parameters, tag, flags
+      22,    1,  600,    2, 0x0a /* Public */,
+      24,    0,  603,    2, 0x0a /* Public */,
+      25,    0,  604,    2, 0x0a /* Public */,
+      26,    0,  605,    2, 0x0a /* Public */,
+      27,    0,  606,    2, 0x0a /* Public */,
+      28,    0,  607,    2, 0x0a /* Public */,
+      29,    0,  608,    2, 0x0a /* Public */,
+      30,    0,  609,    2, 0x0a /* Public */,
+      31,    0,  610,    2, 0x0a /* Public */,
+      32,    1,  611,    2, 0x0a /* Public */,
+      33,    1,  614,    2, 0x0a /* Public */,
+      33,    0,  617,    2, 0x2a /* Public | MethodCloned */,
+      35,    1,  618,    2, 0x0a /* Public */,
+      36,    1,  621,    2, 0x0a /* Public */,
+      37,    1,  624,    2, 0x0a /* Public */,
+      38,    3,  627,    2, 0x0a /* Public */,
+      39,    0,  634,    2, 0x0a /* Public */,
+      40,    0,  635,    2, 0x0a /* Public */,
+      41,    0,  636,    2, 0x0a /* Public */,
+      42,    0,  637,    2, 0x0a /* Public */,
+      43,    1,  638,    2, 0x0a /* Public */,
+      44,    0,  641,    2, 0x0a /* Public */,
+      45,    0,  642,    2, 0x0a /* Public */,
+      46,    1,  643,    2, 0x0a /* Public */,
+      46,    0,  646,    2, 0x2a /* Public | MethodCloned */,
+      48,    0,  647,    2, 0x0a /* Public */,
+      49,    1,  648,    2, 0x0a /* Public */,
+      51,    1,  651,    2, 0x0a /* Public */,
+      53,    1,  654,    2, 0x0a /* Public */,
+      55,    1,  657,    2, 0x0a /* Public */,
+      58,    1,  660,    2, 0x0a /* Public */,
+      60,    1,  663,    2, 0x0a /* Public */,
+      62,    1,  666,    2, 0x0a /* Public */,
+      64,    1,  669,    2, 0x0a /* Public */,
+      67,    1,  672,    2, 0x0a /* Public */,
+      69,    1,  675,    2, 0x0a /* Public */,
+      71,    1,  678,    2, 0x0a /* Public */,
+      72,    1,  681,    2, 0x0a /* Public */,
+      74,    1,  684,    2, 0x0a /* Public */,
+      76,    1,  687,    2, 0x0a /* Public */,
+      78,    2,  690,    2, 0x0a /* Public */,
+      79,    1,  695,    2, 0x0a /* Public */,
+      82,    1,  698,    2, 0x0a /* Public */,
+      84,    2,  701,    2, 0x0a /* Public */,
+      84,    1,  706,    2, 0x2a /* Public | MethodCloned */,
+      87,    2,  709,    2, 0x0a /* Public */,
+      89,    1,  714,    2, 0x0a /* Public */,
+      90,    1,  717,    2, 0x0a /* Public */,
+      91,    1,  720,    2, 0x0a /* Public */,
+      92,    1,  723,    2, 0x0a /* Public */,
+      94,    1,  726,    2, 0x0a /* Public */,
+      95,    1,  729,    2, 0x0a /* Public */,
+      95,    0,  732,    2, 0x2a /* Public | MethodCloned */,
+      98,    1,  733,    2, 0x0a /* Public */,
+      99,    1,  736,    2, 0x0a /* Public */,
+     101,    1,  739,    2, 0x0a /* Public */,
+     102,    2,  742,    2, 0x0a /* Public */,
+     104,    2,  747,    2, 0x0a /* Public */,
+     106,    2,  752,    2, 0x0a /* Public */,
+     108,    2,  757,    2, 0x0a /* Public */,
+     108,    2,  762,    2, 0x0a /* Public */,
+     110,    1,  767,    2, 0x0a /* Public */,
+     111,    1,  770,    2, 0x0a /* Public */,
+     112,    1,  773,    2, 0x0a /* Public */,
+     114,    4,  776,    2, 0x0a /* Public */,
+     119,    1,  785,    2, 0x0a /* Public */,
+     120,    1,  788,    2, 0x0a /* Public */,
+     121,    1,  791,    2, 0x0a /* Public */,
+     122,    1,  794,    2, 0x0a /* Public */,
+     123,    1,  797,    2, 0x0a /* Public */,
+     124,    1,  800,    2, 0x0a /* Public */,
+     126,    1,  803,    2, 0x0a /* Public */,
+     128,    1,  806,    2, 0x0a /* Public */,
+     130,    0,  809,    2, 0x0a /* Public */,
+      68,    1,  810,    2, 0x0a /* Public */,
+     131,    1,  813,    2, 0x0a /* Public */,
+     131,    0,  816,    2, 0x0a /* Public */,
+     133,    1,  817,    2, 0x0a /* Public */,
+     133,    0,  820,    2, 0x0a /* Public */,
+     134,    1,  821,    2, 0x0a /* Public */,
+     136,    1,  824,    2, 0x08 /* Private */,
+     138,    1,  827,    2, 0x08 /* Private */,
+     140,    2,  830,    2, 0x08 /* Private */,
+     143,    2,  835,    2, 0x08 /* Private */,
+     144,    3,  840,    2, 0x08 /* Private */,
+     145,   10,  847,    2, 0x08 /* Private */,
+     154,    2,  868,    2, 0x08 /* Private */,
+     157,    0,  873,    2, 0x08 /* Private */,
+     158,    0,  874,    2, 0x08 /* Private */,
+     159,    1,  875,    2, 0x08 /* Private */,
+     160,    0,  878,    2, 0x08 /* Private */,
+     161,    2,  879,    2, 0x08 /* Private */,
+     162,    2,  884,    2, 0x08 /* Private */,
+     164,    2,  889,    2, 0x08 /* Private */,
+     166,    2,  894,    2, 0x08 /* Private */,
+     167,    2,  899,    2, 0x08 /* Private */,
+     168,    1,  904,    2, 0x08 /* Private */,
+     170,    0,  907,    2, 0x08 /* Private */,
+
+ // signals: parameters
+    QMetaType::Void, QMetaType::Int, QMetaType::Int,    3,    4,
+    QMetaType::Void, QMetaType::Bool,    6,
+    QMetaType::Void, QMetaType::Int, QMetaType::Int, 0x80000000 | 8,    3,    4,    9,
+    QMetaType::Void, QMetaType::Int, QMetaType::Int, 0x80000000 | 8,    3,    4,    9,
+    QMetaType::Void,
+    QMetaType::Void, QMetaType::Int, QMetaType::Int, 0x80000000 | 8,   13,    3,    9,
+    QMetaType::Void,
+    QMetaType::Void, QMetaType::Bool,   16,
+    QMetaType::Void,
+    QMetaType::Void,
+    QMetaType::Void, QMetaType::Int, QMetaType::QString,   20,   21,
+
+ // slots: parameters
+    QMetaType::Void, QMetaType::QString,   23,
+    QMetaType::Void,
+    QMetaType::Void,
+    QMetaType::Void,
+    QMetaType::Void,
+    QMetaType::Void,
+    QMetaType::Void,
+    QMetaType::Void,
+    QMetaType::Void,
+    QMetaType::Void, QMetaType::Int,    3,
+    QMetaType::Void, QMetaType::Bool,   34,
+    QMetaType::Void,
+    QMetaType::Void, QMetaType::Int,    3,
+    QMetaType::Void, QMetaType::Int,    3,
+    QMetaType::Void, QMetaType::QString,   23,
+    QMetaType::Void, QMetaType::QString, QMetaType::Int, QMetaType::Int,   23,    3,    4,
+    QMetaType::Void,
+    QMetaType::Void,
+    QMetaType::Void,
+    QMetaType::Void,
+    QMetaType::Void, QMetaType::QString,   23,
+    QMetaType::Void,
+    QMetaType::Void,
+    QMetaType::Void, QMetaType::Bool,   47,
+    QMetaType::Void,
+    QMetaType::Void,
+    QMetaType::Void, QMetaType::Bool,   50,
+    QMetaType::Void, QMetaType::Bool,   52,
+    QMetaType::Void, QMetaType::Bool,   54,
+    QMetaType::Void, 0x80000000 | 56,   57,
+    QMetaType::Void, QMetaType::Int,   59,
+    QMetaType::Void, 0x80000000 | 61,   54,
+    QMetaType::Void, QMetaType::Bool,   63,
+    QMetaType::Void, 0x80000000 | 65,   66,
+    QMetaType::Void, QMetaType::Bool,   68,
+    QMetaType::Void, QMetaType::QColor,   70,
+    QMetaType::Void, QMetaType::QColor,   70,
+    QMetaType::Void, QMetaType::Bool,   73,
+    QMetaType::Void, QMetaType::Int,   75,
+    QMetaType::Void, QMetaType::QColor,   77,
+    QMetaType::Void, QMetaType::Int, QMetaType::Int,    3,    4,
+    QMetaType::Void, 0x80000000 | 80,   81,
+    QMetaType::Void, QMetaType::Bool,   83,
+    QMetaType::Void, 0x80000000 | 85, QMetaType::Int,   86,   13,
+    QMetaType::Void, 0x80000000 | 85,   86,
+    QMetaType::Void, QMetaType::Int, QMetaType::Int,    3,   88,
+    QMetaType::Void, QMetaType::Bool,   73,
+    QMetaType::Void, QMetaType::QColor,   70,
+    QMetaType::Void, QMetaType::QColor,   70,
+    QMetaType::Void, QMetaType::Bool,   93,
+    QMetaType::Void, QMetaType::Int,   75,
+    QMetaType::Void, 0x80000000 | 96,   97,
+    QMetaType::Void,
+    QMetaType::Void, QMetaType::QColor,   70,
+    QMetaType::Void, QMetaType::QFont,  100,
+    QMetaType::Void, QMetaType::QColor,   70,
+    QMetaType::Void, QMetaType::Int, QMetaType::Bool,   13,  103,
+    QMetaType::Void, QMetaType::Int, QMetaType::Int,   13,  105,
+    QMetaType::Void, QMetaType::Int, QMetaType::Bool,   13,  107,
+    QMetaType::Void, QMetaType::Int, QMetaType::Int,   13,   75,
+    QMetaType::Void, QMetaType::Int, QMetaType::QString,   13,  109,
+    QMetaType::Void, QMetaType::Bool,   16,
+    QMetaType::Void, QMetaType::QColor,   77,
+    QMetaType::Void, QMetaType::Bool,  113,
+    QMetaType::Void, QMetaType::Int, QMetaType::Int, QMetaType::Int, QMetaType::Int,  115,  116,  117,  118,
+    QMetaType::Void, QMetaType::QColor,   70,
+    QMetaType::Void, QMetaType::QColor,   70,
+    QMetaType::Void, QMetaType::Bool,   36,
+    QMetaType::Void, QMetaType::Int,   75,
+    QMetaType::Void, QMetaType::QString,   23,
+    QMetaType::Void, QMetaType::Bool,  125,
+    QMetaType::Void, 0x80000000 | 127,   81,
+    QMetaType::Void, 0x80000000 | 129,   81,
+    QMetaType::Void,
+    QMetaType::Void, QMetaType::Int,    3,
+    QMetaType::Void, QMetaType::Int,  132,
+    QMetaType::Void,
+    QMetaType::Void, QMetaType::Int,  132,
+    QMetaType::Void,
+    QMetaType::Void, QMetaType::Int,  135,
+    QMetaType::Void, QMetaType::Int,  137,
+    QMetaType::Void, QMetaType::Int,  139,
+    QMetaType::Void, QMetaType::Int, QMetaType::Int,  141,  142,
+    QMetaType::Void, QMetaType::Int, QMetaType::Int,  141,  142,
+    QMetaType::Void, QMetaType::Int, QMetaType::Int, QMetaType::Int,  141,   13,  142,
+    QMetaType::Void, QMetaType::Int, QMetaType::Int, 0x80000000 | 147, QMetaType::Int, QMetaType::Int, QMetaType::Int, QMetaType::Int, QMetaType::Int, QMetaType::Int, QMetaType::Int,  141,  146,   23,  148,  149,    3,  150,  151,  152,  153,
+    QMetaType::Void, 0x80000000 | 147, 0x80000000 | 147,  155,  156,
+    QMetaType::Void,
+    QMetaType::Void,
+    QMetaType::Void, QMetaType::Bool,    6,
+    QMetaType::Void,
+    QMetaType::Void, 0x80000000 | 147, QMetaType::Int,   23,   20,
+    QMetaType::Void, QMetaType::QColor, QMetaType::Int,   77,  163,
+    QMetaType::Void, QMetaType::Bool, QMetaType::Int,  165,  163,
+    QMetaType::Void, QMetaType::QFont, QMetaType::Int,  100,  163,
+    QMetaType::Void, QMetaType::QColor, QMetaType::Int,   77,  163,
+    QMetaType::Void, QMetaType::Int,  169,
+    QMetaType::Void,
+
+       0        // eod
+};
+
+void QsciScintilla::qt_static_metacall(QObject *_o, QMetaObject::Call _c, int _id, void **_a)
+{
+    if (_c == QMetaObject::InvokeMetaMethod) {
+        QsciScintilla *_t = static_cast<QsciScintilla *>(_o);
+        switch (_id) {
+        case 0: _t->cursorPositionChanged((*reinterpret_cast< int(*)>(_a[1])),(*reinterpret_cast< int(*)>(_a[2]))); break;
+        case 1: _t->copyAvailable((*reinterpret_cast< bool(*)>(_a[1]))); break;
+        case 2: _t->indicatorClicked((*reinterpret_cast< int(*)>(_a[1])),(*reinterpret_cast< int(*)>(_a[2])),(*reinterpret_cast< Qt::KeyboardModifiers(*)>(_a[3]))); break;
+        case 3: _t->indicatorReleased((*reinterpret_cast< int(*)>(_a[1])),(*reinterpret_cast< int(*)>(_a[2])),(*reinterpret_cast< Qt::KeyboardModifiers(*)>(_a[3]))); break;
+        case 4: _t->linesChanged(); break;
+        case 5: _t->marginClicked((*reinterpret_cast< int(*)>(_a[1])),(*reinterpret_cast< int(*)>(_a[2])),(*reinterpret_cast< Qt::KeyboardModifiers(*)>(_a[3]))); break;
+        case 6: _t->modificationAttempted(); break;
+        case 7: _t->modificationChanged((*reinterpret_cast< bool(*)>(_a[1]))); break;
+        case 8: _t->selectionChanged(); break;
+        case 9: _t->textChanged(); break;
+        case 10: _t->userListActivated((*reinterpret_cast< int(*)>(_a[1])),(*reinterpret_cast< const QString(*)>(_a[2]))); break;
+        case 11: _t->append((*reinterpret_cast< const QString(*)>(_a[1]))); break;
+        case 12: _t->autoCompleteFromAll(); break;
+        case 13: _t->autoCompleteFromAPIs(); break;
+        case 14: _t->autoCompleteFromDocument(); break;
+        case 15: _t->callTip(); break;
+        case 16: _t->clear(); break;
+        case 17: _t->copy(); break;
+        case 18: _t->cut(); break;
+        case 19: _t->ensureCursorVisible(); break;
+        case 20: _t->ensureLineVisible((*reinterpret_cast< int(*)>(_a[1]))); break;
+        case 21: _t->foldAll((*reinterpret_cast< bool(*)>(_a[1]))); break;
+        case 22: _t->foldAll(); break;
+        case 23: _t->foldLine((*reinterpret_cast< int(*)>(_a[1]))); break;
+        case 24: _t->indent((*reinterpret_cast< int(*)>(_a[1]))); break;
+        case 25: _t->insert((*reinterpret_cast< const QString(*)>(_a[1]))); break;
+        case 26: _t->insertAt((*reinterpret_cast< const QString(*)>(_a[1])),(*reinterpret_cast< int(*)>(_a[2])),(*reinterpret_cast< int(*)>(_a[3]))); break;
+        case 27: _t->moveToMatchingBrace(); break;
+        case 28: _t->paste(); break;
+        case 29: _t->redo(); break;
+        case 30: _t->removeSelectedText(); break;
+        case 31: _t->replaceSelectedText((*reinterpret_cast< const QString(*)>(_a[1]))); break;
+        case 32: _t->resetSelectionBackgroundColor(); break;
+        case 33: _t->resetSelectionForegroundColor(); break;
+        case 34: _t->selectAll((*reinterpret_cast< bool(*)>(_a[1]))); break;
+        case 35: _t->selectAll(); break;
+        case 36: _t->selectToMatchingBrace(); break;
+        case 37: _t->setAutoCompletionCaseSensitivity((*reinterpret_cast< bool(*)>(_a[1]))); break;
+        case 38: _t->setAutoCompletionReplaceWord((*reinterpret_cast< bool(*)>(_a[1]))); break;
+        case 39: _t->setAutoCompletionShowSingle((*reinterpret_cast< bool(*)>(_a[1]))); break;
+        case 40: _t->setAutoCompletionSource((*reinterpret_cast< AutoCompletionSource(*)>(_a[1]))); break;
+        case 41: _t->setAutoCompletionThreshold((*reinterpret_cast< int(*)>(_a[1]))); break;
+        case 42: _t->setAutoCompletionUseSingle((*reinterpret_cast< AutoCompletionUseSingle(*)>(_a[1]))); break;
+        case 43: _t->setAutoIndent((*reinterpret_cast< bool(*)>(_a[1]))); break;
+        case 44: _t->setBraceMatching((*reinterpret_cast< BraceMatch(*)>(_a[1]))); break;
+        case 45: _t->setBackspaceUnindents((*reinterpret_cast< bool(*)>(_a[1]))); break;
+        case 46: _t->setCaretForegroundColor((*reinterpret_cast< const QColor(*)>(_a[1]))); break;
+        case 47: _t->setCaretLineBackgroundColor((*reinterpret_cast< const QColor(*)>(_a[1]))); break;
+        case 48: _t->setCaretLineVisible((*reinterpret_cast< bool(*)>(_a[1]))); break;
+        case 49: _t->setCaretWidth((*reinterpret_cast< int(*)>(_a[1]))); break;
+        case 50: _t->setColor((*reinterpret_cast< const QColor(*)>(_a[1]))); break;
+        case 51: _t->setCursorPosition((*reinterpret_cast< int(*)>(_a[1])),(*reinterpret_cast< int(*)>(_a[2]))); break;
+        case 52: _t->setEolMode((*reinterpret_cast< EolMode(*)>(_a[1]))); break;
+        case 53: _t->setEolVisibility((*reinterpret_cast< bool(*)>(_a[1]))); break;
+        case 54: _t->setFolding((*reinterpret_cast< FoldStyle(*)>(_a[1])),(*reinterpret_cast< int(*)>(_a[2]))); break;
+        case 55: _t->setFolding((*reinterpret_cast< FoldStyle(*)>(_a[1]))); break;
+        case 56: _t->setIndentation((*reinterpret_cast< int(*)>(_a[1])),(*reinterpret_cast< int(*)>(_a[2]))); break;
+        case 57: _t->setIndentationGuides((*reinterpret_cast< bool(*)>(_a[1]))); break;
+        case 58: _t->setIndentationGuidesBackgroundColor((*reinterpret_cast< const QColor(*)>(_a[1]))); break;
+        case 59: _t->setIndentationGuidesForegroundColor((*reinterpret_cast< const QColor(*)>(_a[1]))); break;
+        case 60: _t->setIndentationsUseTabs((*reinterpret_cast< bool(*)>(_a[1]))); break;
+        case 61: _t->setIndentationWidth((*reinterpret_cast< int(*)>(_a[1]))); break;
+        case 62: _t->setLexer((*reinterpret_cast< QsciLexer*(*)>(_a[1]))); break;
+        case 63: _t->setLexer(); break;
+        case 64: _t->setMarginsBackgroundColor((*reinterpret_cast< const QColor(*)>(_a[1]))); break;
+        case 65: _t->setMarginsFont((*reinterpret_cast< const QFont(*)>(_a[1]))); break;
+        case 66: _t->setMarginsForegroundColor((*reinterpret_cast< const QColor(*)>(_a[1]))); break;
+        case 67: _t->setMarginLineNumbers((*reinterpret_cast< int(*)>(_a[1])),(*reinterpret_cast< bool(*)>(_a[2]))); break;
+        case 68: _t->setMarginMarkerMask((*reinterpret_cast< int(*)>(_a[1])),(*reinterpret_cast< int(*)>(_a[2]))); break;
+        case 69: _t->setMarginSensitivity((*reinterpret_cast< int(*)>(_a[1])),(*reinterpret_cast< bool(*)>(_a[2]))); break;
+        case 70: _t->setMarginWidth((*reinterpret_cast< int(*)>(_a[1])),(*reinterpret_cast< int(*)>(_a[2]))); break;
+        case 71: _t->setMarginWidth((*reinterpret_cast< int(*)>(_a[1])),(*reinterpret_cast< const QString(*)>(_a[2]))); break;
+        case 72: _t->setModified((*reinterpret_cast< bool(*)>(_a[1]))); break;
+        case 73: _t->setPaper((*reinterpret_cast< const QColor(*)>(_a[1]))); break;
+        case 74: _t->setReadOnly((*reinterpret_cast< bool(*)>(_a[1]))); break;
+        case 75: _t->setSelection((*reinterpret_cast< int(*)>(_a[1])),(*reinterpret_cast< int(*)>(_a[2])),(*reinterpret_cast< int(*)>(_a[3])),(*reinterpret_cast< int(*)>(_a[4]))); break;
+        case 76: _t->setSelectionBackgroundColor((*reinterpret_cast< const QColor(*)>(_a[1]))); break;
+        case 77: _t->setSelectionForegroundColor((*reinterpret_cast< const QColor(*)>(_a[1]))); break;
+        case 78: _t->setTabIndents((*reinterpret_cast< bool(*)>(_a[1]))); break;
+        case 79: _t->setTabWidth((*reinterpret_cast< int(*)>(_a[1]))); break;
+        case 80: _t->setText((*reinterpret_cast< const QString(*)>(_a[1]))); break;
+        case 81: _t->setUtf8((*reinterpret_cast< bool(*)>(_a[1]))); break;
+        case 82: _t->setWhitespaceVisibility((*reinterpret_cast< WhitespaceVisibility(*)>(_a[1]))); break;
+        case 83: _t->setWrapMode((*reinterpret_cast< WrapMode(*)>(_a[1]))); break;
+        case 84: _t->undo(); break;
+        case 85: _t->unindent((*reinterpret_cast< int(*)>(_a[1]))); break;
+        case 86: _t->zoomIn((*reinterpret_cast< int(*)>(_a[1]))); break;
+        case 87: _t->zoomIn(); break;
+        case 88: _t->zoomOut((*reinterpret_cast< int(*)>(_a[1]))); break;
+        case 89: _t->zoomOut(); break;
+        case 90: _t->zoomTo((*reinterpret_cast< int(*)>(_a[1]))); break;
+        case 91: _t->handleCallTipClick((*reinterpret_cast< int(*)>(_a[1]))); break;
+        case 92: _t->handleCharAdded((*reinterpret_cast< int(*)>(_a[1]))); break;
+        case 93: _t->handleIndicatorClick((*reinterpret_cast< int(*)>(_a[1])),(*reinterpret_cast< int(*)>(_a[2]))); break;
+        case 94: _t->handleIndicatorRelease((*reinterpret_cast< int(*)>(_a[1])),(*reinterpret_cast< int(*)>(_a[2]))); break;
+        case 95: _t->handleMarginClick((*reinterpret_cast< int(*)>(_a[1])),(*reinterpret_cast< int(*)>(_a[2])),(*reinterpret_cast< int(*)>(_a[3]))); break;
+        case 96: _t->handleModified((*reinterpret_cast< int(*)>(_a[1])),(*reinterpret_cast< int(*)>(_a[2])),(*reinterpret_cast< const char*(*)>(_a[3])),(*reinterpret_cast< int(*)>(_a[4])),(*reinterpret_cast< int(*)>(_a[5])),(*reinterpret_cast< int(*)>(_a[6])),(*reinterpret_cast< int(*)>(_a[7])),(*reinterpret_cast< int(*)>(_a[8])),(*reinterpret_cast< int(*)>(_a[9])),(*reinterpret_cast< int(*)>(_a[10]))); break;
+        case 97: _t->handlePropertyChange((*reinterpret_cast< const char*(*)>(_a[1])),(*reinterpret_cast< const char*(*)>(_a[2]))); break;
+        case 98: _t->handleSavePointReached(); break;
+        case 99: _t->handleSavePointLeft(); break;
+        case 100: _t->handleSelectionChanged((*reinterpret_cast< bool(*)>(_a[1]))); break;
+        case 101: _t->handleAutoCompletionSelection(); break;
+        case 102: _t->handleUserListSelection((*reinterpret_cast< const char*(*)>(_a[1])),(*reinterpret_cast< int(*)>(_a[2]))); break;
+        case 103: _t->handleStyleColorChange((*reinterpret_cast< const QColor(*)>(_a[1])),(*reinterpret_cast< int(*)>(_a[2]))); break;
+        case 104: _t->handleStyleEolFillChange((*reinterpret_cast< bool(*)>(_a[1])),(*reinterpret_cast< int(*)>(_a[2]))); break;
+        case 105: _t->handleStyleFontChange((*reinterpret_cast< const QFont(*)>(_a[1])),(*reinterpret_cast< int(*)>(_a[2]))); break;
+        case 106: _t->handleStylePaperChange((*reinterpret_cast< const QColor(*)>(_a[1])),(*reinterpret_cast< int(*)>(_a[2]))); break;
+        case 107: _t->handleUpdateUI((*reinterpret_cast< int(*)>(_a[1]))); break;
+        case 108: _t->delete_selection(); break;
+        default: ;
+        }
+    } else if (_c == QMetaObject::IndexOfMethod) {
+        int *result = reinterpret_cast<int *>(_a[0]);
+        void **func = reinterpret_cast<void **>(_a[1]);
+        {
+            typedef void (QsciScintilla::*_t)(int , int );
+            if (*reinterpret_cast<_t *>(func) == static_cast<_t>(&QsciScintilla::cursorPositionChanged)) {
+                *result = 0;
+            }
+        }
+        {
+            typedef void (QsciScintilla::*_t)(bool );
+            if (*reinterpret_cast<_t *>(func) == static_cast<_t>(&QsciScintilla::copyAvailable)) {
+                *result = 1;
+            }
+        }
+        {
+            typedef void (QsciScintilla::*_t)(int , int , Qt::KeyboardModifiers );
+            if (*reinterpret_cast<_t *>(func) == static_cast<_t>(&QsciScintilla::indicatorClicked)) {
+                *result = 2;
+            }
+        }
+        {
+            typedef void (QsciScintilla::*_t)(int , int , Qt::KeyboardModifiers );
+            if (*reinterpret_cast<_t *>(func) == static_cast<_t>(&QsciScintilla::indicatorReleased)) {
+                *result = 3;
+            }
+        }
+        {
+            typedef void (QsciScintilla::*_t)();
+            if (*reinterpret_cast<_t *>(func) == static_cast<_t>(&QsciScintilla::linesChanged)) {
+                *result = 4;
+            }
+        }
+        {
+            typedef void (QsciScintilla::*_t)(int , int , Qt::KeyboardModifiers );
+            if (*reinterpret_cast<_t *>(func) == static_cast<_t>(&QsciScintilla::marginClicked)) {
+                *result = 5;
+            }
+        }
+        {
+            typedef void (QsciScintilla::*_t)();
+            if (*reinterpret_cast<_t *>(func) == static_cast<_t>(&QsciScintilla::modificationAttempted)) {
+                *result = 6;
+            }
+        }
+        {
+            typedef void (QsciScintilla::*_t)(bool );
+            if (*reinterpret_cast<_t *>(func) == static_cast<_t>(&QsciScintilla::modificationChanged)) {
+                *result = 7;
+            }
+        }
+        {
+            typedef void (QsciScintilla::*_t)();
+            if (*reinterpret_cast<_t *>(func) == static_cast<_t>(&QsciScintilla::selectionChanged)) {
+                *result = 8;
+            }
+        }
+        {
+            typedef void (QsciScintilla::*_t)();
+            if (*reinterpret_cast<_t *>(func) == static_cast<_t>(&QsciScintilla::textChanged)) {
+                *result = 9;
+            }
+        }
+        {
+            typedef void (QsciScintilla::*_t)(int , const QString & );
+            if (*reinterpret_cast<_t *>(func) == static_cast<_t>(&QsciScintilla::userListActivated)) {
+                *result = 10;
+            }
+        }
+    }
+}
+
+const QMetaObject QsciScintilla::staticMetaObject = {
+    { &QsciScintillaBase::staticMetaObject, qt_meta_stringdata_QsciScintilla.data,
+      qt_meta_data_QsciScintilla,  qt_static_metacall, 0, 0}
+};
+
+
+const QMetaObject *QsciScintilla::metaObject() const
+{
+    return QObject::d_ptr->metaObject ? QObject::d_ptr->dynamicMetaObject() : &staticMetaObject;
+}
+
+void *QsciScintilla::qt_metacast(const char *_clname)
+{
+    if (!_clname) return 0;
+    if (!strcmp(_clname, qt_meta_stringdata_QsciScintilla.stringdata))
+        return static_cast<void*>(const_cast< QsciScintilla*>(this));
+    return QsciScintillaBase::qt_metacast(_clname);
+}
+
+int QsciScintilla::qt_metacall(QMetaObject::Call _c, int _id, void **_a)
+{
+    _id = QsciScintillaBase::qt_metacall(_c, _id, _a);
+    if (_id < 0)
+        return _id;
+    if (_c == QMetaObject::InvokeMetaMethod) {
+        if (_id < 109)
+            qt_static_metacall(this, _c, _id, _a);
+        _id -= 109;
+    } else if (_c == QMetaObject::RegisterMethodArgumentMetaType) {
+        if (_id < 109)
+            *reinterpret_cast<int*>(_a[0]) = -1;
+        _id -= 109;
+    }
+    return _id;
+}
+
+// SIGNAL 0
+void QsciScintilla::cursorPositionChanged(int _t1, int _t2)
+{
+    void *_a[] = { 0, const_cast<void*>(reinterpret_cast<const void*>(&_t1)), const_cast<void*>(reinterpret_cast<const void*>(&_t2)) };
+    QMetaObject::activate(this, &staticMetaObject, 0, _a);
+}
+
+// SIGNAL 1
+void QsciScintilla::copyAvailable(bool _t1)
+{
+    void *_a[] = { 0, const_cast<void*>(reinterpret_cast<const void*>(&_t1)) };
+    QMetaObject::activate(this, &staticMetaObject, 1, _a);
+}
+
+// SIGNAL 2
+void QsciScintilla::indicatorClicked(int _t1, int _t2, Qt::KeyboardModifiers _t3)
+{
+    void *_a[] = { 0, const_cast<void*>(reinterpret_cast<const void*>(&_t1)), const_cast<void*>(reinterpret_cast<const void*>(&_t2)), const_cast<void*>(reinterpret_cast<const void*>(&_t3)) };
+    QMetaObject::activate(this, &staticMetaObject, 2, _a);
+}
+
+// SIGNAL 3
+void QsciScintilla::indicatorReleased(int _t1, int _t2, Qt::KeyboardModifiers _t3)
+{
+    void *_a[] = { 0, const_cast<void*>(reinterpret_cast<const void*>(&_t1)), const_cast<void*>(reinterpret_cast<const void*>(&_t2)), const_cast<void*>(reinterpret_cast<const void*>(&_t3)) };
+    QMetaObject::activate(this, &staticMetaObject, 3, _a);
+}
+
+// SIGNAL 4
+void QsciScintilla::linesChanged()
+{
+    QMetaObject::activate(this, &staticMetaObject, 4, 0);
+}
+
+// SIGNAL 5
+void QsciScintilla::marginClicked(int _t1, int _t2, Qt::KeyboardModifiers _t3)
+{
+    void *_a[] = { 0, const_cast<void*>(reinterpret_cast<const void*>(&_t1)), const_cast<void*>(reinterpret_cast<const void*>(&_t2)), const_cast<void*>(reinterpret_cast<const void*>(&_t3)) };
+    QMetaObject::activate(this, &staticMetaObject, 5, _a);
+}
+
+// SIGNAL 6
+void QsciScintilla::modificationAttempted()
+{
+    QMetaObject::activate(this, &staticMetaObject, 6, 0);
+}
+
+// SIGNAL 7
+void QsciScintilla::modificationChanged(bool _t1)
+{
+    void *_a[] = { 0, const_cast<void*>(reinterpret_cast<const void*>(&_t1)) };
+    QMetaObject::activate(this, &staticMetaObject, 7, _a);
+}
+
+// SIGNAL 8
+void QsciScintilla::selectionChanged()
+{
+    QMetaObject::activate(this, &staticMetaObject, 8, 0);
+}
+
+// SIGNAL 9
+void QsciScintilla::textChanged()
+{
+    QMetaObject::activate(this, &staticMetaObject, 9, 0);
+}
+
+// SIGNAL 10
+void QsciScintilla::userListActivated(int _t1, const QString & _t2)
+{
+    void *_a[] = { 0, const_cast<void*>(reinterpret_cast<const void*>(&_t1)), const_cast<void*>(reinterpret_cast<const void*>(&_t2)) };
+    QMetaObject::activate(this, &staticMetaObject, 10, _a);
+}
+QT_END_MOC_NAMESPACE

--- a/app/gui/qt/platform/win/moc_qsciscintillabase.cpp
+++ b/app/gui/qt/platform/win/moc_qsciscintillabase.cpp
@@ -1,0 +1,637 @@
+/****************************************************************************
+** Meta object code from reading C++ file 'qsciscintillabase.h'
+**
+** Created by: The Qt Meta Object Compiler version 67 (Qt 5.3.2)
+**
+** WARNING! All changes made in this file will be lost!
+*****************************************************************************/
+
+#include "../Qsci/qsciscintillabase.h"
+#include <QtCore/qbytearray.h>
+#include <QtCore/qmetatype.h>
+#if !defined(Q_MOC_OUTPUT_REVISION)
+#error "The header file 'qsciscintillabase.h' doesn't include <QObject>."
+#elif Q_MOC_OUTPUT_REVISION != 67
+#error "This file was generated using the moc from 5.3.2. It"
+#error "cannot be used with the include files from this version of Qt."
+#error "(The moc has changed too much.)"
+#endif
+
+QT_BEGIN_MOC_NAMESPACE
+struct qt_meta_stringdata_QsciScintillaBase_t {
+    QByteArrayData data[46];
+    char stringdata[639];
+};
+#define QT_MOC_LITERAL(idx, ofs, len) \
+    Q_STATIC_BYTE_ARRAY_DATA_HEADER_INITIALIZER_WITH_OFFSET(len, \
+    qptrdiff(offsetof(qt_meta_stringdata_QsciScintillaBase_t, stringdata) + ofs \
+        - idx * sizeof(QByteArrayData)) \
+    )
+static const qt_meta_stringdata_QsciScintillaBase_t qt_meta_stringdata_QsciScintillaBase = {
+    {
+QT_MOC_LITERAL(0, 0, 17),
+QT_MOC_LITERAL(1, 18, 15),
+QT_MOC_LITERAL(2, 34, 0),
+QT_MOC_LITERAL(3, 35, 3),
+QT_MOC_LITERAL(4, 39, 18),
+QT_MOC_LITERAL(5, 58, 20),
+QT_MOC_LITERAL(6, 79, 18),
+QT_MOC_LITERAL(7, 98, 11),
+QT_MOC_LITERAL(8, 110, 9),
+QT_MOC_LITERAL(9, 120, 8),
+QT_MOC_LITERAL(10, 129, 11),
+QT_MOC_LITERAL(11, 141, 16),
+QT_MOC_LITERAL(12, 158, 9),
+QT_MOC_LITERAL(13, 168, 13),
+QT_MOC_LITERAL(14, 182, 9),
+QT_MOC_LITERAL(15, 192, 15),
+QT_MOC_LITERAL(16, 208, 4),
+QT_MOC_LITERAL(17, 213, 9),
+QT_MOC_LITERAL(18, 223, 12),
+QT_MOC_LITERAL(19, 236, 14),
+QT_MOC_LITERAL(20, 251, 11),
+QT_MOC_LITERAL(21, 263, 12),
+QT_MOC_LITERAL(22, 276, 16),
+QT_MOC_LITERAL(23, 293, 22),
+QT_MOC_LITERAL(24, 316, 23),
+QT_MOC_LITERAL(25, 340, 18),
+QT_MOC_LITERAL(26, 359, 20),
+QT_MOC_LITERAL(27, 380, 15),
+QT_MOC_LITERAL(28, 396, 15),
+QT_MOC_LITERAL(29, 412, 6),
+QT_MOC_LITERAL(30, 419, 12),
+QT_MOC_LITERAL(31, 432, 19),
+QT_MOC_LITERAL(32, 452, 13),
+QT_MOC_LITERAL(33, 466, 11),
+QT_MOC_LITERAL(34, 478, 17),
+QT_MOC_LITERAL(35, 496, 20),
+QT_MOC_LITERAL(36, 517, 15),
+QT_MOC_LITERAL(37, 533, 12),
+QT_MOC_LITERAL(38, 546, 7),
+QT_MOC_LITERAL(39, 554, 21),
+QT_MOC_LITERAL(40, 576, 8),
+QT_MOC_LITERAL(41, 585, 11),
+QT_MOC_LITERAL(42, 597, 9),
+QT_MOC_LITERAL(43, 607, 5),
+QT_MOC_LITERAL(44, 613, 9),
+QT_MOC_LITERAL(45, 623, 15)
+    },
+    "QsciScintillaBase\0QSCN_SELCHANGED\0\0"
+    "yes\0SCN_AUTOCCANCELLED\0SCN_AUTOCCHARDELETED\0"
+    "SCN_AUTOCSELECTION\0const char*\0selection\0"
+    "position\0SCEN_CHANGE\0SCN_CALLTIPCLICK\0"
+    "direction\0SCN_CHARADDED\0charadded\0"
+    "SCN_DOUBLECLICK\0line\0modifiers\0"
+    "SCN_DWELLEND\0SCN_DWELLSTART\0SCN_FOCUSIN\0"
+    "SCN_FOCUSOUT\0SCN_HOTSPOTCLICK\0"
+    "SCN_HOTSPOTDOUBLECLICK\0SCN_HOTSPOTRELEASECLICK\0"
+    "SCN_INDICATORCLICK\0SCN_INDICATORRELEASE\0"
+    "SCN_MACRORECORD\0SCN_MARGINCLICK\0margin\0"
+    "SCN_MODIFIED\0SCN_MODIFYATTEMPTRO\0"
+    "SCN_NEEDSHOWN\0SCN_PAINTED\0SCN_SAVEPOINTLEFT\0"
+    "SCN_SAVEPOINTREACHED\0SCN_STYLENEEDED\0"
+    "SCN_UPDATEUI\0updated\0SCN_USERLISTSELECTION\0"
+    "SCN_ZOOM\0handleTimer\0handleVSb\0value\0"
+    "handleHSb\0handleSelection"
+};
+#undef QT_MOC_LITERAL
+
+static const uint qt_meta_data_QsciScintillaBase[] = {
+
+ // content:
+       7,       // revision
+       0,       // classname
+       0,    0, // classinfo
+      33,   14, // methods
+       0,    0, // properties
+       0,    0, // enums/sets
+       0,    0, // constructors
+       0,       // flags
+      29,       // signalCount
+
+ // signals: name, argc, parameters, tag, flags
+       1,    1,  179,    2, 0x06 /* Public */,
+       4,    0,  182,    2, 0x06 /* Public */,
+       5,    0,  183,    2, 0x06 /* Public */,
+       6,    2,  184,    2, 0x06 /* Public */,
+      10,    0,  189,    2, 0x06 /* Public */,
+      11,    1,  190,    2, 0x06 /* Public */,
+      13,    1,  193,    2, 0x06 /* Public */,
+      15,    3,  196,    2, 0x06 /* Public */,
+      18,    3,  203,    2, 0x06 /* Public */,
+      19,    3,  210,    2, 0x06 /* Public */,
+      20,    0,  217,    2, 0x06 /* Public */,
+      21,    0,  218,    2, 0x06 /* Public */,
+      22,    2,  219,    2, 0x06 /* Public */,
+      23,    2,  224,    2, 0x06 /* Public */,
+      24,    2,  229,    2, 0x06 /* Public */,
+      25,    2,  234,    2, 0x06 /* Public */,
+      26,    2,  239,    2, 0x06 /* Public */,
+      27,    3,  244,    2, 0x06 /* Public */,
+      28,    3,  251,    2, 0x06 /* Public */,
+      30,   10,  258,    2, 0x06 /* Public */,
+      31,    0,  279,    2, 0x06 /* Public */,
+      32,    2,  280,    2, 0x06 /* Public */,
+      33,    0,  285,    2, 0x06 /* Public */,
+      34,    0,  286,    2, 0x06 /* Public */,
+      35,    0,  287,    2, 0x06 /* Public */,
+      36,    1,  288,    2, 0x06 /* Public */,
+      37,    1,  291,    2, 0x06 /* Public */,
+      39,    2,  294,    2, 0x06 /* Public */,
+      40,    0,  299,    2, 0x06 /* Public */,
+
+ // slots: name, argc, parameters, tag, flags
+      41,    0,  300,    2, 0x08 /* Private */,
+      42,    1,  301,    2, 0x08 /* Private */,
+      44,    1,  304,    2, 0x08 /* Private */,
+      45,    0,  307,    2, 0x08 /* Private */,
+
+ // signals: parameters
+    QMetaType::Void, QMetaType::Bool,    3,
+    QMetaType::Void,
+    QMetaType::Void,
+    QMetaType::Void, 0x80000000 | 7, QMetaType::Int,    8,    9,
+    QMetaType::Void,
+    QMetaType::Void, QMetaType::Int,   12,
+    QMetaType::Void, QMetaType::Int,   14,
+    QMetaType::Void, QMetaType::Int, QMetaType::Int, QMetaType::Int,    9,   16,   17,
+    QMetaType::Void, QMetaType::Int, QMetaType::Int, QMetaType::Int,    2,    2,    2,
+    QMetaType::Void, QMetaType::Int, QMetaType::Int, QMetaType::Int,    2,    2,    2,
+    QMetaType::Void,
+    QMetaType::Void,
+    QMetaType::Void, QMetaType::Int, QMetaType::Int,    9,   17,
+    QMetaType::Void, QMetaType::Int, QMetaType::Int,    9,   17,
+    QMetaType::Void, QMetaType::Int, QMetaType::Int,    9,   17,
+    QMetaType::Void, QMetaType::Int, QMetaType::Int,    9,   17,
+    QMetaType::Void, QMetaType::Int, QMetaType::Int,    9,   17,
+    QMetaType::Void, QMetaType::UInt, QMetaType::ULong, QMetaType::VoidStar,    2,    2,    2,
+    QMetaType::Void, QMetaType::Int, QMetaType::Int, QMetaType::Int,    9,   17,   29,
+    QMetaType::Void, QMetaType::Int, QMetaType::Int, 0x80000000 | 7, QMetaType::Int, QMetaType::Int, QMetaType::Int, QMetaType::Int, QMetaType::Int, QMetaType::Int, QMetaType::Int,    2,    2,    2,    2,    2,    2,    2,    2,    2,    2,
+    QMetaType::Void,
+    QMetaType::Void, QMetaType::Int, QMetaType::Int,    2,    2,
+    QMetaType::Void,
+    QMetaType::Void,
+    QMetaType::Void,
+    QMetaType::Void, QMetaType::Int,    9,
+    QMetaType::Void, QMetaType::Int,   38,
+    QMetaType::Void, 0x80000000 | 7, QMetaType::Int,    2,    2,
+    QMetaType::Void,
+
+ // slots: parameters
+    QMetaType::Void,
+    QMetaType::Void, QMetaType::Int,   43,
+    QMetaType::Void, QMetaType::Int,   43,
+    QMetaType::Void,
+
+       0        // eod
+};
+
+void QsciScintillaBase::qt_static_metacall(QObject *_o, QMetaObject::Call _c, int _id, void **_a)
+{
+    if (_c == QMetaObject::InvokeMetaMethod) {
+        QsciScintillaBase *_t = static_cast<QsciScintillaBase *>(_o);
+        switch (_id) {
+        case 0: _t->QSCN_SELCHANGED((*reinterpret_cast< bool(*)>(_a[1]))); break;
+        case 1: _t->SCN_AUTOCCANCELLED(); break;
+        case 2: _t->SCN_AUTOCCHARDELETED(); break;
+        case 3: _t->SCN_AUTOCSELECTION((*reinterpret_cast< const char*(*)>(_a[1])),(*reinterpret_cast< int(*)>(_a[2]))); break;
+        case 4: _t->SCEN_CHANGE(); break;
+        case 5: _t->SCN_CALLTIPCLICK((*reinterpret_cast< int(*)>(_a[1]))); break;
+        case 6: _t->SCN_CHARADDED((*reinterpret_cast< int(*)>(_a[1]))); break;
+        case 7: _t->SCN_DOUBLECLICK((*reinterpret_cast< int(*)>(_a[1])),(*reinterpret_cast< int(*)>(_a[2])),(*reinterpret_cast< int(*)>(_a[3]))); break;
+        case 8: _t->SCN_DWELLEND((*reinterpret_cast< int(*)>(_a[1])),(*reinterpret_cast< int(*)>(_a[2])),(*reinterpret_cast< int(*)>(_a[3]))); break;
+        case 9: _t->SCN_DWELLSTART((*reinterpret_cast< int(*)>(_a[1])),(*reinterpret_cast< int(*)>(_a[2])),(*reinterpret_cast< int(*)>(_a[3]))); break;
+        case 10: _t->SCN_FOCUSIN(); break;
+        case 11: _t->SCN_FOCUSOUT(); break;
+        case 12: _t->SCN_HOTSPOTCLICK((*reinterpret_cast< int(*)>(_a[1])),(*reinterpret_cast< int(*)>(_a[2]))); break;
+        case 13: _t->SCN_HOTSPOTDOUBLECLICK((*reinterpret_cast< int(*)>(_a[1])),(*reinterpret_cast< int(*)>(_a[2]))); break;
+        case 14: _t->SCN_HOTSPOTRELEASECLICK((*reinterpret_cast< int(*)>(_a[1])),(*reinterpret_cast< int(*)>(_a[2]))); break;
+        case 15: _t->SCN_INDICATORCLICK((*reinterpret_cast< int(*)>(_a[1])),(*reinterpret_cast< int(*)>(_a[2]))); break;
+        case 16: _t->SCN_INDICATORRELEASE((*reinterpret_cast< int(*)>(_a[1])),(*reinterpret_cast< int(*)>(_a[2]))); break;
+        case 17: _t->SCN_MACRORECORD((*reinterpret_cast< uint(*)>(_a[1])),(*reinterpret_cast< ulong(*)>(_a[2])),(*reinterpret_cast< void*(*)>(_a[3]))); break;
+        case 18: _t->SCN_MARGINCLICK((*reinterpret_cast< int(*)>(_a[1])),(*reinterpret_cast< int(*)>(_a[2])),(*reinterpret_cast< int(*)>(_a[3]))); break;
+        case 19: _t->SCN_MODIFIED((*reinterpret_cast< int(*)>(_a[1])),(*reinterpret_cast< int(*)>(_a[2])),(*reinterpret_cast< const char*(*)>(_a[3])),(*reinterpret_cast< int(*)>(_a[4])),(*reinterpret_cast< int(*)>(_a[5])),(*reinterpret_cast< int(*)>(_a[6])),(*reinterpret_cast< int(*)>(_a[7])),(*reinterpret_cast< int(*)>(_a[8])),(*reinterpret_cast< int(*)>(_a[9])),(*reinterpret_cast< int(*)>(_a[10]))); break;
+        case 20: _t->SCN_MODIFYATTEMPTRO(); break;
+        case 21: _t->SCN_NEEDSHOWN((*reinterpret_cast< int(*)>(_a[1])),(*reinterpret_cast< int(*)>(_a[2]))); break;
+        case 22: _t->SCN_PAINTED(); break;
+        case 23: _t->SCN_SAVEPOINTLEFT(); break;
+        case 24: _t->SCN_SAVEPOINTREACHED(); break;
+        case 25: _t->SCN_STYLENEEDED((*reinterpret_cast< int(*)>(_a[1]))); break;
+        case 26: _t->SCN_UPDATEUI((*reinterpret_cast< int(*)>(_a[1]))); break;
+        case 27: _t->SCN_USERLISTSELECTION((*reinterpret_cast< const char*(*)>(_a[1])),(*reinterpret_cast< int(*)>(_a[2]))); break;
+        case 28: _t->SCN_ZOOM(); break;
+        case 29: _t->handleTimer(); break;
+        case 30: _t->handleVSb((*reinterpret_cast< int(*)>(_a[1]))); break;
+        case 31: _t->handleHSb((*reinterpret_cast< int(*)>(_a[1]))); break;
+        case 32: _t->handleSelection(); break;
+        default: ;
+        }
+    } else if (_c == QMetaObject::IndexOfMethod) {
+        int *result = reinterpret_cast<int *>(_a[0]);
+        void **func = reinterpret_cast<void **>(_a[1]);
+        {
+            typedef void (QsciScintillaBase::*_t)(bool );
+            if (*reinterpret_cast<_t *>(func) == static_cast<_t>(&QsciScintillaBase::QSCN_SELCHANGED)) {
+                *result = 0;
+            }
+        }
+        {
+            typedef void (QsciScintillaBase::*_t)();
+            if (*reinterpret_cast<_t *>(func) == static_cast<_t>(&QsciScintillaBase::SCN_AUTOCCANCELLED)) {
+                *result = 1;
+            }
+        }
+        {
+            typedef void (QsciScintillaBase::*_t)();
+            if (*reinterpret_cast<_t *>(func) == static_cast<_t>(&QsciScintillaBase::SCN_AUTOCCHARDELETED)) {
+                *result = 2;
+            }
+        }
+        {
+            typedef void (QsciScintillaBase::*_t)(const char * , int );
+            if (*reinterpret_cast<_t *>(func) == static_cast<_t>(&QsciScintillaBase::SCN_AUTOCSELECTION)) {
+                *result = 3;
+            }
+        }
+        {
+            typedef void (QsciScintillaBase::*_t)();
+            if (*reinterpret_cast<_t *>(func) == static_cast<_t>(&QsciScintillaBase::SCEN_CHANGE)) {
+                *result = 4;
+            }
+        }
+        {
+            typedef void (QsciScintillaBase::*_t)(int );
+            if (*reinterpret_cast<_t *>(func) == static_cast<_t>(&QsciScintillaBase::SCN_CALLTIPCLICK)) {
+                *result = 5;
+            }
+        }
+        {
+            typedef void (QsciScintillaBase::*_t)(int );
+            if (*reinterpret_cast<_t *>(func) == static_cast<_t>(&QsciScintillaBase::SCN_CHARADDED)) {
+                *result = 6;
+            }
+        }
+        {
+            typedef void (QsciScintillaBase::*_t)(int , int , int );
+            if (*reinterpret_cast<_t *>(func) == static_cast<_t>(&QsciScintillaBase::SCN_DOUBLECLICK)) {
+                *result = 7;
+            }
+        }
+        {
+            typedef void (QsciScintillaBase::*_t)(int , int , int );
+            if (*reinterpret_cast<_t *>(func) == static_cast<_t>(&QsciScintillaBase::SCN_DWELLEND)) {
+                *result = 8;
+            }
+        }
+        {
+            typedef void (QsciScintillaBase::*_t)(int , int , int );
+            if (*reinterpret_cast<_t *>(func) == static_cast<_t>(&QsciScintillaBase::SCN_DWELLSTART)) {
+                *result = 9;
+            }
+        }
+        {
+            typedef void (QsciScintillaBase::*_t)();
+            if (*reinterpret_cast<_t *>(func) == static_cast<_t>(&QsciScintillaBase::SCN_FOCUSIN)) {
+                *result = 10;
+            }
+        }
+        {
+            typedef void (QsciScintillaBase::*_t)();
+            if (*reinterpret_cast<_t *>(func) == static_cast<_t>(&QsciScintillaBase::SCN_FOCUSOUT)) {
+                *result = 11;
+            }
+        }
+        {
+            typedef void (QsciScintillaBase::*_t)(int , int );
+            if (*reinterpret_cast<_t *>(func) == static_cast<_t>(&QsciScintillaBase::SCN_HOTSPOTCLICK)) {
+                *result = 12;
+            }
+        }
+        {
+            typedef void (QsciScintillaBase::*_t)(int , int );
+            if (*reinterpret_cast<_t *>(func) == static_cast<_t>(&QsciScintillaBase::SCN_HOTSPOTDOUBLECLICK)) {
+                *result = 13;
+            }
+        }
+        {
+            typedef void (QsciScintillaBase::*_t)(int , int );
+            if (*reinterpret_cast<_t *>(func) == static_cast<_t>(&QsciScintillaBase::SCN_HOTSPOTRELEASECLICK)) {
+                *result = 14;
+            }
+        }
+        {
+            typedef void (QsciScintillaBase::*_t)(int , int );
+            if (*reinterpret_cast<_t *>(func) == static_cast<_t>(&QsciScintillaBase::SCN_INDICATORCLICK)) {
+                *result = 15;
+            }
+        }
+        {
+            typedef void (QsciScintillaBase::*_t)(int , int );
+            if (*reinterpret_cast<_t *>(func) == static_cast<_t>(&QsciScintillaBase::SCN_INDICATORRELEASE)) {
+                *result = 16;
+            }
+        }
+        {
+            typedef void (QsciScintillaBase::*_t)(unsigned int , unsigned long , void * );
+            if (*reinterpret_cast<_t *>(func) == static_cast<_t>(&QsciScintillaBase::SCN_MACRORECORD)) {
+                *result = 17;
+            }
+        }
+        {
+            typedef void (QsciScintillaBase::*_t)(int , int , int );
+            if (*reinterpret_cast<_t *>(func) == static_cast<_t>(&QsciScintillaBase::SCN_MARGINCLICK)) {
+                *result = 18;
+            }
+        }
+        {
+            typedef void (QsciScintillaBase::*_t)(int , int , const char * , int , int , int , int , int , int , int );
+            if (*reinterpret_cast<_t *>(func) == static_cast<_t>(&QsciScintillaBase::SCN_MODIFIED)) {
+                *result = 19;
+            }
+        }
+        {
+            typedef void (QsciScintillaBase::*_t)();
+            if (*reinterpret_cast<_t *>(func) == static_cast<_t>(&QsciScintillaBase::SCN_MODIFYATTEMPTRO)) {
+                *result = 20;
+            }
+        }
+        {
+            typedef void (QsciScintillaBase::*_t)(int , int );
+            if (*reinterpret_cast<_t *>(func) == static_cast<_t>(&QsciScintillaBase::SCN_NEEDSHOWN)) {
+                *result = 21;
+            }
+        }
+        {
+            typedef void (QsciScintillaBase::*_t)();
+            if (*reinterpret_cast<_t *>(func) == static_cast<_t>(&QsciScintillaBase::SCN_PAINTED)) {
+                *result = 22;
+            }
+        }
+        {
+            typedef void (QsciScintillaBase::*_t)();
+            if (*reinterpret_cast<_t *>(func) == static_cast<_t>(&QsciScintillaBase::SCN_SAVEPOINTLEFT)) {
+                *result = 23;
+            }
+        }
+        {
+            typedef void (QsciScintillaBase::*_t)();
+            if (*reinterpret_cast<_t *>(func) == static_cast<_t>(&QsciScintillaBase::SCN_SAVEPOINTREACHED)) {
+                *result = 24;
+            }
+        }
+        {
+            typedef void (QsciScintillaBase::*_t)(int );
+            if (*reinterpret_cast<_t *>(func) == static_cast<_t>(&QsciScintillaBase::SCN_STYLENEEDED)) {
+                *result = 25;
+            }
+        }
+        {
+            typedef void (QsciScintillaBase::*_t)(int );
+            if (*reinterpret_cast<_t *>(func) == static_cast<_t>(&QsciScintillaBase::SCN_UPDATEUI)) {
+                *result = 26;
+            }
+        }
+        {
+            typedef void (QsciScintillaBase::*_t)(const char * , int );
+            if (*reinterpret_cast<_t *>(func) == static_cast<_t>(&QsciScintillaBase::SCN_USERLISTSELECTION)) {
+                *result = 27;
+            }
+        }
+        {
+            typedef void (QsciScintillaBase::*_t)();
+            if (*reinterpret_cast<_t *>(func) == static_cast<_t>(&QsciScintillaBase::SCN_ZOOM)) {
+                *result = 28;
+            }
+        }
+    }
+}
+
+const QMetaObject QsciScintillaBase::staticMetaObject = {
+    { &QAbstractScrollArea::staticMetaObject, qt_meta_stringdata_QsciScintillaBase.data,
+      qt_meta_data_QsciScintillaBase,  qt_static_metacall, 0, 0}
+};
+
+
+const QMetaObject *QsciScintillaBase::metaObject() const
+{
+    return QObject::d_ptr->metaObject ? QObject::d_ptr->dynamicMetaObject() : &staticMetaObject;
+}
+
+void *QsciScintillaBase::qt_metacast(const char *_clname)
+{
+    if (!_clname) return 0;
+    if (!strcmp(_clname, qt_meta_stringdata_QsciScintillaBase.stringdata))
+        return static_cast<void*>(const_cast< QsciScintillaBase*>(this));
+    return QAbstractScrollArea::qt_metacast(_clname);
+}
+
+int QsciScintillaBase::qt_metacall(QMetaObject::Call _c, int _id, void **_a)
+{
+    _id = QAbstractScrollArea::qt_metacall(_c, _id, _a);
+    if (_id < 0)
+        return _id;
+    if (_c == QMetaObject::InvokeMetaMethod) {
+        if (_id < 33)
+            qt_static_metacall(this, _c, _id, _a);
+        _id -= 33;
+    } else if (_c == QMetaObject::RegisterMethodArgumentMetaType) {
+        if (_id < 33)
+            *reinterpret_cast<int*>(_a[0]) = -1;
+        _id -= 33;
+    }
+    return _id;
+}
+
+// SIGNAL 0
+void QsciScintillaBase::QSCN_SELCHANGED(bool _t1)
+{
+    void *_a[] = { 0, const_cast<void*>(reinterpret_cast<const void*>(&_t1)) };
+    QMetaObject::activate(this, &staticMetaObject, 0, _a);
+}
+
+// SIGNAL 1
+void QsciScintillaBase::SCN_AUTOCCANCELLED()
+{
+    QMetaObject::activate(this, &staticMetaObject, 1, 0);
+}
+
+// SIGNAL 2
+void QsciScintillaBase::SCN_AUTOCCHARDELETED()
+{
+    QMetaObject::activate(this, &staticMetaObject, 2, 0);
+}
+
+// SIGNAL 3
+void QsciScintillaBase::SCN_AUTOCSELECTION(const char * _t1, int _t2)
+{
+    void *_a[] = { 0, const_cast<void*>(reinterpret_cast<const void*>(&_t1)), const_cast<void*>(reinterpret_cast<const void*>(&_t2)) };
+    QMetaObject::activate(this, &staticMetaObject, 3, _a);
+}
+
+// SIGNAL 4
+void QsciScintillaBase::SCEN_CHANGE()
+{
+    QMetaObject::activate(this, &staticMetaObject, 4, 0);
+}
+
+// SIGNAL 5
+void QsciScintillaBase::SCN_CALLTIPCLICK(int _t1)
+{
+    void *_a[] = { 0, const_cast<void*>(reinterpret_cast<const void*>(&_t1)) };
+    QMetaObject::activate(this, &staticMetaObject, 5, _a);
+}
+
+// SIGNAL 6
+void QsciScintillaBase::SCN_CHARADDED(int _t1)
+{
+    void *_a[] = { 0, const_cast<void*>(reinterpret_cast<const void*>(&_t1)) };
+    QMetaObject::activate(this, &staticMetaObject, 6, _a);
+}
+
+// SIGNAL 7
+void QsciScintillaBase::SCN_DOUBLECLICK(int _t1, int _t2, int _t3)
+{
+    void *_a[] = { 0, const_cast<void*>(reinterpret_cast<const void*>(&_t1)), const_cast<void*>(reinterpret_cast<const void*>(&_t2)), const_cast<void*>(reinterpret_cast<const void*>(&_t3)) };
+    QMetaObject::activate(this, &staticMetaObject, 7, _a);
+}
+
+// SIGNAL 8
+void QsciScintillaBase::SCN_DWELLEND(int _t1, int _t2, int _t3)
+{
+    void *_a[] = { 0, const_cast<void*>(reinterpret_cast<const void*>(&_t1)), const_cast<void*>(reinterpret_cast<const void*>(&_t2)), const_cast<void*>(reinterpret_cast<const void*>(&_t3)) };
+    QMetaObject::activate(this, &staticMetaObject, 8, _a);
+}
+
+// SIGNAL 9
+void QsciScintillaBase::SCN_DWELLSTART(int _t1, int _t2, int _t3)
+{
+    void *_a[] = { 0, const_cast<void*>(reinterpret_cast<const void*>(&_t1)), const_cast<void*>(reinterpret_cast<const void*>(&_t2)), const_cast<void*>(reinterpret_cast<const void*>(&_t3)) };
+    QMetaObject::activate(this, &staticMetaObject, 9, _a);
+}
+
+// SIGNAL 10
+void QsciScintillaBase::SCN_FOCUSIN()
+{
+    QMetaObject::activate(this, &staticMetaObject, 10, 0);
+}
+
+// SIGNAL 11
+void QsciScintillaBase::SCN_FOCUSOUT()
+{
+    QMetaObject::activate(this, &staticMetaObject, 11, 0);
+}
+
+// SIGNAL 12
+void QsciScintillaBase::SCN_HOTSPOTCLICK(int _t1, int _t2)
+{
+    void *_a[] = { 0, const_cast<void*>(reinterpret_cast<const void*>(&_t1)), const_cast<void*>(reinterpret_cast<const void*>(&_t2)) };
+    QMetaObject::activate(this, &staticMetaObject, 12, _a);
+}
+
+// SIGNAL 13
+void QsciScintillaBase::SCN_HOTSPOTDOUBLECLICK(int _t1, int _t2)
+{
+    void *_a[] = { 0, const_cast<void*>(reinterpret_cast<const void*>(&_t1)), const_cast<void*>(reinterpret_cast<const void*>(&_t2)) };
+    QMetaObject::activate(this, &staticMetaObject, 13, _a);
+}
+
+// SIGNAL 14
+void QsciScintillaBase::SCN_HOTSPOTRELEASECLICK(int _t1, int _t2)
+{
+    void *_a[] = { 0, const_cast<void*>(reinterpret_cast<const void*>(&_t1)), const_cast<void*>(reinterpret_cast<const void*>(&_t2)) };
+    QMetaObject::activate(this, &staticMetaObject, 14, _a);
+}
+
+// SIGNAL 15
+void QsciScintillaBase::SCN_INDICATORCLICK(int _t1, int _t2)
+{
+    void *_a[] = { 0, const_cast<void*>(reinterpret_cast<const void*>(&_t1)), const_cast<void*>(reinterpret_cast<const void*>(&_t2)) };
+    QMetaObject::activate(this, &staticMetaObject, 15, _a);
+}
+
+// SIGNAL 16
+void QsciScintillaBase::SCN_INDICATORRELEASE(int _t1, int _t2)
+{
+    void *_a[] = { 0, const_cast<void*>(reinterpret_cast<const void*>(&_t1)), const_cast<void*>(reinterpret_cast<const void*>(&_t2)) };
+    QMetaObject::activate(this, &staticMetaObject, 16, _a);
+}
+
+// SIGNAL 17
+void QsciScintillaBase::SCN_MACRORECORD(unsigned int _t1, unsigned long _t2, void * _t3)
+{
+    void *_a[] = { 0, const_cast<void*>(reinterpret_cast<const void*>(&_t1)), const_cast<void*>(reinterpret_cast<const void*>(&_t2)), const_cast<void*>(reinterpret_cast<const void*>(&_t3)) };
+    QMetaObject::activate(this, &staticMetaObject, 17, _a);
+}
+
+// SIGNAL 18
+void QsciScintillaBase::SCN_MARGINCLICK(int _t1, int _t2, int _t3)
+{
+    void *_a[] = { 0, const_cast<void*>(reinterpret_cast<const void*>(&_t1)), const_cast<void*>(reinterpret_cast<const void*>(&_t2)), const_cast<void*>(reinterpret_cast<const void*>(&_t3)) };
+    QMetaObject::activate(this, &staticMetaObject, 18, _a);
+}
+
+// SIGNAL 19
+void QsciScintillaBase::SCN_MODIFIED(int _t1, int _t2, const char * _t3, int _t4, int _t5, int _t6, int _t7, int _t8, int _t9, int _t10)
+{
+    void *_a[] = { 0, const_cast<void*>(reinterpret_cast<const void*>(&_t1)), const_cast<void*>(reinterpret_cast<const void*>(&_t2)), const_cast<void*>(reinterpret_cast<const void*>(&_t3)), const_cast<void*>(reinterpret_cast<const void*>(&_t4)), const_cast<void*>(reinterpret_cast<const void*>(&_t5)), const_cast<void*>(reinterpret_cast<const void*>(&_t6)), const_cast<void*>(reinterpret_cast<const void*>(&_t7)), const_cast<void*>(reinterpret_cast<const void*>(&_t8)), const_cast<void*>(reinterpret_cast<const void*>(&_t9)), const_cast<void*>(reinterpret_cast<const void*>(&_t10)) };
+    QMetaObject::activate(this, &staticMetaObject, 19, _a);
+}
+
+// SIGNAL 20
+void QsciScintillaBase::SCN_MODIFYATTEMPTRO()
+{
+    QMetaObject::activate(this, &staticMetaObject, 20, 0);
+}
+
+// SIGNAL 21
+void QsciScintillaBase::SCN_NEEDSHOWN(int _t1, int _t2)
+{
+    void *_a[] = { 0, const_cast<void*>(reinterpret_cast<const void*>(&_t1)), const_cast<void*>(reinterpret_cast<const void*>(&_t2)) };
+    QMetaObject::activate(this, &staticMetaObject, 21, _a);
+}
+
+// SIGNAL 22
+void QsciScintillaBase::SCN_PAINTED()
+{
+    QMetaObject::activate(this, &staticMetaObject, 22, 0);
+}
+
+// SIGNAL 23
+void QsciScintillaBase::SCN_SAVEPOINTLEFT()
+{
+    QMetaObject::activate(this, &staticMetaObject, 23, 0);
+}
+
+// SIGNAL 24
+void QsciScintillaBase::SCN_SAVEPOINTREACHED()
+{
+    QMetaObject::activate(this, &staticMetaObject, 24, 0);
+}
+
+// SIGNAL 25
+void QsciScintillaBase::SCN_STYLENEEDED(int _t1)
+{
+    void *_a[] = { 0, const_cast<void*>(reinterpret_cast<const void*>(&_t1)) };
+    QMetaObject::activate(this, &staticMetaObject, 25, _a);
+}
+
+// SIGNAL 26
+void QsciScintillaBase::SCN_UPDATEUI(int _t1)
+{
+    void *_a[] = { 0, const_cast<void*>(reinterpret_cast<const void*>(&_t1)) };
+    QMetaObject::activate(this, &staticMetaObject, 26, _a);
+}
+
+// SIGNAL 27
+void QsciScintillaBase::SCN_USERLISTSELECTION(const char * _t1, int _t2)
+{
+    void *_a[] = { 0, const_cast<void*>(reinterpret_cast<const void*>(&_t1)), const_cast<void*>(reinterpret_cast<const void*>(&_t2)) };
+    QMetaObject::activate(this, &staticMetaObject, 27, _a);
+}
+
+// SIGNAL 28
+void QsciScintillaBase::SCN_ZOOM()
+{
+    QMetaObject::activate(this, &staticMetaObject, 28, 0);
+}
+QT_END_MOC_NAMESPACE


### PR DESCRIPTION
Windows build is using Qt5.3 currently, which doesn't have QDebug.noquote().