### PR TITLE
initialize variable before first use

### DIFF
--- a/app/gui/qt/mainwindow.cpp
+++ b/app/gui/qt/mainwindow.cpp
@@ -411,6 +411,7 @@ MainWindow::MainWindow(QApplication &app, bool i18n, QSplashScreen* splash)
   }
 
   focusMode = false;
+  restoreDocPane = false;
   disableFocusMode();
 }
 


### PR DESCRIPTION
This variable was uninitialized before first use (see #511)