### PR TITLE
i18n - reminder users of translation in preferences pane

### DIFF
--- a/app/gui/qt/lang/sonic-pi_de.ts
+++ b/app/gui/qt/lang/sonic-pi_de.ts
@@ -5,127 +5,127 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../mainwindow.cpp" line="278"/>
+        <location filename="../mainwindow.cpp" line="292"/>
         <source>Preferences</source>
         <translation>Einstellungen</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="288"/>
+        <location filename="../mainwindow.cpp" line="302"/>
         <source>Log</source>
         <translation>Protokoll</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="367"/>
-        <location filename="../mainwindow.cpp" line="1568"/>
-        <location filename="../mainwindow.cpp" line="1586"/>
+        <location filename="../mainwindow.cpp" line="370"/>
+        <location filename="../mainwindow.cpp" line="1591"/>
+        <location filename="../mainwindow.cpp" line="1609"/>
         <source>Sonic Pi</source>
         <translation>Sonic Pi</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="503"/>
+        <location filename="../mainwindow.cpp" line="506"/>
         <source>ruby could not be started, is it installed and in your PATH?</source>
         <translation>Konnte ruby nicht starten - ist es korrekt installiert?</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="522"/>
+        <location filename="../mainwindow.cpp" line="525"/>
         <source>Failed to start server, please check %1.</source>
         <oldsource>Failed to start server, please check </oldsource>
         <translation>Konnte Server nicht starten, bitte in %1 nachsehen.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="596"/>
+        <location filename="../mainwindow.cpp" line="599"/>
         <source>Raspberry Pi System Volume</source>
         <translation>Raspberry Pi Lautstärke</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="599"/>
+        <location filename="../mainwindow.cpp" line="602"/>
         <source>Studio Settings</source>
         <translation>Studio-Einstellungen</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="616"/>
+        <location filename="../mainwindow.cpp" line="619"/>
         <source>Raspberry Pi Audio Output</source>
         <translation>Raspberry Pi Audio-Ausgabe</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="618"/>
+        <location filename="../mainwindow.cpp" line="621"/>
         <source>&amp;Default</source>
         <translation>&amp;Standard</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="619"/>
+        <location filename="../mainwindow.cpp" line="622"/>
         <source>&amp;Headphones</source>
         <translation>&amp;Kopfhörerbuchse</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="620"/>
+        <location filename="../mainwindow.cpp" line="623"/>
         <source>&amp;HDMI</source>
         <translation>&amp;HDMI</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="834"/>
+        <location filename="../mainwindow.cpp" line="856"/>
         <source>Save Current Workspace</source>
         <translation>Arbeitsbereich speichern</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="902"/>
+        <location filename="../mainwindow.cpp" line="924"/>
         <source>Running Code...</source>
         <oldsource>Running Code....</oldsource>
         <translation>Führe Programm aus...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="945"/>
+        <location filename="../mainwindow.cpp" line="967"/>
         <source>Beautifying...</source>
         <oldsource>Beautifying....</oldsource>
         <translation>Textausrichtung...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="964"/>
+        <location filename="../mainwindow.cpp" line="986"/>
         <source>Reloading...</source>
         <oldsource>Reloading....</oldsource>
         <translation>Neu laden...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="985"/>
+        <location filename="../mainwindow.cpp" line="1007"/>
         <source>Enabling Mixer HPF...</source>
         <oldsource>Enabling Mixer HPF....</oldsource>
         <translation>Mixer-Hochpassfilter aktiv...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="993"/>
+        <location filename="../mainwindow.cpp" line="1015"/>
         <source>Disabling Mixer HPF...</source>
         <oldsource>Disabling Mixer HPF....</oldsource>
         <translation>Mixer-Hochpassfilter inaktiv...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="227"/>
-        <location filename="../mainwindow.cpp" line="924"/>
+        <location filename="../mainwindow.cpp" line="237"/>
+        <location filename="../mainwindow.cpp" line="946"/>
         <source>Workspace %1</source>
         <translation>Arbeitsbereich %1</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="384"/>
+        <location filename="../mainwindow.cpp" line="387"/>
         <source>Welcome to Sonic Pi</source>
         <translation>Willkommen zu Sonic Pi</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="412"/>
+        <location filename="../mainwindow.cpp" line="415"/>
         <source>Indenting selection...</source>
         <translation>Auswahl einrücken...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="416"/>
+        <location filename="../mainwindow.cpp" line="419"/>
         <source>Indenting line...</source>
         <translation>Zeile einrücken...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="597"/>
+        <location filename="../mainwindow.cpp" line="600"/>
         <source>Use this slider to change the system volume of your Raspberry Pi.</source>
         <oldsource>Use this slider to change the system volume of your Raspberry Pi</oldsource>
         <translation>Hier veränderst Du die Systemlautstärke Deines Raspberry Pi.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="600"/>
+        <location filename="../mainwindow.cpp" line="603"/>
         <source>Advanced audio settings for working with
 external PA systems when performing with Sonic Pi.</source>
         <oldsource>Advanced audio settings for working with external PA systems when performing with Sonic Pi.</oldsource>
@@ -133,17 +133,17 @@ external PA systems when performing with Sonic Pi.</source>
 an einem externen Verstärker gut gebrauchen kann.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="601"/>
+        <location filename="../mainwindow.cpp" line="604"/>
         <source>Invert Stereo</source>
         <translation>Stereokanäle tauschen</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="603"/>
+        <location filename="../mainwindow.cpp" line="606"/>
         <source>Force Mono</source>
         <translation>Mono-Ton erzwingen</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="617"/>
+        <location filename="../mainwindow.cpp" line="620"/>
         <source>Your Raspberry Pi has two forms of audio output.
 Firstly, there is the headphone jack of the Raspberry Pi itself.
 Secondly, some HDMI monitors/TVs support audio through the HDMI port.
@@ -159,37 +159,37 @@ Zweitens: Der digitale HDMI-Monitoranschluss, der den Ton zum Monitor/Fernseher 
 Hier wählst Du aus, über welchen davon die Tonausgabe gehen soll.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="640"/>
+        <location filename="../mainwindow.cpp" line="643"/>
         <source>Debug Options</source>
         <translation>Debug-Einstellungen</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="641"/>
+        <location filename="../mainwindow.cpp" line="644"/>
         <source>Print output</source>
         <translation>Ausgabe anzeigen</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="642"/>
+        <location filename="../mainwindow.cpp" line="645"/>
         <source>Check synth args</source>
         <translation>Synth-Parameter prüfen</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="643"/>
+        <location filename="../mainwindow.cpp" line="646"/>
         <source>Clear output on run</source>
         <translation>Vorm Ausführen Ausgabe leeren</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="653"/>
+        <location filename="../mainwindow.cpp" line="656"/>
         <source>Updates</source>
         <translation>Updates</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="654"/>
+        <location filename="../mainwindow.cpp" line="657"/>
         <source>Check for updates</source>
         <translation>Auf Updates prüfen</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="657"/>
+        <location filename="../mainwindow.cpp" line="660"/>
         <source>Configure whether Sonic Pi may check for new updates on launch.
 Please note, the checking process includes sending
 anonymous information to the Sonic Pi server.</source>
@@ -198,112 +198,122 @@ Bitte beachte, dass dabei einige anonymisierte Informationen
 an den Server des Sonic-Pi-Entwicklers geschickt werden.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="664"/>
+        <location filename="../mainwindow.cpp" line="667"/>
         <source>Editor</source>
         <translation>Editor</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="665"/>
+        <location filename="../mainwindow.cpp" line="668"/>
         <source>Show line numbers</source>
         <translation>Zeilennummern anzeigen</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="668"/>
+        <location filename="../mainwindow.cpp" line="671"/>
         <source>Editor Preferences</source>
         <translation>Editor-Einstellungen</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="737"/>
+        <location filename="../mainwindow.cpp" line="759"/>
         <source>We&apos;re sorry, but Sonic Pi was unable to start...</source>
         <translation>Sonic Pi konnte nicht starten. Das tut uns leid...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="971"/>
+        <location filename="../mainwindow.cpp" line="993"/>
         <source>Enabling update checking...</source>
         <translation>Update-Prüfung aktiv...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="978"/>
+        <location filename="../mainwindow.cpp" line="1000"/>
         <source>Disabling update checking...</source>
         <translation>Update-Prüfung inaktiv...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1000"/>
+        <location filename="../mainwindow.cpp" line="1022"/>
         <source>Enabling Mixer LPF...</source>
         <oldsource>Enabling Mixer LPF....</oldsource>
         <translation>Mixer-Tiefpassfilter aktiv...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1008"/>
+        <location filename="../mainwindow.cpp" line="1030"/>
         <source>Disabling Mixer LPF...</source>
         <oldsource>Disabling Mixer LPF....</oldsource>
         <translation>Mixer-Tiefpassfilter inaktiv...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1015"/>
+        <location filename="../mainwindow.cpp" line="1037"/>
         <source>Enabling Inverted Stereo...</source>
         <oldsource>Enabling Inverted Stereo....</oldsource>
         <translation>Stereo-Kanaltausch aktiv...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1022"/>
+        <location filename="../mainwindow.cpp" line="1044"/>
         <source>Enabling Standard Stereo...</source>
         <oldsource>Enabling Standard Stereo....</oldsource>
         <translation>Stereo-Kanaltausch inaktiv...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1029"/>
+        <location filename="../mainwindow.cpp" line="1051"/>
         <source>Mono Mode...</source>
         <oldsource>Mono Mode....</oldsource>
         <translation>Mono-Ton aktiv...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1036"/>
+        <location filename="../mainwindow.cpp" line="1058"/>
         <source>Stereo Mode...</source>
         <oldsource>Stereo Mode....</oldsource>
         <translation>Stereo-Ton aktiv...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1044"/>
+        <location filename="../mainwindow.cpp" line="1066"/>
         <source>Stopping...</source>
         <translation>Stopp...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1108"/>
-        <location filename="../mainwindow.cpp" line="1124"/>
+        <location filename="../mainwindow.cpp" line="1130"/>
+        <location filename="../mainwindow.cpp" line="1146"/>
         <source>Updating System Volume...</source>
         <translation>Setze System-Lautstärke...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1147"/>
-        <location filename="../mainwindow.cpp" line="1153"/>
+        <location filename="../mainwindow.cpp" line="1169"/>
+        <location filename="../mainwindow.cpp" line="1175"/>
         <source>Switching To Headphone Audio Output...</source>
         <translation>Umschalten auf Kopfhörerbuchse...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1166"/>
-        <location filename="../mainwindow.cpp" line="1172"/>
+        <location filename="../mainwindow.cpp" line="1188"/>
+        <location filename="../mainwindow.cpp" line="1194"/>
         <source>Switching To HDMI Audio Output...</source>
         <translation>Umschalten auf HDMI-Anschluss...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1185"/>
-        <location filename="../mainwindow.cpp" line="1191"/>
+        <location filename="../mainwindow.cpp" line="1207"/>
+        <location filename="../mainwindow.cpp" line="1213"/>
         <source>Switching To Default Audio Output...</source>
         <translation>Umschalten auf Standard-Tonausgabe...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1500"/>
+        <location filename="../mainwindow.cpp" line="1391"/>
+        <source>Start recording to WAV audio file</source>
+        <translation>Tonausgabe in WAV-Datei aufnehmen</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1396"/>
+        <source>Improve readability of code</source>
+        <translation>Lesbarkeit des Codes verbessern</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1523"/>
         <source>Ready...</source>
         <translation>Bereit...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1579"/>
+        <location filename="../mainwindow.cpp" line="1602"/>
         <source>File loaded...</source>
         <translation>Datei geladen...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1604"/>
+        <location filename="../mainwindow.cpp" line="1627"/>
         <source>File saved...</source>
         <translation>Datei gespeichert...</translation>
     </message>
@@ -328,48 +338,48 @@ an den Server des Sonic-Pi-Entwicklers geschickt werden.</translation>
         <translation type="obsolete">Umschalten auf Standard-Tonausgabe.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1341"/>
+        <location filename="../mainwindow.cpp" line="1363"/>
         <source>Run</source>
         <translation>Ausführen</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1342"/>
+        <location filename="../mainwindow.cpp" line="1364"/>
         <source>Run the code in the current workspace</source>
         <translation>Das Programm im aktuellen Arbeitsbereich ausführen</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1346"/>
+        <location filename="../mainwindow.cpp" line="1368"/>
         <source>Stop</source>
         <translation>Stopp</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1347"/>
+        <location filename="../mainwindow.cpp" line="1369"/>
         <source>Stop all running code</source>
         <translation>Alle laufenden Programme beenden</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1350"/>
+        <location filename="../mainwindow.cpp" line="1372"/>
         <source>Save As...</source>
         <translation>Speichern als...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1351"/>
+        <location filename="../mainwindow.cpp" line="1373"/>
         <source>Save current workspace as an external file</source>
         <translation>Den aktuellen Arbeitsbereich als Datei speichern</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1354"/>
+        <location filename="../mainwindow.cpp" line="1376"/>
         <source>Info</source>
         <translation>Info</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1355"/>
+        <location filename="../mainwindow.cpp" line="1377"/>
         <source>See information about Sonic Pi</source>
         <translation>Einige Informationen über Sonic Pi</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="336"/>
-        <location filename="../mainwindow.cpp" line="1359"/>
+        <location filename="../mainwindow.cpp" line="339"/>
+        <location filename="../mainwindow.cpp" line="1381"/>
         <source>Help</source>
         <translation>Hilfe</translation>
     </message>
@@ -382,107 +392,105 @@ an den Server des Sonic-Pi-Entwicklers geschickt werden.</translation>
         <translation type="obsolete">Update-Prüfung inaktiv...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1360"/>
+        <location filename="../mainwindow.cpp" line="1382"/>
         <source>Toggle help pane</source>
         <translation>Hilfetexte anzeigen</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1363"/>
+        <location filename="../mainwindow.cpp" line="1385"/>
         <source>Prefs</source>
         <translation>Einstellungen</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1364"/>
+        <location filename="../mainwindow.cpp" line="1386"/>
         <source>Toggle preferences pane</source>
         <translation>Einstellungen anzeigen</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1368"/>
-        <location filename="../mainwindow.cpp" line="1369"/>
-        <location filename="../mainwindow.cpp" line="1480"/>
-        <location filename="../mainwindow.cpp" line="1481"/>
+        <location filename="../mainwindow.cpp" line="1390"/>
+        <location filename="../mainwindow.cpp" line="1503"/>
+        <location filename="../mainwindow.cpp" line="1504"/>
         <source>Start Recording</source>
         <translation>Aufnahme starten</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1373"/>
+        <location filename="../mainwindow.cpp" line="1395"/>
         <source>Auto-Align Text</source>
         <oldsource>Auto Align Text</oldsource>
         <translation>Text automatisch ausrichten</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1374"/>
         <source>Auto-align text</source>
-        <translation>Text automatisch ausrichten</translation>
+        <translation type="obsolete">Text automatisch ausrichten</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1378"/>
+        <location filename="../mainwindow.cpp" line="1400"/>
         <source>Increase Text Size</source>
         <translation>Text vergrößern</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1379"/>
+        <location filename="../mainwindow.cpp" line="1401"/>
         <source>Make text bigger</source>
         <translation>Text vergrößern</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1384"/>
+        <location filename="../mainwindow.cpp" line="1406"/>
         <source>Decrease Text Size</source>
         <translation>Text verkleinern</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1385"/>
+        <location filename="../mainwindow.cpp" line="1407"/>
         <source>Make text smaller</source>
         <translation>Text verkleinern</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1391"/>
+        <location filename="../mainwindow.cpp" line="1413"/>
         <source>Tools</source>
         <translation>Werkzeuge</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1432"/>
+        <location filename="../mainwindow.cpp" line="1454"/>
         <source>About</source>
         <translation>Über Sonic Pi</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1432"/>
+        <location filename="../mainwindow.cpp" line="1454"/>
         <source>Core Team</source>
         <translation>Kern-Team</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1432"/>
+        <location filename="../mainwindow.cpp" line="1454"/>
         <source>Contributors</source>
         <translation>Mitwirkende</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1433"/>
+        <location filename="../mainwindow.cpp" line="1455"/>
         <source>Community</source>
         <translation>Gemeinschaft</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1433"/>
+        <location filename="../mainwindow.cpp" line="1455"/>
         <source>License</source>
         <translation>Lizenz</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1433"/>
+        <location filename="../mainwindow.cpp" line="1455"/>
         <source>History</source>
         <translation>Änderungen</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1453"/>
+        <location filename="../mainwindow.cpp" line="1476"/>
         <source>Sonic Pi - Info</source>
         <translation>Über Sonic Pi</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1473"/>
-        <location filename="../mainwindow.cpp" line="1474"/>
+        <location filename="../mainwindow.cpp" line="1496"/>
+        <location filename="../mainwindow.cpp" line="1497"/>
         <source>Stop Recording</source>
         <translation>Aufnahme stoppen</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1485"/>
+        <location filename="../mainwindow.cpp" line="1508"/>
         <source>Save Recording</source>
         <translation>Aufnahme speichern</translation>
     </message>
@@ -491,7 +499,7 @@ an den Server des Sonic-Pi-Entwicklers geschickt werden.</translation>
         <translation type="obsolete">Bereit</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1569"/>
+        <location filename="../mainwindow.cpp" line="1592"/>
         <source>Cannot read file %1:
 %2.</source>
         <translation>Kann Datei %1 nicht laden:
@@ -502,7 +510,7 @@ an den Server des Sonic-Pi-Entwicklers geschickt werden.</translation>
         <translation type="obsolete">Datei geladen</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1587"/>
+        <location filename="../mainwindow.cpp" line="1610"/>
         <source>Cannot write file %1:
 %2.</source>
         <translation>Kann Datei %1 nicht schreiben:
@@ -513,33 +521,33 @@ an den Server des Sonic-Pi-Entwicklers geschickt werden.</translation>
         <translation type="obsolete">Datei geschrieben</translation>
     </message>
     <message>
-        <location filename="../ruby_help.h" line="78"/>
-        <location filename="../ruby_help.h" line="140"/>
+        <location filename="../ruby_help.h" line="79"/>
+        <location filename="../ruby_help.h" line="141"/>
         <source>Tutorial</source>
         <translation>Tutorial</translation>
     </message>
     <message>
-        <location filename="../ruby_help.h" line="170"/>
+        <location filename="../ruby_help.h" line="171"/>
         <source>Examples</source>
         <translation>Beispiele</translation>
     </message>
     <message>
-        <location filename="../ruby_help.h" line="206"/>
+        <location filename="../ruby_help.h" line="208"/>
         <source>Synths</source>
         <translation>Synths</translation>
     </message>
     <message>
-        <location filename="../ruby_help.h" line="239"/>
+        <location filename="../ruby_help.h" line="241"/>
         <source>Fx</source>
         <translation>Fx</translation>
     </message>
     <message>
-        <location filename="../ruby_help.h" line="256"/>
+        <location filename="../ruby_help.h" line="258"/>
         <source>Samples</source>
         <translation>Samples</translation>
     </message>
     <message>
-        <location filename="../ruby_help.h" line="395"/>
+        <location filename="../ruby_help.h" line="398"/>
         <source>Lang</source>
         <translation>Lang</translation>
     </message>
@@ -547,7 +555,7 @@ an den Server des Sonic-Pi-Entwicklers geschickt werden.</translation>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../main.cpp" line="49"/>
+        <location filename="../main.cpp" line="41"/>
         <source>Sonic Pi</source>
         <translation>Sonic Pi</translation>
     </message>

--- a/app/gui/qt/main.cpp
+++ b/app/gui/qt/main.cpp
@@ -35,10 +35,7 @@ int main(int argc, char *argv[])
   app.installTranslator(&qtTranslator);
 
   QTranslator translator;
-  if (!translator.load("sonic-pi_" + systemLocale, ":/lang/") && (!systemLocale.startsWith("en")) && (systemLocale != "C")) {
-    std::cout << "No translation found for your locale \"" + systemLocale.toStdString() + "\"." << std::endl;
-    std::cout << "Please contact us if you want to translate Sonic Pi to your language." << std::endl;
-  }
+  bool i18n = translator.load("sonic-pi_" + systemLocale, ":/lang/") || systemLocale.startsWith("en") || systemLocale == "C";
   app.installTranslator(&translator);
 
   app.setApplicationName(QObject::tr("Sonic Pi"));
@@ -60,7 +57,7 @@ int main(int argc, char *argv[])
   splashWindow->raise();
   splashWindow->show();
 
-  MainWindow mainWin(app, splashWindow);
+  MainWindow mainWin(app, i18n, splashWindow);
   return app.exec();
 #else
   QPixmap pixmap(":/images/splash.png");
@@ -69,7 +66,7 @@ int main(int argc, char *argv[])
   splash->show();
   splash->repaint();
 
-  MainWindow mainWin(app, splash);
+  MainWindow mainWin(app, i18n, splash);
   return app.exec();
 #endif
 

--- a/app/gui/qt/mainwindow.cpp
+++ b/app/gui/qt/mainwindow.cpp
@@ -92,9 +92,9 @@ using namespace oscpkt;
 #include "mainwindow.h"
 
 #ifdef Q_OS_MAC
-MainWindow::MainWindow(QApplication &app, QMainWindow* splash)
+MainWindow::MainWindow(QApplication &app, bool i18n, QMainWindow* splash)
 #else
-MainWindow::MainWindow(QApplication &app, QSplashScreen* splash)
+MainWindow::MainWindow(QApplication &app, bool i18n, QSplashScreen* splash)
 #endif
 {
   this->protocol = UDP;
@@ -104,6 +104,7 @@ MainWindow::MainWindow(QApplication &app, QSplashScreen* splash)
     clientSock = new QTcpSocket(this);
   }
 
+  this->i18n = i18n;
 
   printAsciiArtLogo();
   // kill any zombie processes that may exist
@@ -672,7 +673,7 @@ void MainWindow::initPrefsWindow() {
   QVBoxLayout *editor_box_layout = new QVBoxLayout;
   editor_box_layout->addWidget(show_line_numbers);
   editor_box->setLayout(editor_box_layout);
-
+  
 #if defined(Q_OS_LINUX)
    grid->addWidget(audioOutputBox, 0, 0);
    grid->addWidget(volBox, 0, 1);
@@ -681,9 +682,28 @@ void MainWindow::initPrefsWindow() {
   grid->addWidget(advancedAudioBox, 1, 0);
   grid->addWidget(update_box, 2, 0);
   grid->addWidget(editor_box, 2, 1);
+
+  if (!i18n) {
+    QGroupBox *translation_box = new QGroupBox("Translation");
+    QVBoxLayout *translation_box_layout = new QVBoxLayout;
+    QLabel *go_translate = new QLabel;
+    go_translate->setOpenExternalLinks(true);
+    go_translate->setText(
+      "Sonic Pi hasn't been translated to " +
+      QLocale::languageToString(QLocale::system().language()) +
+      " yet.<br>" +
+      "You can help " +
+      "<a href=\"https://github.com/samaaron/sonic-pi/blob/master/TRANSLATION.md\">" +
+      "translate the Sonic Pi GUI</a> to your language."
+    );
+    go_translate->setTextFormat(Qt::RichText);
+    translation_box_layout->addWidget(go_translate);
+    translation_box->setLayout(translation_box_layout);
+    
+    grid->addWidget(translation_box, 3, 0, 1, 2);
+  }
+
   prefsCentral->setLayout(grid);
-
-
 
   // Read in preferences from previous session
   QSettings settings("uk.ac.cam.cl", "Sonic Pi");
@@ -1368,12 +1388,12 @@ void MainWindow::createToolBar()
 
   // Record
   recAct = new QAction(QIcon(":/images/rec.png"), tr("Start Recording"), this);
-  setupAction(recAct, 0, tr("Start Recording"), SLOT(toggleRecording()));
+  setupAction(recAct, 0, tr("Start recording to WAV audio file"), SLOT(toggleRecording()));
 
   // Align
   QAction *textAlignAct = new QAction(QIcon(":/images/align.png"),
 			     tr("Auto-Align Text"), this);
-  setupAction(textAlignAct, 'M', tr("Auto-align text"), SLOT(beautifyCode()));
+  setupAction(textAlignAct, 'M', tr("Improve readability of code"), SLOT(beautifyCode()));
 
   // Font Size Increase
   QAction *textIncAct = new QAction(QIcon(":/images/size_up.png"),
@@ -1430,7 +1450,7 @@ void MainWindow::createInfoPane() {
 
   QStringList files, tabs;
   files << ":/html/info.html" << ":/info/CORETEAM.html" << ":/info/CONTRIBUTORS.html" <<
-    ":/info/COMMUNITY.html" << ":/info/LICENSE.html" <<":/info/CHANGELOG.html";
+    ":/info/COMMUNITY.html" << ":/info/LICENSE.html" << ":/info/CHANGELOG.html";
   tabs << tr("About") << tr("Core Team") << tr("Contributors") <<
     tr("Community") << tr("License") << tr("History");
 

--- a/app/gui/qt/mainwindow.h
+++ b/app/gui/qt/mainwindow.h
@@ -65,9 +65,9 @@ class MainWindow : public QMainWindow
 
 public:
 #if defined(Q_OS_MAC)
-    MainWindow(QApplication &ref, QMainWindow* splash);
+    MainWindow(QApplication &ref, bool i18n, QMainWindow* splash);
 #else
-    MainWindow(QApplication &ref, QSplashScreen* splash);
+    MainWindow(QApplication &ref, bool i18n, QSplashScreen* splash);
 #endif
     void invokeStartupError(QString msg);
     SonicPiServer *sonicPiServer;
@@ -189,6 +189,7 @@ private:
     QSplashScreen* splash;
 #endif
 
+    bool i18n;
     static const int workspace_max = 10;
     SonicPiScintilla *workspaces[workspace_max];
     QWidget *prefsCentral;


### PR DESCRIPTION
This replaces #448, which turned out to be a bit of overkill.

So here's the same result with a much simpler patch.

![not-french](https://cloud.githubusercontent.com/assets/1705654/7251922/116217da-e830-11e4-8669-1df90167de22.png)

That translation reminder above is shown if Sonic Pi is started on a non-English system and doesn't have a translation ready. You can test this with `LC_ALL=fr_FR.utf8 ./sonic-pi`.