### PR TITLE
WIP: Some readFile() cleanups (bonus: reduced memory usage)

### DIFF
--- a/app/gui/qt/html/doc.html
+++ b/app/gui/qt/html/doc.html
@@ -1,5 +1,6 @@
 <head>
 <link rel="stylesheet" type="text/css" href="qrc:///html/styles.css"/>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
 </head>
 
 <body class="info">

--- a/app/gui/qt/html/info.html
+++ b/app/gui/qt/html/info.html
@@ -1,5 +1,6 @@
 <head>
 <link rel="stylesheet" type="text/css" href="qrc:///html/styles.css"/>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
 </head>
 
 <body class="info">

--- a/app/gui/qt/html/startup.html
+++ b/app/gui/qt/html/startup.html
@@ -1,5 +1,6 @@
 <head>
 <link rel="stylesheet" type="text/css" href="qrc:///html/styles.css"/>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
 </head>
 
 <body class="info">

--- a/app/gui/qt/mainwindow.cpp
+++ b/app/gui/qt/mainwindow.cpp
@@ -812,10 +812,9 @@ void MainWindow::startupError(QString msg) {
   splashClose();
   startup_error_reported = true;
 
-  QString logtext = readFile(log_path + QDir::separator() + "output.log");
   QMessageBox *box = new QMessageBox(QMessageBox::Warning,
 				     tr("We're sorry, but Sonic Pi was unable to start..."), msg);
-  box->setDetailedText(logtext);
+  box->setDetailedText(readFile(log_path + QDir::separator() + "output.log"));
 
   QGridLayout* layout = (QGridLayout*)box->layout();
   QSpacerItem* hSpacer = new QSpacerItem(500, 0, QSizePolicy::Minimum, QSizePolicy::Expanding);
@@ -1487,14 +1486,14 @@ void MainWindow::createToolBar()
 QString MainWindow::readFile(QString name)
 {
   QFile file(name);
-  if (!file.open(QFile::ReadOnly | QFile::Text))
+  if (file.open(QFile::ReadOnly | QFile::Text)) {
+    QTextStream st(&file);
+    st.setCodec("UTF-8");
+    return st.readAll();
+    file.close();
+  } else {
     return "";
-
-  QTextStream st(&file);
-  st.setCodec("UTF-8");
-  QString s;
-  s.append(st.readAll());
-  return s;
+  }
 }
 
 void MainWindow::createInfoPane() {

--- a/app/gui/qt/mainwindow.cpp
+++ b/app/gui/qt/mainwindow.cpp
@@ -1485,7 +1485,9 @@ void MainWindow::createToolBar()
 QString MainWindow::readFile(QString name)
 {
   QFile file(name);
-  if (!file.open(QFile::ReadOnly | QFile::Text)) return "";
+  if (!file.open(QFile::ReadOnly | QFile::Text)) {
+    return "";
+  }
 
   QTextStream st(&file);
   st.setCodec("UTF-8");

--- a/app/gui/qt/mainwindow.cpp
+++ b/app/gui/qt/mainwindow.cpp
@@ -1489,7 +1489,6 @@ QString MainWindow::readFile(QString name)
     QTextStream st(&file);
     st.setCodec("UTF-8");
     return st.readAll();
-    file.close();
   } else {
     return "";
   }

--- a/app/gui/qt/mainwindow.cpp
+++ b/app/gui/qt/mainwindow.cpp
@@ -1726,17 +1726,7 @@ void MainWindow::updateDocPane2(QListWidgetItem *cur, QListWidgetItem *prev) {
 }
 
 void MainWindow::setHelpText(QListWidgetItem *item, const QString filename) {
-  QFile file(filename);
-
-  if(!file.open(QFile::ReadOnly | QFile::Text)) {
-  }
-
-  QString s;
-  QTextStream st(&file);
-  st.setCodec("UTF-8");
-  s.append(st.readAll());
-
-  item->setData(32, QVariant(s));
+  item->setData(32, QVariant(readFile(filename)));
 }
 
 void MainWindow::addHelpPage(QListWidget *nameList,
@@ -1858,15 +1848,7 @@ void MainWindow::addUniversalCopyShortcuts(QTextEdit *te){
 }
 
 QString MainWindow::asciiArtLogo(){
-  QFile file(":/images/logo.txt");
-  if(!file.open(QFile::ReadOnly | QFile::Text)) {
-  }
-
-  QString s;
-  QTextStream st(&file);
-  st.setCodec("UTF-8");
-  s.append(st.readAll());
-  return s;
+  return readFile(":/images/logo.txt");
 }
 
 void MainWindow::printAsciiArtLogo(){

--- a/app/gui/qt/mainwindow.cpp
+++ b/app/gui/qt/mainwindow.cpp
@@ -1497,18 +1497,18 @@ QString MainWindow::readFile(QString name)
 void MainWindow::createInfoPane() {
   QTabWidget *infoTabs = new QTabWidget(this);
 
-  QStringList files, tabs;
-  files << "qrc:///html/info.html" << "qrc:///info/CORETEAM.html" << "qrc:///info/CONTRIBUTORS.html" <<
+  QStringList urls, tabs;
+  urls << "qrc:///html/info.html" << "qrc:///info/CORETEAM.html" << "qrc:///info/CONTRIBUTORS.html" <<
     "qrc:///info/COMMUNITY.html" << "qrc:///info/LICENSE.html" << "qrc:///info/CHANGELOG.html";
   tabs << tr("About") << tr("Core Team") << tr("Contributors") <<
     tr("Community") << tr("License") << tr("History");
 
-  for (int t=0; t < files.size(); t++) {
+  for (int t=0; t < urls.size(); t++) {
     QTextBrowser *pane = new QTextBrowser;
     addUniversalCopyShortcuts(pane);
     pane->setOpenExternalLinks(true);
     pane->setFixedSize(600, 615);
-    pane->setSource(QUrl(files[t]));
+    pane->setSource(QUrl(urls[t]));
     pane->setStyleSheet(defaultTextBrowserStyle);
     infoTabs->addTab(pane, tabs[t]);
   }

--- a/app/gui/qt/mainwindow.cpp
+++ b/app/gui/qt/mainwindow.cpp
@@ -179,7 +179,6 @@ MainWindow::MainWindow(QApplication &app, bool i18n, QSplashScreen* splash)
   for(int ws = 0; ws < workspace_max; ws++) {
     std::string s;
 
-
     SonicPiScintilla *workspace = new SonicPiScintilla(lexer, theme);
 
     //tab completion when in list
@@ -1698,17 +1697,13 @@ void MainWindow::onExitCleanup()
 }
 
 void MainWindow::updateDocPane(QListWidgetItem *cur) {
-  QString content = cur->data(32).toString();
-  docPane->setHtml(content);
+  QString url = cur->data(32).toString();
+  docPane->setSource(QUrl(url));
 }
 
 void MainWindow::updateDocPane2(QListWidgetItem *cur, QListWidgetItem *prev) {
   (void)prev;
   updateDocPane(cur);
-}
-
-void MainWindow::setHelpText(QListWidgetItem *item, const QString filename) {
-  item->setData(32, QVariant(readFile(filename)));
 }
 
 void MainWindow::addHelpPage(QListWidget *nameList,
@@ -1719,7 +1714,7 @@ void MainWindow::addHelpPage(QListWidget *nameList,
 
   for(i = 0; i < len; i++) {
     QListWidgetItem *item = new QListWidgetItem(helpPages[i].title);
-    setHelpText(item, QString(helpPages[i].filename));
+    item->setData(32, QVariant(helpPages[i].url));
     item->setSizeHint(QSize(item->sizeHint().width(), 25));
     nameList->addItem(item);
     entry.entryIndex = nameList->count()-1;

--- a/app/gui/qt/mainwindow.cpp
+++ b/app/gui/qt/mainwindow.cpp
@@ -1485,13 +1485,11 @@ void MainWindow::createToolBar()
 QString MainWindow::readFile(QString name)
 {
   QFile file(name);
-  if (file.open(QFile::ReadOnly | QFile::Text)) {
-    QTextStream st(&file);
-    st.setCodec("UTF-8");
-    return st.readAll();
-  } else {
-    return "";
-  }
+  if (!file.open(QFile::ReadOnly | QFile::Text)) return "";
+
+  QTextStream st(&file);
+  st.setCodec("UTF-8");
+  return st.readAll();
 }
 
 void MainWindow::createInfoPane() {

--- a/app/gui/qt/mainwindow.cpp
+++ b/app/gui/qt/mainwindow.cpp
@@ -342,7 +342,7 @@ MainWindow::MainWindow(QApplication &app, bool i18n, QSplashScreen* splash)
   down->setContext(Qt::WidgetShortcut);
   connect(down, SIGNAL(activated()), this, SLOT(docScrollDown()));
 
-  docPane->setHtml(readFile(":/html/doc.html"));
+  docPane->setSource(QUrl("qrc:///html/doc.html"));
 
   addUniversalCopyShortcuts(docPane);
 
@@ -401,9 +401,8 @@ MainWindow::MainWindow(QApplication &app, bool i18n, QSplashScreen* splash)
     startupPane->setWindowIcon(QIcon(":images/icon-smaller.png"));
     startupPane->setWindowTitle(tr("Welcome to Sonic Pi"));
     addUniversalCopyShortcuts(startupPane);
-    QString html;
 
-    startupPane->setHtml(readFile(":/html/startup.html"));
+    startupPane->setSource(QUrl("qrc:///html/startup.html"));
     startupPane->setStyleSheet(defaultTextBrowserStyle);
 
     docWidget->show();
@@ -1502,8 +1501,8 @@ void MainWindow::createInfoPane() {
   QTabWidget *infoTabs = new QTabWidget(this);
 
   QStringList files, tabs;
-  files << ":/html/info.html" << ":/info/CORETEAM.html" << ":/info/CONTRIBUTORS.html" <<
-    ":/info/COMMUNITY.html" << ":/info/LICENSE.html" << ":/info/CHANGELOG.html";
+  files << "qrc:///html/info.html" << "qrc:///info/CORETEAM.html" << "qrc:///info/CONTRIBUTORS.html" <<
+    "qrc:///info/COMMUNITY.html" << "qrc:///info/LICENSE.html" << "qrc:///info/CHANGELOG.html";
   tabs << tr("About") << tr("Core Team") << tr("Contributors") <<
     tr("Community") << tr("License") << tr("History");
 
@@ -1512,7 +1511,7 @@ void MainWindow::createInfoPane() {
     addUniversalCopyShortcuts(pane);
     pane->setOpenExternalLinks(true);
     pane->setFixedSize(600, 615);
-    pane->setHtml(readFile(files[t]));
+    pane->setSource(QUrl(files[t]));
     pane->setStyleSheet(defaultTextBrowserStyle);
     infoTabs->addTab(pane, tabs[t]);
   }

--- a/app/gui/qt/mainwindow.cpp
+++ b/app/gui/qt/mainwindow.cpp
@@ -1635,24 +1635,6 @@ void MainWindow::writeSettings()
   settings.setValue("windowState", saveState());
 }
 
-void MainWindow::loadFile(const QString &fileName, SonicPiScintilla* &text)
-{
-  QFile file(fileName);
-  if (!file.open(QFile::ReadOnly)) {
-    QMessageBox::warning(this, tr("Sonic Pi"),
-			 tr("Cannot read file %1:\n%2.")
-			 .arg(fileName)
-			 .arg(file.errorString()));
-    return;
-  }
-
-  QTextStream in(&file);
-  QApplication::setOverrideCursor(Qt::WaitCursor);
-  text->setText(in.readAll());
-  QApplication::restoreOverrideCursor();
-  statusBar()->showMessage(tr("File loaded..."), 2000);
-}
-
 bool MainWindow::saveFile(const QString &fileName, SonicPiScintilla* text)
 {
   QFile file(fileName);

--- a/app/gui/qt/mainwindow.h
+++ b/app/gui/qt/mainwindow.h
@@ -52,7 +52,7 @@ class SonicPiServer;
 struct help_page {
   QString title;
   QString keyword;
-  QString filename;
+  QString url;
 };
 
 struct help_entry {

--- a/app/gui/qt/mainwindow.h
+++ b/app/gui/qt/mainwindow.h
@@ -149,7 +149,6 @@ private:
     void createInfoPane();
     void readSettings();
     void writeSettings();
-    void loadFile(const QString &fileName, SonicPiScintilla* &text);
     bool saveFile(const QString &fileName, SonicPiScintilla* text);
     void loadWorkspaces();
     void saveWorkspaces();

--- a/app/gui/qt/mainwindow.h
+++ b/app/gui/qt/mainwindow.h
@@ -158,7 +158,6 @@ private:
     void sendOSC(oscpkt::Message m);
     void initPrefsWindow();
     void initDocsWindow();
-    void setHelpText(QListWidgetItem *item, const QString filename);
     void addHelpPage(QListWidget *nameList, struct help_page *helpPages,
                      int len);
     QListWidget *createHelpTab(QString name);

--- a/app/server/bin/qt-doc.rb
+++ b/app/server/bin/qt-doc.rb
@@ -87,7 +87,7 @@ make_tab = lambda do |name, doc_items, titleize=false, should_sort=true, with_ke
     end
 
     docs << ", "
-    docs << "\":/#{filename}\""
+    docs << "\"qrc:///#{filename}\""
     docs << "},\n"
 
     filenames << filename

--- a/app/server/bin/qt-doc.rb
+++ b/app/server/bin/qt-doc.rb
@@ -133,7 +133,7 @@ example_dirs.each do |ex_dir|
     bname = ActiveSupport::Inflector.titleize(bname)
     name = "[#{ex_dir}] #{bname}"
     lines = IO.readlines(path).map(&:chop).map{|s| CGI.escapeHTML(s)}
-    html = "<head>\n<link rel=\"stylesheet\" type=\"text/css\" href=\"qrc:///html/styles.css\"/>\n</head>\n\n<body class=\"example\">\n\n"
+    html = "<head>\n<link rel=\"stylesheet\" type=\"text/css\" href=\"qrc:///html/styles.css\"/>\n<meta http-equiv=\"Content-Type\" content=\"text/html; charset=utf-8\"/>\n</head>\n\n<body class=\"example\">\n\n"
     html << '<h1>'
     html << "# #{bname}"
     html << '</h1>'

--- a/app/server/sonicpi/lib/sonicpi/docsystem.rb
+++ b/app/server/sonicpi/lib/sonicpi/docsystem.rb
@@ -53,7 +53,7 @@ module SonicPi
           @@docs.each do |k, v|
             unless(v[:hide])
               html = ""
-              html << "<head>\n<link rel=\"stylesheet\" type=\"text/css\" href=\"qrc:///html/styles.css\"/>\n</head>\n\n<body class=\"manual\">\n\n"
+              html << "<head>\n<link rel=\"stylesheet\" type=\"text/css\" href=\"qrc:///html/styles.css\"/>\n<meta http-equiv=\"Content-Type\" content=\"text/html; charset=utf-8\"/>\n</head>\n\n<body class=\"manual\">\n\n"
 
               summary = (v[:summary] || v[:name]).to_s
               summary[0] = summary[0].capitalize

--- a/app/server/sonicpi/lib/sonicpi/markdown_converter.rb
+++ b/app/server/sonicpi/lib/sonicpi/markdown_converter.rb
@@ -17,7 +17,7 @@ module SonicPi
       # remove unneeded newlines before </pre>
       html.gsub!(/\n(<\/code>)?<\/pre>/, '\1</pre>')
       # add stylesheet header reference and <body>-tags
-      "<head>\n<link rel=\"stylesheet\" type=\"text/css\" href=\"qrc:///html/styles.css\"/>\n</head>\n\n<body>\n\n" + html + "\n</body>\n"
+      "<head>\n<link rel=\"stylesheet\" type=\"text/css\" href=\"qrc:///html/styles.css\"/>\n<meta http-equiv=\"Content-Type\" content=\"text/html; charset=utf-8\"/>\n</head>\n\n<body>\n\n" + html + "\n</body>\n"
     end
   end
 end

--- a/app/server/sonicpi/lib/sonicpi/synthinfo.rb
+++ b/app/server/sonicpi/lib/sonicpi/synthinfo.rb
@@ -4631,7 +4631,7 @@ The window_size is the length of the slices and is measured in seconds. It needs
         next if v.is_a? StudioInfo
         doc = ""
 
-        doc << "<head>\n<link rel=\"stylesheet\" type=\"text/css\" href=\"qrc:///html/styles.css\"/>\n</head>\n\n<body class=\"manual\">\n\n"
+        doc << "<head>\n<link rel=\"stylesheet\" type=\"text/css\" href=\"qrc:///html/styles.css\"/>\n<meta http-equiv=\"Content-Type\" content=\"text/html; charset=utf-8\"/>\n</head>\n\n<body class=\"manual\">\n\n"
         doc << "<h1>" << v.name << "</h1>\n\n"
 
         doc << "<p><table class=\"arguments\"><tr>\n"


### PR DESCRIPTION
Where `readAll()` was used, it was a copy/pasted code block that can be replaced by a single call to `readFile()`

But most of the times, `readAll()` / `readFile()` were used to read the full content of a text file to a `QString` in memory and then use that string with `setHtml()`.

That isn't needed. Those widgets can also use `setSource()` and then read the content from a file stored in the resources.

As a result, this patch avoids keeping all the docs/help/info panes in memory and reduces the footprint of Sonic Pi from 38.3MiB to 36.1MiB by 2.2MiB or ca. 5% on my machine (Qt4, Ubuntu).