### PR TITLE
make context sensitive help function name search more generic

### DIFF
--- a/app/gui/qt/mainwindow.cpp
+++ b/app/gui/qt/mainwindow.cpp
@@ -1154,8 +1154,9 @@ void MainWindow::helpContext()
     for (start = pos; start > 0; start--) {
       if (!text[start-1].isLetter() && text[start-1] != '_') break;
     }
+    QString identifierEndChars = QString("?!_=");
     for (end = pos; end < text.length(); end++) {
-      if (!text[end].isLetter() && text[end] != '_' && text[end] !='?') break;
+      if (!text[end].isLetter() && !identifierEndChars.contains(text[end])) break;
     }
     selection = text.mid(start, end-start);
   }


### PR DESCRIPTION
Hopefully this is the right idea.

It would allow the function name lookup to match names that end in more than just '?' or '_', (eg 'set_control_delta!' etc) and is hopefully better than stringing a lot of individual char checks together in a row.