### PR TITLE
I18n - "Hey you, you can translate Sonic Pi to <your language>"

### DIFF
--- a/COMMUNITY.md
+++ b/COMMUNITY.md
@@ -60,4 +60,6 @@ contain Sonic Pi related material:
 ## GitHub
 *<http://github.com/samaaron/sonic-pi>*
 
-For developers interested in the full source code. The issue tracker is also hosted here.
+For developers interested in the full source code.
+The [issue tracker](https://github.com/samaaron/sonic-pi/issues) is also hosted here.
+Read the [translation guide](https://github.com/samaaron/sonic-pi/blob/master/TRANSLATION.md) if you want to help translate Sonic Pi to your language.

--- a/app/gui/qt/main.cpp
+++ b/app/gui/qt/main.cpp
@@ -35,10 +35,7 @@ int main(int argc, char *argv[])
   app.installTranslator(&qtTranslator);
 
   QTranslator translator;
-  if (!translator.load("sonic-pi_" + systemLocale, ":/lang/") && (!systemLocale.startsWith("en")) && (systemLocale != "C")) {
-    std::cout << "No translation found for your locale \"" + systemLocale.toStdString() + "\"." << std::endl;
-    std::cout << "Please contact us if you want to translate Sonic Pi to your language." << std::endl;
-  }
+  bool i18n = translator.load("sonic-pi_" + systemLocale, ":/lang/") || systemLocale.startsWith("en") || systemLocale == "C";
   app.installTranslator(&translator);
 
   app.setApplicationName(QObject::tr("Sonic Pi"));
@@ -60,7 +57,7 @@ int main(int argc, char *argv[])
   splashWindow->raise();
   splashWindow->show();
 
-  MainWindow mainWin(app, splashWindow);
+  MainWindow mainWin(app, i18n, splashWindow);
   return app.exec();
 #else
   QPixmap pixmap(":/images/splash.png");
@@ -69,7 +66,7 @@ int main(int argc, char *argv[])
   splash->show();
   splash->repaint();
 
-  MainWindow mainWin(app, splash);
+  MainWindow mainWin(app, i18n, splash);
   return app.exec();
 #endif
 

--- a/app/gui/qt/mainwindow.cpp
+++ b/app/gui/qt/mainwindow.cpp
@@ -92,9 +92,9 @@ using namespace oscpkt;
 #include "mainwindow.h"
 
 #ifdef Q_OS_MAC
-MainWindow::MainWindow(QApplication &app, QMainWindow* splash)
+MainWindow::MainWindow(QApplication &app, bool i18n, QMainWindow* splash)
 #else
-MainWindow::MainWindow(QApplication &app, QSplashScreen* splash)
+MainWindow::MainWindow(QApplication &app, bool i18n, QSplashScreen* splash)
 #endif
 {
   this->protocol = UDP;
@@ -271,6 +271,12 @@ MainWindow::MainWindow(QApplication &app, QSplashScreen* splash)
   outputPane->setTextColor(QColor("#5e5e5e"));
   outputPane->append("\n");
   outputPane->append(asciiArtLogo());
+  
+  if (!i18n) {
+    outputPane->append("     You can help translate Sonic Pi to " + QLocale::languageToString(QLocale::system().language()) + ".");
+    outputPane->append("     Click Info & read Community/Github for how.");
+    outputPane->append("");
+  }
 
   errorPane->zoomIn(1);
   errorPane->setMaximumHeight(130);
@@ -1430,7 +1436,7 @@ void MainWindow::createInfoPane() {
 
   QStringList files, tabs;
   files << ":/html/info.html" << ":/info/CORETEAM.html" << ":/info/CONTRIBUTORS.html" <<
-    ":/info/COMMUNITY.html" << ":/info/LICENSE.html" <<":/info/CHANGELOG.html";
+    ":/info/COMMUNITY.html" << ":/info/LICENSE.html" << ":/info/CHANGELOG.html";
   tabs << tr("About") << tr("Core Team") << tr("Contributors") <<
     tr("Community") << tr("License") << tr("History");
 

--- a/app/gui/qt/mainwindow.h
+++ b/app/gui/qt/mainwindow.h
@@ -65,9 +65,9 @@ class MainWindow : public QMainWindow
 
 public:
 #if defined(Q_OS_MAC)
-    MainWindow(QApplication &ref, QMainWindow* splash);
+    MainWindow(QApplication &ref, bool i18n, QMainWindow* splash);
 #else
-    MainWindow(QApplication &ref, QSplashScreen* splash);
+    MainWindow(QApplication &ref, bool i18n, QSplashScreen* splash);
 #endif
     void invokeStartupError(QString msg);
     SonicPiServer *sonicPiServer;


### PR DESCRIPTION
This shows a more prominent translation reminder in the GUI's startup log, mentioning the user's system language as a call to action.

![french](https://cloud.githubusercontent.com/assets/1705654/7226396/b11d99c2-e748-11e4-9067-f991f279e3bd.png)

You can test this with `LC_ALL=fr_FR.utf8 ./sonic-pi` on Linux.

The reminder is only shown if [the system language isn't English and Sonic Pi doesn't have a translation already](https://github.com/samaaron/sonic-pi/commit/6d1de65be744c269a89f1ba0dce684946b3ec695#diff-b136b3b84c550c25980c8424682c1b52R38)