### PR TITLE
Fix startup window

### DIFF
--- a/app/gui/qt/html/info.html
+++ b/app/gui/qt/html/info.html
@@ -4,24 +4,33 @@
 
 <body class="info">
   <center>
-  <img src=":/images/logo-smaller.png" height="268" width="328"/>
-  <p class="hightlight">
-    A Sound Synthesiser<br/>
-    for Live Coding</p>
-  <p>Designed and developed by Sam Aaron<br/>
-  in Cambridge, England</p>
-  <p><a href="http://sonic-pi.net">http://sonic-pi.net</a></p>
+    <img src=":/images/logo-smaller.png" height="268" width="328"/>
+    <p class="hightlight">
+      A Sound Synthesiser<br/>
+      for Live Coding
+    </p>
 
-  <p>For the latest updates follow<br/>
-  <a href="http://twitter.com/sonic_pi">@sonic_pi</a></p>
+    <p>
+      Designed and developed by Sam Aaron<br/>
+      in Cambridge, England
+    </p>
 
-  <br/>
-  
-  <p><b>music_as <span class="hightlight">:code</span></b><br/>
-  <b>code_as <span class="hightlight">:art</span></b></p>
-  
-  <br/>
+    <p><a href="http://sonic-pi.net">http://sonic-pi.net</a></p>
 
-  <p class="version">v2.6-dev</p>
+    <p>
+      For the latest updates follow<br/>
+      <a href="http://twitter.com/sonic_pi">@sonic_pi</a>
+    </p>
+
+    <br/>
+
+    <p>
+      <b>music_as <span class="hightlight">:code</span></b><br/>
+      <b>code_as <span class="hightlight">:art</span></b>
+    </p>
+
+    <br/>
+
+    <p class="version">v2.6-dev</p>
   </center>
 </body>

--- a/app/gui/qt/html/startup.html
+++ b/app/gui/qt/html/startup.html
@@ -8,20 +8,27 @@
 
     <h1>Welcome!</h1>
 
-    <p>This is Sonic Pi<br/>
-    the live coding music environment</p>
+    <p>
+      This is Sonic Pi<br/>
+      the live coding music environment
+    </p>
 
-    <p>To get started please follow the<br/>
-    tutorial in the help system below<br/>
-    (which you can always access via the Help button)</p>
+    <p>
+      To get started please follow the<br/>
+      tutorial in the help system below<br/>
+      (which you can always access via the Help button)
+    </p>
     
-    <p><em>and remember...</em></p>
+    <p>
+      <em>and remember...</em><br/>
+      with live coding<br/>
+      there are no mistakes<br/>
+      only opportunities
+    </p>
 
-    <p>with live coding<br/>
-    there are no mistakes<br/>
-    only opportunities</p>
-
-    <p class="hightlight">Have fun and share your code<br/>
-    for others to jam with</p>
+    <p class="hightlight">
+      Have fun and share your code<br/>
+      for others to jam with
+    </p>
   </center>
 </body>

--- a/app/gui/qt/mainwindow.cpp
+++ b/app/gui/qt/mainwindow.cpp
@@ -396,7 +396,7 @@ MainWindow::MainWindow(QApplication &app, bool i18n, QSplashScreen* splash)
   QSettings settings("uk.ac.cam.cl", "Sonic Pi");
 
   if(settings.value("first_time", 1).toInt() == 1) {
-    QTextEdit* startupPane = new QTextEdit;
+    QTextEdit* startupPane = new QTextBrowser;
     startupPane->setReadOnly(true);
     startupPane->setFixedSize(600, 615);
     startupPane->setWindowIcon(QIcon(":images/icon-smaller.png"));
@@ -405,6 +405,8 @@ MainWindow::MainWindow(QApplication &app, bool i18n, QSplashScreen* splash)
     QString html;
 
     startupPane->setHtml(readFile(":/html/startup.html"));
+    startupPane->setStyleSheet(defaultTextBrowserStyle);
+
     docWidget->show();
     startupPane->show();
   }

--- a/app/gui/qt/mainwindow.cpp
+++ b/app/gui/qt/mainwindow.cpp
@@ -397,7 +397,6 @@ MainWindow::MainWindow(QApplication &app, bool i18n, QSplashScreen* splash)
 
   if(settings.value("first_time", 1).toInt() == 1) {
     QTextEdit* startupPane = new QTextBrowser;
-    startupPane->setReadOnly(true);
     startupPane->setFixedSize(600, 615);
     startupPane->setWindowIcon(QIcon(":images/icon-smaller.png"));
     startupPane->setWindowTitle(tr("Welcome to Sonic Pi"));

--- a/app/gui/qt/mainwindow.cpp
+++ b/app/gui/qt/mainwindow.cpp
@@ -396,7 +396,7 @@ MainWindow::MainWindow(QApplication &app, bool i18n, QSplashScreen* splash)
   QSettings settings("uk.ac.cam.cl", "Sonic Pi");
 
   if(settings.value("first_time", 1).toInt() == 1) {
-    QTextEdit* startupPane = new QTextBrowser;
+    QTextBrowser* startupPane = new QTextBrowser;
     startupPane->setFixedSize(600, 615);
     startupPane->setWindowIcon(QIcon(":images/icon-smaller.png"));
     startupPane->setWindowTitle(tr("Welcome to Sonic Pi"));


### PR DESCRIPTION
The startup welcome window didn't use the stylesheet when displayed.

Using `QTextBrowser` instead of `QTextEdit` fixes that.