### PR TITLE
i18n - allow to switch off GUI translation at runtime

### DIFF
--- a/app/gui/qt/lang/sonic-pi_de.ts
+++ b/app/gui/qt/lang/sonic-pi_de.ts
@@ -5,127 +5,127 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../mainwindow.cpp" line="278"/>
+        <location filename="../mainwindow.cpp" line="469"/>
         <source>Preferences</source>
         <translation>Einstellungen</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="288"/>
+        <location filename="../mainwindow.cpp" line="470"/>
         <source>Log</source>
         <translation>Protokoll</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="367"/>
-        <location filename="../mainwindow.cpp" line="1568"/>
-        <location filename="../mainwindow.cpp" line="1586"/>
+        <location filename="../mainwindow.cpp" line="418"/>
+        <location filename="../mainwindow.cpp" line="1687"/>
+        <location filename="../mainwindow.cpp" line="1705"/>
         <source>Sonic Pi</source>
         <translation>Sonic Pi</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="503"/>
+        <location filename="../mainwindow.cpp" line="635"/>
         <source>ruby could not be started, is it installed and in your PATH?</source>
         <translation>Konnte ruby nicht starten - ist es korrekt installiert?</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="522"/>
+        <location filename="../mainwindow.cpp" line="654"/>
         <source>Failed to start server, please check %1.</source>
         <oldsource>Failed to start server, please check </oldsource>
         <translation>Konnte Server nicht starten, bitte in %1 nachsehen.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="596"/>
+        <location filename="../mainwindow.cpp" line="473"/>
         <source>Raspberry Pi System Volume</source>
         <translation>Raspberry Pi Lautstärke</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="599"/>
+        <location filename="../mainwindow.cpp" line="476"/>
         <source>Studio Settings</source>
         <translation>Studio-Einstellungen</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="616"/>
+        <location filename="../mainwindow.cpp" line="479"/>
         <source>Raspberry Pi Audio Output</source>
         <translation>Raspberry Pi Audio-Ausgabe</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="618"/>
+        <location filename="../mainwindow.cpp" line="482"/>
         <source>&amp;Default</source>
         <translation>&amp;Standard</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="619"/>
+        <location filename="../mainwindow.cpp" line="483"/>
         <source>&amp;Headphones</source>
         <translation>&amp;Kopfhörerbuchse</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="620"/>
+        <location filename="../mainwindow.cpp" line="484"/>
         <source>&amp;HDMI</source>
         <translation>&amp;HDMI</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="834"/>
+        <location filename="../mainwindow.cpp" line="980"/>
         <source>Save Current Workspace</source>
         <translation>Arbeitsbereich speichern</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="902"/>
+        <location filename="../mainwindow.cpp" line="1048"/>
         <source>Running Code...</source>
         <oldsource>Running Code....</oldsource>
         <translation>Führe Programm aus...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="945"/>
+        <location filename="../mainwindow.cpp" line="1091"/>
         <source>Beautifying...</source>
         <oldsource>Beautifying....</oldsource>
         <translation>Textausrichtung...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="964"/>
+        <location filename="../mainwindow.cpp" line="1110"/>
         <source>Reloading...</source>
         <oldsource>Reloading....</oldsource>
         <translation>Neu laden...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="985"/>
+        <location filename="../mainwindow.cpp" line="1131"/>
         <source>Enabling Mixer HPF...</source>
         <oldsource>Enabling Mixer HPF....</oldsource>
         <translation>Mixer-Hochpassfilter aktiv...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="993"/>
+        <location filename="../mainwindow.cpp" line="1139"/>
         <source>Disabling Mixer HPF...</source>
         <oldsource>Disabling Mixer HPF....</oldsource>
         <translation>Mixer-Hochpassfilter inaktiv...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="227"/>
-        <location filename="../mainwindow.cpp" line="924"/>
+        <location filename="../mainwindow.cpp" line="518"/>
+        <location filename="../mainwindow.cpp" line="1070"/>
         <source>Workspace %1</source>
         <translation>Arbeitsbereich %1</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="384"/>
+        <location filename="../mainwindow.cpp" line="388"/>
         <source>Welcome to Sonic Pi</source>
         <translation>Willkommen zu Sonic Pi</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="412"/>
+        <location filename="../mainwindow.cpp" line="545"/>
         <source>Indenting selection...</source>
         <translation>Auswahl einrücken...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="416"/>
+        <location filename="../mainwindow.cpp" line="549"/>
         <source>Indenting line...</source>
         <translation>Zeile einrücken...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="597"/>
+        <location filename="../mainwindow.cpp" line="474"/>
         <source>Use this slider to change the system volume of your Raspberry Pi.</source>
         <oldsource>Use this slider to change the system volume of your Raspberry Pi</oldsource>
         <translation>Hier veränderst Du die Systemlautstärke Deines Raspberry Pi.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="600"/>
+        <location filename="../mainwindow.cpp" line="477"/>
         <source>Advanced audio settings for working with
 external PA systems when performing with Sonic Pi.</source>
         <oldsource>Advanced audio settings for working with external PA systems when performing with Sonic Pi.</oldsource>
@@ -133,17 +133,17 @@ external PA systems when performing with Sonic Pi.</source>
 an einem externen Verstärker gut gebrauchen kann.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="601"/>
+        <location filename="../mainwindow.cpp" line="486"/>
         <source>Invert Stereo</source>
         <translation>Stereokanäle tauschen</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="603"/>
+        <location filename="../mainwindow.cpp" line="487"/>
         <source>Force Mono</source>
         <translation>Mono-Ton erzwingen</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="617"/>
+        <location filename="../mainwindow.cpp" line="480"/>
         <source>Your Raspberry Pi has two forms of audio output.
 Firstly, there is the headphone jack of the Raspberry Pi itself.
 Secondly, some HDMI monitors/TVs support audio through the HDMI port.
@@ -159,37 +159,37 @@ Zweitens: Der digitale HDMI-Monitoranschluss, der den Ton zum Monitor/Fernseher 
 Hier wählst Du aus, über welchen davon die Tonausgabe gehen soll.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="640"/>
+        <location filename="../mainwindow.cpp" line="489"/>
         <source>Debug Options</source>
         <translation>Debug-Einstellungen</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="641"/>
+        <location filename="../mainwindow.cpp" line="491"/>
         <source>Print output</source>
         <translation>Ausgabe anzeigen</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="642"/>
+        <location filename="../mainwindow.cpp" line="492"/>
         <source>Check synth args</source>
         <translation>Synth-Parameter prüfen</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="643"/>
+        <location filename="../mainwindow.cpp" line="493"/>
         <source>Clear output on run</source>
         <translation>Vorm Ausführen Ausgabe leeren</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="653"/>
+        <location filename="../mainwindow.cpp" line="495"/>
         <source>Updates</source>
         <translation>Updates</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="654"/>
+        <location filename="../mainwindow.cpp" line="498"/>
         <source>Check for updates</source>
         <translation>Auf Updates prüfen</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="657"/>
+        <location filename="../mainwindow.cpp" line="496"/>
         <source>Configure whether Sonic Pi may check for new updates on launch.
 Please note, the checking process includes sending
 anonymous information to the Sonic Pi server.</source>
@@ -198,358 +198,335 @@ Bitte beachte, dass dabei einige anonymisierte Informationen
 an den Server des Sonic-Pi-Entwicklers geschickt werden.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="664"/>
+        <location filename="../mainwindow.cpp" line="500"/>
         <source>Editor</source>
         <translation>Editor</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="665"/>
+        <location filename="../mainwindow.cpp" line="503"/>
         <source>Show line numbers</source>
         <translation>Zeilennummern anzeigen</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="668"/>
+        <location filename="../mainwindow.cpp" line="501"/>
         <source>Editor Preferences</source>
         <translation>Editor-Einstellungen</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="737"/>
+        <location filename="../mainwindow.cpp" line="442"/>
+        <location filename="../mainwindow.cpp" line="443"/>
+        <source>Start recording to WAV audio file</source>
+        <translation>Tonausgabe in WAV-Datei aufnehmen</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="454"/>
+        <location filename="../mainwindow.cpp" line="455"/>
+        <source>Improve readability of code</source>
+        <translation>Lesbarkeit des Codes verbessern</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="505"/>
+        <source>Translation</source>
+        <translation>Übersetzung</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="506"/>
+        <location filename="../mainwindow.cpp" line="508"/>
+        <source>Use translated Sonic Pi GUI</source>
+        <translation>Verwende die übersetzte Benutzeroberfläche für Sonic Pi</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="883"/>
         <source>We&apos;re sorry, but Sonic Pi was unable to start...</source>
         <translation>Sonic Pi konnte nicht starten. Das tut uns leid...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="971"/>
+        <location filename="../mainwindow.cpp" line="1117"/>
         <source>Enabling update checking...</source>
         <translation>Update-Prüfung aktiv...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="978"/>
+        <location filename="../mainwindow.cpp" line="1124"/>
         <source>Disabling update checking...</source>
         <translation>Update-Prüfung inaktiv...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1000"/>
+        <location filename="../mainwindow.cpp" line="1146"/>
         <source>Enabling Mixer LPF...</source>
         <oldsource>Enabling Mixer LPF....</oldsource>
         <translation>Mixer-Tiefpassfilter aktiv...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1008"/>
+        <location filename="../mainwindow.cpp" line="1154"/>
         <source>Disabling Mixer LPF...</source>
         <oldsource>Disabling Mixer LPF....</oldsource>
         <translation>Mixer-Tiefpassfilter inaktiv...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1015"/>
+        <location filename="../mainwindow.cpp" line="1161"/>
         <source>Enabling Inverted Stereo...</source>
         <oldsource>Enabling Inverted Stereo....</oldsource>
         <translation>Stereo-Kanaltausch aktiv...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1022"/>
+        <location filename="../mainwindow.cpp" line="1168"/>
         <source>Enabling Standard Stereo...</source>
         <oldsource>Enabling Standard Stereo....</oldsource>
         <translation>Stereo-Kanaltausch inaktiv...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1029"/>
+        <location filename="../mainwindow.cpp" line="1175"/>
         <source>Mono Mode...</source>
         <oldsource>Mono Mode....</oldsource>
         <translation>Mono-Ton aktiv...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1036"/>
+        <location filename="../mainwindow.cpp" line="1182"/>
         <source>Stereo Mode...</source>
         <oldsource>Stereo Mode....</oldsource>
         <translation>Stereo-Ton aktiv...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1044"/>
+        <location filename="../mainwindow.cpp" line="1190"/>
         <source>Stopping...</source>
         <translation>Stopp...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1108"/>
-        <location filename="../mainwindow.cpp" line="1124"/>
+        <location filename="../mainwindow.cpp" line="1254"/>
+        <location filename="../mainwindow.cpp" line="1270"/>
         <source>Updating System Volume...</source>
         <translation>Setze System-Lautstärke...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1147"/>
-        <location filename="../mainwindow.cpp" line="1153"/>
+        <location filename="../mainwindow.cpp" line="1293"/>
+        <location filename="../mainwindow.cpp" line="1299"/>
         <source>Switching To Headphone Audio Output...</source>
         <translation>Umschalten auf Kopfhörerbuchse...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1166"/>
-        <location filename="../mainwindow.cpp" line="1172"/>
+        <location filename="../mainwindow.cpp" line="1312"/>
+        <location filename="../mainwindow.cpp" line="1318"/>
         <source>Switching To HDMI Audio Output...</source>
         <translation>Umschalten auf HDMI-Anschluss...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1185"/>
-        <location filename="../mainwindow.cpp" line="1191"/>
+        <location filename="../mainwindow.cpp" line="1331"/>
+        <location filename="../mainwindow.cpp" line="1337"/>
         <source>Switching To Default Audio Output...</source>
         <translation>Umschalten auf Standard-Tonausgabe...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1500"/>
+        <location filename="../mainwindow.cpp" line="1618"/>
         <source>Ready...</source>
         <translation>Bereit...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1579"/>
+        <location filename="../mainwindow.cpp" line="1698"/>
         <source>File loaded...</source>
         <translation>Datei geladen...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1604"/>
+        <location filename="../mainwindow.cpp" line="1723"/>
         <source>File saved...</source>
         <translation>Datei gespeichert...</translation>
     </message>
     <message>
-        <source>Updating System Volume.</source>
-        <oldsource>Updating system volume.</oldsource>
-        <translation type="obsolete">Setze System-Lautstärke.</translation>
-    </message>
-    <message>
-        <source>Switching To Headphone Audio Output.</source>
-        <oldsource>Switching To Headphone Audio Output .</oldsource>
-        <translation type="obsolete">Umschalten auf Kopfhörerbuchse.</translation>
-    </message>
-    <message>
-        <source>Switching To HDMI Audio Output.</source>
-        <oldsource>Switching To HDMI Audio Output .</oldsource>
-        <translation type="obsolete">Umschalten auf HDMI-Anschluss.</translation>
-    </message>
-    <message>
-        <source>Switching To Default Audio Output.</source>
-        <oldsource>Switching To Default Audio Output .</oldsource>
-        <translation type="obsolete">Umschalten auf Standard-Tonausgabe.</translation>
-    </message>
-    <message>
-        <location filename="../mainwindow.cpp" line="1341"/>
+        <location filename="../mainwindow.cpp" line="429"/>
         <source>Run</source>
         <translation>Ausführen</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1342"/>
+        <location filename="../mainwindow.cpp" line="430"/>
+        <location filename="../mainwindow.cpp" line="431"/>
         <source>Run the code in the current workspace</source>
         <translation>Das Programm im aktuellen Arbeitsbereich ausführen</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1346"/>
+        <location filename="../mainwindow.cpp" line="433"/>
         <source>Stop</source>
         <translation>Stopp</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1347"/>
+        <location filename="../mainwindow.cpp" line="434"/>
+        <location filename="../mainwindow.cpp" line="435"/>
         <source>Stop all running code</source>
         <translation>Alle laufenden Programme beenden</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1350"/>
+        <location filename="../mainwindow.cpp" line="437"/>
         <source>Save As...</source>
         <translation>Speichern als...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1351"/>
+        <location filename="../mainwindow.cpp" line="438"/>
+        <location filename="../mainwindow.cpp" line="439"/>
         <source>Save current workspace as an external file</source>
         <translation>Den aktuellen Arbeitsbereich als Datei speichern</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1354"/>
+        <location filename="../mainwindow.cpp" line="457"/>
         <source>Info</source>
         <translation>Info</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1355"/>
+        <location filename="../mainwindow.cpp" line="458"/>
+        <location filename="../mainwindow.cpp" line="459"/>
         <source>See information about Sonic Pi</source>
         <translation>Einige Informationen über Sonic Pi</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="336"/>
-        <location filename="../mainwindow.cpp" line="1359"/>
+        <location filename="../mainwindow.cpp" line="461"/>
+        <location filename="../mainwindow.cpp" line="471"/>
         <source>Help</source>
         <translation>Hilfe</translation>
     </message>
     <message>
-        <source>Enabling update checking....</source>
-        <translation type="obsolete">Update-Prüfung aktiv...</translation>
-    </message>
-    <message>
-        <source>Disabling update checking....</source>
-        <translation type="obsolete">Update-Prüfung inaktiv...</translation>
-    </message>
-    <message>
-        <location filename="../mainwindow.cpp" line="1360"/>
+        <location filename="../mainwindow.cpp" line="462"/>
+        <location filename="../mainwindow.cpp" line="463"/>
         <source>Toggle help pane</source>
         <translation>Hilfetexte anzeigen</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1363"/>
+        <location filename="../mainwindow.cpp" line="465"/>
         <source>Prefs</source>
         <translation>Einstellungen</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1364"/>
+        <location filename="../mainwindow.cpp" line="466"/>
+        <location filename="../mainwindow.cpp" line="467"/>
         <source>Toggle preferences pane</source>
         <translation>Einstellungen anzeigen</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1368"/>
-        <location filename="../mainwindow.cpp" line="1369"/>
-        <location filename="../mainwindow.cpp" line="1480"/>
-        <location filename="../mainwindow.cpp" line="1481"/>
+        <location filename="../mainwindow.cpp" line="441"/>
+        <location filename="../mainwindow.cpp" line="1598"/>
+        <location filename="../mainwindow.cpp" line="1599"/>
         <source>Start Recording</source>
         <translation>Aufnahme starten</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1373"/>
+        <location filename="../mainwindow.cpp" line="453"/>
         <source>Auto-Align Text</source>
         <oldsource>Auto Align Text</oldsource>
         <translation>Text automatisch ausrichten</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1374"/>
-        <source>Auto-align text</source>
-        <translation>Text automatisch ausrichten</translation>
-    </message>
-    <message>
-        <location filename="../mainwindow.cpp" line="1378"/>
+        <location filename="../mainwindow.cpp" line="449"/>
         <source>Increase Text Size</source>
         <translation>Text vergrößern</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1379"/>
+        <location filename="../mainwindow.cpp" line="450"/>
+        <location filename="../mainwindow.cpp" line="451"/>
         <source>Make text bigger</source>
         <translation>Text vergrößern</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1384"/>
+        <location filename="../mainwindow.cpp" line="445"/>
         <source>Decrease Text Size</source>
         <translation>Text verkleinern</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1385"/>
+        <location filename="../mainwindow.cpp" line="446"/>
+        <location filename="../mainwindow.cpp" line="447"/>
         <source>Make text smaller</source>
         <translation>Text verkleinern</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1391"/>
+        <location filename="../mainwindow.cpp" line="421"/>
         <source>Tools</source>
         <translation>Werkzeuge</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1432"/>
+        <location filename="../mainwindow.cpp" line="510"/>
         <source>About</source>
         <translation>Über Sonic Pi</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1432"/>
+        <location filename="../mainwindow.cpp" line="511"/>
         <source>Core Team</source>
         <translation>Kern-Team</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1432"/>
+        <location filename="../mainwindow.cpp" line="512"/>
         <source>Contributors</source>
         <translation>Mitwirkende</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1433"/>
+        <location filename="../mainwindow.cpp" line="513"/>
         <source>Community</source>
         <translation>Gemeinschaft</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1433"/>
+        <location filename="../mainwindow.cpp" line="514"/>
         <source>License</source>
         <translation>Lizenz</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1433"/>
+        <location filename="../mainwindow.cpp" line="515"/>
         <source>History</source>
         <translation>Änderungen</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1453"/>
+        <location filename="../mainwindow.cpp" line="1571"/>
         <source>Sonic Pi - Info</source>
         <translation>Über Sonic Pi</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1473"/>
-        <location filename="../mainwindow.cpp" line="1474"/>
+        <location filename="../mainwindow.cpp" line="1591"/>
+        <location filename="../mainwindow.cpp" line="1592"/>
         <source>Stop Recording</source>
         <translation>Aufnahme stoppen</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1485"/>
+        <location filename="../mainwindow.cpp" line="1603"/>
         <source>Save Recording</source>
         <translation>Aufnahme speichern</translation>
     </message>
     <message>
-        <source>Ready</source>
-        <translation type="obsolete">Bereit</translation>
-    </message>
-    <message>
-        <location filename="../mainwindow.cpp" line="1569"/>
+        <location filename="../mainwindow.cpp" line="1688"/>
         <source>Cannot read file %1:
 %2.</source>
         <translation>Kann Datei %1 nicht laden:
 %2.</translation>
     </message>
     <message>
-        <source>File loaded</source>
-        <translation type="obsolete">Datei geladen</translation>
-    </message>
-    <message>
-        <location filename="../mainwindow.cpp" line="1587"/>
+        <location filename="../mainwindow.cpp" line="1706"/>
         <source>Cannot write file %1:
 %2.</source>
         <translation>Kann Datei %1 nicht schreiben:
 %2.</translation>
     </message>
     <message>
-        <source>File saved</source>
-        <translation type="obsolete">Datei geschrieben</translation>
-    </message>
-    <message>
-        <location filename="../ruby_help.h" line="78"/>
-        <location filename="../ruby_help.h" line="140"/>
+        <location filename="../ruby_help.h" line="79"/>
+        <location filename="../ruby_help.h" line="141"/>
         <source>Tutorial</source>
         <translation>Tutorial</translation>
     </message>
     <message>
-        <location filename="../ruby_help.h" line="170"/>
+        <location filename="../ruby_help.h" line="171"/>
         <source>Examples</source>
         <translation>Beispiele</translation>
     </message>
     <message>
-        <location filename="../ruby_help.h" line="206"/>
+        <location filename="../ruby_help.h" line="208"/>
         <source>Synths</source>
         <translation>Synths</translation>
     </message>
     <message>
-        <location filename="../ruby_help.h" line="239"/>
+        <location filename="../ruby_help.h" line="241"/>
         <source>Fx</source>
         <translation>Fx</translation>
     </message>
     <message>
-        <location filename="../ruby_help.h" line="256"/>
+        <location filename="../ruby_help.h" line="258"/>
         <source>Samples</source>
         <translation>Samples</translation>
     </message>
     <message>
-        <location filename="../ruby_help.h" line="395"/>
+        <location filename="../ruby_help.h" line="398"/>
         <source>Lang</source>
         <translation>Lang</translation>
-    </message>
-</context>
-<context>
-    <name>QObject</name>
-    <message>
-        <location filename="../main.cpp" line="49"/>
-        <source>Sonic Pi</source>
-        <translation>Sonic Pi</translation>
     </message>
 </context>
 <context>

--- a/app/gui/qt/main.cpp
+++ b/app/gui/qt/main.cpp
@@ -16,7 +16,6 @@
 #include <QPixmap>
 #include <QBitmap>
 #include <QLabel>
-#include <QTranslator>
 #include <QLibraryInfo>
 
 #include "mainwindow.h"
@@ -27,21 +26,7 @@ int main(int argc, char *argv[])
 #endif
 
   QApplication app(argc, argv);
-
-  QString systemLocale = QLocale::system().name();
-
-  QTranslator qtTranslator;
-  qtTranslator.load("qt_" + systemLocale, QLibraryInfo::location(QLibraryInfo::TranslationsPath));
-  app.installTranslator(&qtTranslator);
-
-  QTranslator translator;
-  if (!translator.load("sonic-pi_" + systemLocale, ":/lang/") && (!systemLocale.startsWith("en")) && (systemLocale != "C")) {
-    std::cout << "No translation found for your locale \"" + systemLocale.toStdString() + "\"." << std::endl;
-    std::cout << "Please contact us if you want to translate Sonic Pi to your language." << std::endl;
-  }
-  app.installTranslator(&translator);
-
-  app.setApplicationName(QObject::tr("Sonic Pi"));
+  app.setApplicationName("Sonic Pi");
   app.setStyle("gtk");
 
 #ifdef Q_OS_MAC

--- a/app/gui/qt/mainwindow.cpp
+++ b/app/gui/qt/mainwindow.cpp
@@ -395,7 +395,7 @@ MainWindow::MainWindow(QApplication &app, QSplashScreen* splash)
   }
 }
 
-void MainWindow::switchTranslation(bool i18n){
+void MainWindow::updateTranslation(bool i18n){
   // sets/updates all translatable labels, titles and tooltips of QT widgets
 
   if (!i18n_english) {
@@ -720,7 +720,7 @@ void MainWindow::update_check_updates() {
 }
 
 void MainWindow::update_show_translation() {
-  switchTranslation(show_translation->isChecked());
+  updateTranslation(show_translation->isChecked());
 }
 
 void MainWindow::initPrefsWindow() {

--- a/app/gui/qt/mainwindow.h
+++ b/app/gui/qt/mainwindow.h
@@ -28,6 +28,8 @@
 #include <QSettings>
 #include <QHash>
 #include <QTcpSocket>
+#include <QTranslator>
+#include <QGroupBox>
 #include "oscpkt.hh"
 #include "udp.hh"
 #include <iostream>
@@ -88,6 +90,7 @@ private slots:
     void update_check_updates();
     void enableCheckUpdates();
     void disableCheckUpdates();
+    void update_show_translation();
     void stopCode();
     void beautifyCode();
     void completeListOrIndentLine(QObject *ws);
@@ -145,6 +148,7 @@ private:
     void createToolBar();
     void createStatusBar();
     void createInfoPane();
+    void switchTranslation(bool i18n);
     void readSettings();
     void writeSettings();
     void loadFile(const QString &fileName, SonicPiScintilla* &text);
@@ -156,7 +160,8 @@ private:
     SonicPiScintilla* filenameToWorkspace(std::string filename);
     void sendOSC(oscpkt::Message m);
     void initPrefsWindow();
-    void initDocsWindow();
+    void updateDocsWindow(bool i18n);
+    void initAutocomplete();
     void setHelpText(QListWidgetItem *item, const QString filename);
     void addHelpPage(QListWidget *nameList, struct help_page *helpPages,
                      int len);
@@ -166,8 +171,6 @@ private:
     QKeySequence ctrlMetaKey(char key);
     QKeySequence ctrlKey(char key);
     char int2char(int i);
-    void setupAction(QAction *action, char key, QString tooltip,
-		     const char *slot);
     QString readFile(QString name);
     QString rootPath();
 
@@ -204,6 +207,12 @@ private:
     bool hidingDocPane;
 
     QTabWidget *tabs;
+    
+    bool i18n_available;
+    bool i18n_installed;
+    bool i18n_english;
+    QTranslator *translator;
+    QTranslator *qtTranslator;
 
     QProcess *serverProcess;
 
@@ -215,25 +224,50 @@ private:
 
     QToolBar *toolBar;
 
+    QAction *runAct;
+    QAction *stopAct;
+    QAction *saveAsAct;
     QAction *recAct;
 
-    QCheckBox *mixer_invert_stereo;
-    QCheckBox *mixer_force_mono;
-    QCheckBox *print_output;
-    QCheckBox *check_args;
-    QCheckBox *clear_output_on_run;
-    QCheckBox *show_line_numbers;
-    QCheckBox *check_updates;
+    QAction *textDecAct;
+    QAction *textIncAct;    
+    QAction *textAlignAct;
+    
+    QAction *infoAct;
+    QAction *helpAct;
+    QAction *prefsAct;
 
+    QGroupBox *audio_output_box;
     QRadioButton *rp_force_audio_hdmi;
     QRadioButton *rp_force_audio_default;
     QRadioButton *rp_force_audio_headphones;
+
+    QGroupBox *volume_box;
     QSlider *rp_system_vol;
+
+    QGroupBox *advanced_audio_box;
+    QCheckBox *mixer_invert_stereo;
+    QCheckBox *mixer_force_mono;
+
+    QGroupBox *debug_box;
+    QCheckBox *print_output;
+    QCheckBox *check_args;
+    QCheckBox *clear_output_on_run;
+
+    QGroupBox *update_box;
+    QCheckBox *check_updates;
+
+    QGroupBox *editor_box;
+    QCheckBox *show_line_numbers;
+    
+    QGroupBox *translation_box;
+    QCheckBox *show_translation;
 
     QAction *aboutQtAct;
     QMap<QString, QString> *map;
 
     QTextBrowser *infoPane;
+    QTabWidget *infoTabs;
     QWidget *infoWidg;
     QTextEdit *startupPane;
     QLabel *imageLabel;
@@ -249,7 +283,6 @@ private:
     SonicPiAPIs *autocomplete;
     QString sample_path, log_path;
     QString defaultTextBrowserStyle;
-
 
 };
 

--- a/app/gui/qt/mainwindow.h
+++ b/app/gui/qt/mainwindow.h
@@ -148,7 +148,7 @@ private:
     void createToolBar();
     void createStatusBar();
     void createInfoPane();
-    void switchTranslation(bool i18n);
+    void updateTranslation(bool i18n);
     void readSettings();
     void writeSettings();
     void loadFile(const QString &fileName, SonicPiScintilla* &text);

--- a/app/server/bin/qt-doc.rb
+++ b/app/server/bin/qt-doc.rb
@@ -159,7 +159,8 @@ languages = Dir.
   select {|n| n != "en"}.
   sort_by {|n| -n.length}
 
-docs << "\n  QString systemLocale = QLocale::system().name();\n\n" unless languages.empty?
+docs << "void MainWindow::updateDocsWindow(bool i18n) {\n"
+docs << "\n  QString systemLocale = i18n ? QLocale::system().name() : \"en\";\n\n" unless languages.empty?
 
 # first, try to match all non-default languages (those that aren't "en")
 languages.each do |lang|
@@ -179,8 +180,12 @@ make_tab.call("fx", SonicPi::SynthInfo.fx_doc_html_map, :titleize, true, true)
 make_tab.call("samples", SonicPi::SynthInfo.samples_doc_html_map)
 make_tab.call("lang", SonicPi::SpiderAPI.docs_html_map.merge(SonicPi::Mods::Sound.docs_html_map).merge(ruby_html_map), false, true, true)
 
+docs << "}\n\n\n"
+
+docs << "void MainWindow::initAutocomplete() {\n"
 docs << "  // FX arguments for autocompletion\n"
 docs << "  QStringList fxtmp;\n"
+
 SonicPi::SynthInfo.get_all.each do |k, v|
   next unless v.is_a? SonicPi::FXInfo
   next if (k.to_s.include? 'replace_')
@@ -194,7 +199,6 @@ SonicPi::SynthInfo.get_all.each do |k, v|
   docs << "  autocomplete->addFXArgs(\":#{safe_k}\", fxtmp);\n\n"
 end
 
-
 SonicPi::SynthInfo.get_all.each do |k, v|
   next unless v.is_a? SonicPi::SynthInfo
   docs << "  // synth :#{k}\n"
@@ -206,6 +210,7 @@ SonicPi::SynthInfo.get_all.each do |k, v|
   docs << "  autocomplete->addSynthArgs(\":#{k}\", fxtmp);\n\n"
 end
 
+docs << "}\n\n\n"
 
 # update ruby_help.h
 if options[:output_name] then
@@ -220,9 +225,7 @@ new_content << "// AUTO-GENERATED-DOCS\n"
 new_content << "// Do not manually add any code below this comment\n"
 new_content << "// otherwise it may be removed\n"
 new_content << "\n"
-new_content << "void MainWindow::initDocsWindow() {\n"
 new_content += docs
-new_content << "}\n"
 
 File.open(cpp, 'w') do |f|
   f << new_content.join


### PR DESCRIPTION
This allows switching the GUI translation on and off via the preferences panel. First time default is "on".

Option is only shown if user's system language is not English and Sonic Pi comes with a translation file. (Test: `LC_ALL=de_DE.utf8 ./sonic-pi`)

Option is hidden if user's system language is English (locale starts with "en_" or is equal to "C"). (Test: `LC_ALL=en_EN.utf8 ./sonic-pi`)

If user's system language is not English and there is no translation file yet, [this](https://github.com/hzulla/sonic-pi/commit/550dc4e814d204ccf989dbc5583c526833e1bddb#diff-295c943452a7e10b2cd03940cfc25296R803) is shown with a link to github. (Test: `LC_ALL=fr_FR.utf8 ./sonic-pi`)

![not-french](https://cloud.githubusercontent.com/assets/1705654/7251922/116217da-e830-11e4-8669-1df90167de22.png)
