### PR TITLE
Add use_tuning

### DIFF
--- a/app/server/sonicpi/lib/sonicpi/mods/sound.rb
+++ b/app/server/sonicpi/lib/sonicpi/mods/sound.rb
@@ -827,33 +827,69 @@ synth :dsaw, note: 50 # Play note 50 of the :dsaw synth with a release of 5"]
          args_h = resolve_synth_opts_hash_or_array(args)
 
          if tuning_system = Thread.current.thread_variable_get(:sonic_pi_mod_sound_tuning)
-           fundamental_sym = Thread.current.thread_variable_get(:sonic_pi_mod_sound_tuning_fundamental_note)
-           fundamental = Note.resolve_midi_note(fundamental_sym)
+           if tuning_system != :equal
+             fundamental_sym = Thread.current.thread_variable_get(:sonic_pi_mod_sound_tuning_fundamental_note)
+             fundamental = Note.resolve_midi_note_without_octave(fundamental_sym)
 
-           @tunings = {:just => [1, #c
-                                16.0/15.0, #cs
-                                9.0/8.0, #d
-                                6.0/5.0, #ds
-                                5.0/4.0, #e
-                                4.0/3.0, #f
-                                45.0/32.0, #fs
-                                3.0/2.0, #g
-                                8.0/5.0, #gs
-                                5.0/3.0, #a
-                                9.0/5.0, #as
-                                15.0/8.0 #b
-           ]}
+             # http://en.wikipedia.org/wiki/Musical_tuning#Systems_for_the_twelve-note_chromatic_scale
+             @tunings = {:just => [
+                           1, #c
+                           16.0/15.0, #cs
+                           9.0/8.0, #d
+                           6.0/5.0, #ds
+                           5.0/4.0, #e
+                           4.0/3.0, #f
+                           45.0/32.0, #fs
+                           3.0/2.0, #g
+                           8.0/5.0, #gs
+                           5.0/3.0, #a
+                           9.0/5.0, #as
+                           15.0/8.0],
+                         :pythagorean => [
+                           1.0/1, #unison
+                           2187.0/2048, #apotome
+                           9.0/8, #major whole tone
+                           19683.0/16384, #Pythagorean augmented second
+                           81.0/64, #Pythagorean major third
+                           4.0/3, #perfect fourth
+                           729.0/512, #Pythagorean tritone
+                           3.0/2, #perfect fifth
+                           6561.0/4096, #Pythagorean augmented fifth
+                           27.0/16, #Pythagorean major sixth
+                           59049.0/32768, #Pythagorean augmented sixth
+                           243.0/128],
+                         :meantone => [
+                           1.00000,
+                           1.0449,
+                           1.1180,
+                           1.1963,
+                           1.2500,
+                           1.3375,
+                           1.3975,
+                           1.4953,
+                           1.5625,
+                           1.6719,
+                           1.7889,
+                           1.8692]}
 
-           # create an array of all the tuned notes
-           tuned_notes = (0..150).to_a.map {|midi_note|
-             note_idx = midi_note % 12
-             # tuning systems are ratios of the fundamental note
-             tuned_note = midi_to_hz(midi_note - note_idx) * @tunings[tuning_system][note_idx]
-             hz_to_midi(tuned_note)
-           }
+             # midi note 0 is a :c
+             # by getting a fundamental without an octave
+             # we know it's in the middle register between
+             # 60 and 72
+             fundamental_offset = fundamental - 60
 
-           #select the tuned note for a given midi note
-           n = tuned_notes[n - 1]
+             # create an array of all the tuned notes
+             tuned_notes = (0..150).to_a.map {|midi_note|
+               # vary the fundamental here
+               note_idx = (midi_note - fundamental_offset) % 12
+               # tuning systems are ratios of the fundamental note
+               tuned_note = midi_to_hz(midi_note - note_idx) * @tunings[tuning_system][note_idx]
+               hz_to_midi(tuned_note)
+             }
+
+             #select the tuned note for a given midi note
+             n = tuned_notes[n]
+           end
          end
 
          if shift = Thread.current.thread_variable_get(:sonic_pi_mod_sound_transpose)


### PR DESCRIPTION
Adds two new methods - `use_tuning` and `with_tuning`

Each takes a symbol (currently one of `:equal, :just, :pythagorean, :meantone`) and an optional key center (notes `:c` to `:b`). This applies the named tuning system to all notes handled by the `play` method.

Good example - get Robin's gist from https://gist.github.com/rbnpi/42c41e85f49de6fd9c38 and stick

```
use_tuning :just, :a
```

at the top. Hear how nice it all sounds? That's because the piece is in A major. Try it with

```
use_tuning :just, :eb
```

Now you can hear how nasty a tuning can sound when you get away from it's key center. Experiment to taste!