### PR TITLE
Group copy key binding definition with cut + paste

### DIFF
--- a/app/gui/qt/sonicpiscintilla.cpp
+++ b/app/gui/qt/sonicpiscintilla.cpp
@@ -90,6 +90,8 @@ SonicPiScintilla::SonicPiScintilla(SonicPiLexer *lexer, SonicPiTheme *theme)
   addKeyBinding(settings, QsciCommand::Backtab, Qt::Key_Tab | Qt::SHIFT);
 
   // copy paste
+  addKeyBinding(settings, QsciCommand::SelectionCopy, Qt::Key_C | SPi_META);
+  addOtherKeyBinding(settings, QsciCommand::SelectionCopy, Qt::Key_C | SPi_CTRL);
   addKeyBinding(settings, QsciCommand::SelectionCut, Qt::Key_X | SPi_META);
   addOtherKeyBinding(settings, QsciCommand::SelectionCut, Qt::Key_X | SPi_CTRL);
 
@@ -139,9 +141,6 @@ SonicPiScintilla::SonicPiScintilla(SonicPiLexer *lexer, SonicPiTheme *theme)
   setCaretWidth(5);
   setCaretForegroundColor(theme->color("CaretForeground"));
   setEolMode(EolUnix);
-
-  addKeyBinding(settings, QsciCommand::SelectionCopy, Qt::Key_C | SPi_META);
-  addOtherKeyBinding(settings, QsciCommand::SelectionCopy, Qt::Key_C | SPi_CTRL);
 
   SendScintilla(SCI_SETWORDCHARS, "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789:_?!");
 


### PR DESCRIPTION
I went to submit a patch to enable copy with Meta+C within Sonic Pi, but then I saw that the code on master has supposedly got this already. I say "supposedly" because I don't understand C++ code very well.

I noticed that the copy key binding was defined seemingly out of place from the other keybindings, so I moved it.