### PR TITLE
create book-like PDFs from docs

### DIFF
--- a/CORETEAM.html
+++ b/CORETEAM.html
@@ -13,7 +13,7 @@
     <td>
       <table>
         <tr>
-          <td> <a href="https://twitter.com/samaaron"><img height="100" width="100" src=":/images/coreteam/samaaron.png"></a> </td>
+          <td> <a href="https://twitter.com/samaaron"><img height="100" width="100" src="../images/coreteam/samaaron.png"></a> </td>
           <td>
             <font size="5" ><span style="color:white; background-color:dodgerblue;">Sam Aaron</span></font>
             <p>
@@ -33,7 +33,7 @@
 
       <table>
         <tr>
-          <td> <a href="https://twitter.com/xavriley"><img height="100" width="100" src=":/images/coreteam/xavierriley.png"></a> </td>
+          <td> <a href="https://twitter.com/xavriley"><img height="100" width="100" src="../images/coreteam/xavierriley.png"></a> </td>
           <td>
             <font size="5" ><span style="color:white; background-color:dodgerblue;">Xavier Riley</span></font>
 
@@ -55,7 +55,7 @@
 
       <table>
         <tr>
-          <td><a href="https://twitter.com/weatherfnord"> <img height="100" width="100" src=":/images/coreteam/jweather.png"></a> </td>
+          <td><a href="https://twitter.com/weatherfnord"> <img height="100" width="100" src="../images/coreteam/jweather.png"></a> </td>
           <td>
             <font size="5" ><span style="color:white; background-color:dodgerblue;">Jeremy Weatherford</span></font>
 
@@ -76,7 +76,7 @@
 
       <table>
         <tr>
-          <td> <a href="https://twitter.com/josephwilk"><img height="100" width="100" src=":/images/coreteam/josephwilk.png"> </a></td>
+          <td> <a href="https://twitter.com/josephwilk"><img height="100" width="100" src="../images/coreteam/josephwilk.png"> </a></td>
           <td>
             <font size="5" ><span style="color:white; background-color:dodgerblue;">Joseph Wilk</span></font>
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -10,6 +10,7 @@ following platforms:
 * [Mac OS X](#mac-os-x)
 * [Windows](#windows)
 
+----
 
 ## Raspberry Pi
 
@@ -151,6 +152,7 @@ ln -s `which ruby` app/server/native/osx/ruby/bin/ruby
 * Run `./mac-build-app`
 * App should be in `build` dir
 
+----
 
 ## Windows
 
@@ -200,6 +202,7 @@ Packaging:
   - file paths will need to be updated, currently absolute
   - build with `candle sonic-pi.wxs -ext WixUtilExtension && light sonic-pi.wixobj -ext WixUtilExtension -ext WixUIExtension`
 
+----
 
 ## Optional: Sonic Pi reference books
 
@@ -222,6 +225,7 @@ On your Linux or OS X system, you will need to have installed
   from their site, as Ubuntu's own binary package does not support all
   features needed for a clean PDF conversion.)
 
+----
 
 ## Unsupported development HTML Interface
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -100,7 +100,7 @@ Arch Linux users are strongly recommended to install the [sonic-pi-git](https://
 
 After installing, users need to follow the instructions in the [Generic Linux](#generic-linux) section to start the `jackd` server, and then run `sonic-pi` at a command prompt. 
 
-###Building from source
+### Building from source
 
 Users can opt to build from source as well if they would like. Instructions and dependencies can be found within the PKGBUILD file in the AUR package previously mentioned, as well as the required patch file. 
 
@@ -199,6 +199,28 @@ Packaging:
 * There is a WiX project file in `sonic-pi.wxs' -- work in progress
   - file paths will need to be updated, currently absolute
   - build with `candle sonic-pi.wxs -ext WixUtilExtension && light sonic-pi.wixobj -ext WixUtilExtension -ext WixUIExtension`
+
+
+## Optional: Sonic Pi reference books
+
+Do you want to read the Sonic Pi tutorial as a whole, e.g. on your
+mobile reader or printed out on paper?
+
+During the Qt GUI build process, the directory `app/gui/qt/book` will
+be generated, containing each section of the integrated help system
+as a printable HTML reference book document.
+
+As an optional step after the build process, you can convert these HTML
+files to more convenient PDFs using the `./create-pdf` script.
+
+On your Linux or OS X system, you will need to have installed
+
+* [wkhtmltopdf](http://wkhtmltopdf.org)
+  
+  (Note: On Ubuntu, you will need the
+  [wkhtmltopdf binary with a patched Qt](http://wkhtmltopdf.org/downloads.html)
+  from their site, as Ubuntu's own binary package does not support all
+  features needed for a clean PDF conversion.)
 
 
 ## Unsupported development HTML Interface

--- a/app/gui/qt/create-pdf
+++ b/app/gui/qt/create-pdf
@@ -1,7 +1,12 @@
 #!/bin/bash
 
-mkdir pdf
-rm pdf/*
+command -v wkhtmltopdf >/dev/null 2>&1 || { echo "This script requires wkhtmltopdf, but it's not installed.  Aborting."; exit 1; }
+
+# On Ubuntu, install the binary from http://wkhtmltopdf.org/downloads.html
+# or --enable-internal-links will not work
+
+mkdir pdf 2> /dev/null
+rm pdf/* 2> /dev/null
 
 for F in book/*.html
 do

--- a/app/gui/qt/create-pdf
+++ b/app/gui/qt/create-pdf
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+mkdir pdf
+rm pdf/*
+
+for F in book/*.html
+do
+
+  PDF=${F/book\//pdf\/}
+  PDF=${PDF/\.html/\.pdf}
+  echo $PDF
+
+  wkhtmltopdf \
+    --enable-internal-links \
+    "$F" \
+    "$PDF"
+
+done

--- a/app/gui/qt/html/info.html
+++ b/app/gui/qt/html/info.html
@@ -2,7 +2,7 @@
 
 <body class="info">
   <center>
-    <img src=":/images/logo-smaller.png" height="268" width="328"/>
+    <img src="../images/logo-smaller.png" height="268" width="328"/>
     <p class="highlight">
       A Sound Synthesiser<br/>
       for Live Coding

--- a/app/gui/qt/html/startup.html
+++ b/app/gui/qt/html/startup.html
@@ -2,7 +2,7 @@
 
 <body class="info">
   <center>
-    <img src=":/images/logo-smaller.png" height="268" width="328"/>
+    <img src="../images/logo-smaller.png" height="268" width="328"/>
 
     <h1>Welcome!</h1>
 

--- a/app/gui/qt/theme/dark/doc-styles.css
+++ b/app/gui/qt/theme/dark/doc-styles.css
@@ -5,6 +5,10 @@ body {
   background-color: black;
 }
 
+ul.toc {
+  list-style-type: none;
+}
+
 a {
     color: #FBDE2D;
     text-decoration: none;

--- a/app/gui/qt/theme/light/doc-styles.css
+++ b/app/gui/qt/theme/light/doc-styles.css
@@ -5,6 +5,10 @@ body {
   background-color: white;
 }
 
+ul.toc {
+  list-style-type: none;
+}
+
 a {
   color: dodgerblue;
   text-decoration: none;

--- a/app/server/bin/qt-doc.rb
+++ b/app/server/bin/qt-doc.rb
@@ -131,7 +131,7 @@ make_tab = lambda do |name, doc_items, titleize=false, should_sort=true, with_ke
   book_body = book[/<body.*?>/]
   book.gsub!(/<\/?body.*?>/, '')
   book.gsub!(/<meta http-equiv.*?>/, '')
-  File.open("#{qt_gui_path}/book/Sonic Pi - #{name.capitalize} (#{lang}).html", 'w') do |f|
+  File.open("#{qt_gui_path}/book/Sonic Pi - #{name.capitalize}" + (lang != "en" ? " (#{lang})" : "") + ".html", 'w') do |f|
     f << "<link rel=\"stylesheet\" href=\"../theme/light/doc-styles.css\" type=\"text/css\"/>\n"
     f << "<meta http-equiv=\"Content-Type\" content=\"text/html; charset=utf-8\"/>\n\n"
     f << book_body << "\n"

--- a/app/server/bin/qt-doc.rb
+++ b/app/server/bin/qt-doc.rb
@@ -117,8 +117,7 @@ make_tab = lambda do |name, doc_items, titleize=false, should_sort=true, with_ke
       f << "#{doc}"
     end
 
-    book << "<hr/>\n"
-    book << "<a name=\"#{item_var}\"></a>\n"
+    book << "<hr id=\"#{item_var}\"/>\n"
     book << doc
 
   end

--- a/app/server/bin/qt-doc.rb
+++ b/app/server/bin/qt-doc.rb
@@ -56,7 +56,7 @@ make_tab = lambda do |name, doc_items, titleize=false, should_sort=true, with_ke
   layout = "#{name}Layout"
   tab_widget = "#{name}TabWidget"
   help_pages = "#{name}HelpPages"
-  
+
   docs << "\n"
   docs << "  // #{name} info\n"
 
@@ -64,7 +64,7 @@ make_tab = lambda do |name, doc_items, titleize=false, should_sort=true, with_ke
   doc_items = doc_items.sort if should_sort
   
   book = ""
-  toc = "<ul>\n"
+  toc = "<ul class=\"toc\">\n"
   toc_level = 0
 
   doc_items.each do |n, doc|
@@ -80,6 +80,17 @@ make_tab = lambda do |name, doc_items, titleize=false, should_sort=true, with_ke
     item_var = "#{name}_item_#{count+=1}"
     filename = "help/#{item_var}.html"
 
+    if title.start_with?("   ") then
+      if toc_level == 0 then
+        toc << "<ul class=\"toc\">\n"
+        toc_level += 1
+      end
+    else
+      if toc_level == 1 then
+        toc << "</ul>\n"
+        toc_level -= 1
+      end
+    end
     toc << "<li><a href=\"\##{item_var}\">#{title}</a></li>\n"
 
     docs << "    { "
@@ -106,6 +117,7 @@ make_tab = lambda do |name, doc_items, titleize=false, should_sort=true, with_ke
       f << "#{doc}"
     end
 
+    book << "<hr/>\n"
     book << "<a name=\"#{item_var}\"></a>\n"
     book << doc
 

--- a/app/server/bin/qt-doc.rb
+++ b/app/server/bin/qt-doc.rb
@@ -50,7 +50,7 @@ OptionParser.new do |opts|
 end.parse!
 
 # valid names: lang, synths, fx, samples, examples
-make_tab = lambda do |name, doc_items, titleize=false, should_sort=true, with_keyword=false, lang="en"|
+make_tab = lambda do |name, doc_items, titleize=false, should_sort=true, with_keyword=false, chapters=false, lang="en"|
   return if doc_items.empty?
   list_widget = "#{name}NameList"
   layout = "#{name}Layout"
@@ -118,6 +118,10 @@ make_tab = lambda do |name, doc_items, titleize=false, should_sort=true, with_ke
     end
 
     book << "<hr id=\"#{item_var}\"/>\n"
+    if chapters then
+      c = title[/\A\s*[0-9]+(\.[0-9]+)?/]
+      doc.gsub!(/(<h1.*?>)/, "\\1#{c} - ")
+    end
     book << doc
 
   end
@@ -125,8 +129,8 @@ make_tab = lambda do |name, doc_items, titleize=false, should_sort=true, with_ke
   toc << "</ul>\n"
 
   book_body = book[/<body.*?>/]
-  book = book.gsub(/<\/?body.*?>/, '')
-  book = book.gsub(/<meta http-equiv.*?>/, '')
+  book.gsub!(/<\/?body.*?>/, '')
+  book.gsub!(/<meta http-equiv.*?>/, '')
   File.open("#{qt_gui_path}/book/Sonic Pi - #{name.capitalize} (#{lang}).html", 'w') do |f|
     f << "<link rel=\"stylesheet\" href=\"../theme/light/doc-styles.css\" type=\"text/css\"/>\n"
     f << "<meta http-equiv=\"Content-Type\" content=\"text/html; charset=utf-8\"/>\n\n"
@@ -159,7 +163,7 @@ make_tutorial = lambda do |lang|
     tutorial_html_map[name] = html
   end
 
-  make_tab.call("tutorial", tutorial_html_map, false, false, false, lang)
+  make_tab.call("tutorial", tutorial_html_map, false, false, false, true, lang)
 end
 
 

--- a/app/server/bin/qt-doc.rb
+++ b/app/server/bin/qt-doc.rb
@@ -128,7 +128,7 @@ make_tab = lambda do |name, doc_items, titleize=false, should_sort=true, with_ke
   book_body = book[/<body.*?>/]
   book = book.gsub(/<\/?body.*?>/, '')
   book = book.gsub(/<meta http-equiv.*?>/, '')
-  File.open("#{qt_gui_path}/book/#{name.capitalize} (#{lang}).html", 'w') do |f|
+  File.open("#{qt_gui_path}/book/Sonic Pi - #{name.capitalize} (#{lang}).html", 'w') do |f|
     f << "<link rel=\"stylesheet\" href=\"../theme/light/doc-styles.css\" type=\"text/css\"/>\n"
     f << "<meta http-equiv=\"Content-Type\" content=\"text/html; charset=utf-8\"/>\n\n"
     f << book_body << "\n"

--- a/etc/doc/tutorial/de/01.2-Exploring-the-Interface.md
+++ b/etc/doc/tutorial/de/01.2-Exploring-the-Interface.md
@@ -5,7 +5,7 @@
 Sonic PI hat eine sehr einfache Oberfläche zum Coden von Musik. Schauen 
 wir uns das einmal genauer an.
 
-![Sonic Pi Interface](:/images/tutorial/GUI.png)
+![Sonic Pi Interface](../images/tutorial/GUI.png)
 
 
 * *A* - Wiedergabe-Steuerung

--- a/etc/doc/tutorial/de/02.1-Your-First-Beeps.md
+++ b/etc/doc/tutorial/de/02.1-Your-First-Beeps.md
@@ -94,7 +94,7 @@ Achte darauf, dass die Melodie nun schneller spielt. Probiere das
 selbst aus, ändere die Zeiten, verwende unterschiedliche Zeiten und 
 Noten.
 
-Versuche einmal Zwischennoten wie `play 52.3`[^1] und `play 52.63`. Es 
+Versuche einmal Zwischennoten wie `play 52.3`[^2] und `play 52.63`. Es 
 gibt überhaupt keinen Grund, nur ganze Zahlen zu verwenden. Spiel damit 
 herum und hab Spaß dabei.
 
@@ -103,7 +103,7 @@ herum und hab Spaß dabei.
 Für die unter Euch, die das Notenschreiben schon ein bisschen kennen 
 (keine Sorge, wenn nicht - Du brauchst es nicht unbedingt) - vielleicht 
 möchtet Ihr eine Melodie mit Notennamen anstelle von Zahlen schreiben, 
-also C oder F#[^2]. Auch das geht mit Sonic Pi. Du kannst folgendes 
+also C oder F#[^3]. Auch das geht mit Sonic Pi. Du kannst folgendes 
 machen:
 
 ```
@@ -135,12 +135,12 @@ Jetzt mach was *Verrücktes* und baue Deine eigenen Melodien.
 
 ## Anmerkungen des Übersetzers
 
-[^1]: Im deutschsprachigen Raum schreibt man solche Zahlen 
+[^2]: Im deutschsprachigen Raum schreibt man solche Zahlen 
     normalerweise mit Komma, also `52,3`. Der Computer versteht aber nur 
     Englisch, deshalb verwenden wir für Zahlen mit Nachkommastellen
     einen Punkt - also `52.3`.
 
-[^2]: Auch hier gibt es im deutschsprachigen Raum eine andere 
+[^3]: Auch hier gibt es im deutschsprachigen Raum eine andere 
     Schreibweise: Erhöhte oder erniedrigte Noten z.B. das F werden als
     Fis oder Fes bezeichnet. Im Englischen heisst das Fis "F sharp" oder
     auch "F#" und das Fes "F flat" oder auch "Fb".

--- a/etc/doc/tutorial/de/02.2-Synth-Params.md
+++ b/etc/doc/tutorial/de/02.2-Synth-Params.md
@@ -101,7 +101,7 @@ play 60, amp: 2
 Der Parameter `amp:` beeinflusst nur den Aufruf von `play`, mit dem er 
 unmittelbar zusammenhängt. Das heißt, in dem folgenden Beispiel wird 
 der erste Aufruf von `play` mit halber Lautstärke gespielt und der 
-zweite wieder mit der Standardlautstärke (1) [^1]:
+zweite wieder mit der Standardlautstärke (1) [^4]:
 
 ```
 play 60, amp: 0.5
@@ -152,6 +152,6 @@ play 60, pan: 0
 Jetzt leg' los und arbeite mit der Amplitude und dem Panning von Deinen 
 Klängen.
 
-[^1]: In Programmiersprachen nennt man einen Standardwert einen
+[^4]: In Programmiersprachen nennt man einen Standardwert einen
     `Default`. Genauer gesagt ist ein `Default`-Wert der Wert, der
     automatisch gesetzt wird, also die `Voreinstellung` im Programm.

--- a/etc/doc/tutorial/de/02.3-Switching-Synths.md
+++ b/etc/doc/tutorial/de/02.3-Switching-Synths.md
@@ -19,7 +19,7 @@ von Sonic Pi sind sehr wirkungsvoll und ausdrucksstark und man kann
 damit tolle Sachen machen. Als erstes lernen wir, wie man einen Synth 
 auswählt, den man benutzen möchte.
 
-## Brilliante Sägen und Prophets[^1]
+## Brilliante Sägen und Prophets[^5]
 
 Einen spaßigen Sound ergibt die *Sägezahn-Welle* - probieren wir es mal 
 aus:
@@ -93,7 +93,7 @@ Spiel mal ein bisschen herum indem Du *in Deinem Stück die Synths
 wechselst*. Kombiniere unterschiedliche Synths oder setze sie für 
 unterschiedliche Stellen in Deinem Stück ein.
 
-[^1]: Die Name "Sägezahn" (engl. saw) kommt von der Wellenform, die
+[^5]: Die Name "Sägezahn" (engl. saw) kommt von der Wellenform, die
     dieser Synthesizer produziert. Wenn man sich diesen Klang mit einem
     Oszilloskop anzeigen lässt, sieht er aus wie die Zähne einer Säge.
     Der Name "Prophet" kommt von einem Synthesizer, der Ende der 70er

--- a/etc/doc/tutorial/de/02.4-Durations-with-Envelopes.md
+++ b/etc/doc/tutorial/de/02.4-Durations-with-Envelopes.md
@@ -8,7 +8,7 @@ noch nicht die Dauer eines Klangs steuern (außer bei Samples, die wir
 strecken oder verdichten können).
 
 Um die *Dauer von Klängen* auf einfache aber weitgehende Weise zu 
-beeinflussen, bietet Sonic Pi das Prinzip der *ADSR-Hüllkurve* [^1]. 
+beeinflussen, bietet Sonic Pi das Prinzip der *ADSR-Hüllkurve* [^6]. 
 (Wir werden später sehen, was ADSR genau bedeutet). Eine Hüllkurve 
 (engl. Envelope) hat zwei nutzbringende Eigenschaften:
 
@@ -180,7 +180,7 @@ play 60, attack: 0.5, decay: 1, sustain_level: 0.4, sustain: 2, release: 0.5
 
 Jetzt weisst Du, wie Du Deine Klänge mit Hüllkurven verändern kannst...
 
-[^1]: Der englische Begriff für *Hüllkurve* heißt *Envelope*.
+[^6]: Der englische Begriff für *Hüllkurve* heißt *Envelope*.
 
     *ADSR* steht als Kurzform für die Begriffe *Attack*, *Decay*,
     *Sustain* und *Release*, die in diesem Kapitel erklärt werden.

--- a/etc/doc/tutorial/de/02.4-Durations-with-Envelopes.md
+++ b/etc/doc/tutorial/de/02.4-Durations-with-Envelopes.md
@@ -65,7 +65,7 @@ bis auf Null abzufallen. Das nennt man auch die *Release-Phase* und es
 ist ein linearer Übergang (d.h. eine gerade Linie). Die folgende 
 Abbildung zeigt, wie ein solcher Übergang aussieht:
 
-![release envelope](:/images/tutorial/env-release.png)
+![release envelope](../images/tutorial/env-release.png)
 
 Die senkrechte Linie ganz links im Bild zeigt, dass der Klang mit einer 
 Amplitude von 0 startet, jedoch sofort auf die volle Höhe geht (das ist 
@@ -102,7 +102,7 @@ play 60, attack: 0.7, release: 4
 
 Diese Hüllkurve mit einem kurzen Attack und langem Release sieht so aus:
 
-![attack release envelope](:/images/tutorial/env-attack-release.png)
+![attack release envelope](../images/tutorial/env-attack-release.png)
 
 Natürlich kann man die Dinge auch umdrehen. Versuche einen langen 
 Attack und einen kurzen Release:
@@ -111,7 +111,7 @@ Attack und einen kurzen Release:
 play 60, attack: 4, release: 0.7
 ```
 
-![long attack short release envelope](:/images/tutorial/env-long-attack-short-release.png)
+![long attack short release envelope](../images/tutorial/env-long-attack-short-release.png)
 
 Schließlich kannst Du auch einen kurzen Attack und Release für kürzere 
 Klänge verwenden.
@@ -120,7 +120,7 @@ Klänge verwenden.
 play 60, attack: 0.5, release: 0.5
 ```
 
-![short attack short release envelope](:/images/tutorial/env-short-attack-short-release.png)
+![short attack short release envelope](../images/tutorial/env-short-attack-short-release.png)
 
 ## Sustain-Zeit
 
@@ -133,7 +133,7 @@ Attack- und dem Release-Stadium.
 play 60, attack: 0.3, sustain: 1, release: 1
 ```
 
-![ASR envelope](:/images/tutorial/env-attack-sustain-release.png)
+![ASR envelope](../images/tutorial/env-attack-sustain-release.png)
 
 Die Sustain-Zeit kann man gut dafür gebrauchen, um wichtige Klänge in 
 einem Mix hervorzuheben, bevor möglicherweise der Release einsetzt. 
@@ -158,7 +158,7 @@ und Sustain also auch angegeben werden:
 play 60, attack: 0.1, attack_level: 1, decay: 0.2, sustain_level: 0.4, sustain: 1, release: 0.5
 ```
 
-![ADSR envelope](:/images/tutorial/env-attack-decay-sustain-release.png)
+![ADSR envelope](../images/tutorial/env-attack-decay-sustain-release.png)
 
 ## ADSR-Hüllkurven
 

--- a/etc/doc/tutorial/de/03.3-Stretching-Samples.md
+++ b/etc/doc/tutorial/de/03.3-Stretching-Samples.md
@@ -110,7 +110,7 @@ Zahlen dargestellt, die der Lautsprechermembran sagen, wo sie zu welchem
 Zeitpunkt sein soll. Wir können diese Zahlenliste nehmen und eine Kurve 
 zeichnen, die ungefähr so aussieht:
 
-![sample graph](:/images/tutorial/sample.png)
+![sample graph](../images/tutorial/sample.png)
 
 Vielleicht hast Du Bilder wie dieses schon einmal gesehen. Das ist die 
 *Kurvenform* eines Sample. Es ist bloß eine Kurve, die aus Zahlen 

--- a/etc/doc/tutorial/de/03.3-Stretching-Samples.md
+++ b/etc/doc/tutorial/de/03.3-Stretching-Samples.md
@@ -19,7 +19,7 @@ Membran zu jedem Zeitpunkt nach innen oder außen bewegen soll.
 Um einen Klang als Aufnahme wirklichkeitsgetreu wiederzugeben,
 muss das Sample je Sekunde viele tausend Zahlen speichern. Sonic Pi
 nimmt diese Zahlenreihe und gibt sie in der richtigen Samplerate
-[^1] an den Lautsprecher in Deinem Computer, so dass der Klang richtig
+[^7] an den Lautsprecher in Deinem Computer, so dass der Klang richtig
 wiedergegeben wird. Es macht aber auch Spaß, die Samplerate zu
 beeinflussen, denn das verändert den Klang.
 
@@ -27,7 +27,7 @@ beeinflussen, denn das verändert den Klang.
 
 Lass uns mit einem der Ambient-Klänge spielen: `ambi_choir`. Um diesen 
 mit Standard-Samplerate wiederzugeben, kannst Du dem `sample` das 
-Argument[^2] `rate:` übergeben:
+Argument[^8] `rate:` übergeben:
 
 ```
 sample :ambi_choir, rate: 1
@@ -156,9 +156,9 @@ auch doppelt so hoch klingen*; andererseits: *eine Halbierung der
 Samplerate wird auch die Frequenz halbieren*. Andere Sampleraten werden 
 dementsprechend die Tonhöhe beinflussen.
 
-[^1]: Die Samplerate heißt auch Samplingrate oder Abtastrate; *rate* 
+[^7]: Die Samplerate heißt auch Samplingrate oder Abtastrate; *rate* 
     steht für die Frequenz, mit der Sonic Pi die Zahlen, die im Sample
     den Klang darstellen, an die Lautsprechermembran sendet.
 
-[^2]: *Argument* ist ein anderer Begriff für *Parameter*; an dieser 
+[^8]: *Argument* ist ein anderer Begriff für *Parameter*; an dieser 
     Stelle bedeuten beide Begriffe dasselbe.

--- a/etc/doc/tutorial/de/04-Randomisation.md
+++ b/etc/doc/tutorial/de/04-Randomisation.md
@@ -1,6 +1,6 @@
 4 Randomisierung
 
-# Randomisierung[^1]
+# Randomisierung[^9]
 
 Zufallszahlen sind eine tolle Möglichkeit, Deine Musik interessant zu 
 gestalten. Sonic Pi bietet einige Funktionen, um Zufallsfaktoren in 
@@ -49,7 +49,7 @@ Code-Durchgangs liefern Aufrufe von Zufallsfunktionen auch zufällige
 Werte. Der nächste Durchgang wird jedoch genau die selbe Folge von 
 Zufallswerten liefern und also auch genau gleich klingen. Es ist, als 
 ob der Code immer zu demselben Zeitpunkt zurückspringt, wenn 
-der Ausführen-Button geklickt wird. Es ist der Groundhog-Day[^2] der 
+der Ausführen-Button geklickt wird. Es ist der Groundhog-Day[^10] der 
 musikalischen Synthese.
 
 ## Ruhelose Glocken
@@ -57,7 +57,7 @@ musikalischen Synthese.
 Ein großartiges Beispiel von Zufall in Aktion bietet der
 "Haunted Bells"-Code. Die "ruhelosen Glocken" spielen das Sample
 `:perc_bell` mit einer zufälligen Samplerate und Pausenzeit
-in einer Endlosschleife[^3] ab:
+in einer Endlosschleife[^11] ab:
 
 ```
 loop do
@@ -69,7 +69,7 @@ end
 ## Zufällig abschneiden (random cutoff)
 
 Ein anderes spannendes Beispiel für die Randomisierung ist das 
-zufällige Abschneiden[^4] eines Synth-Klangs. Der `:tb303`-Emulator ist 
+zufällige Abschneiden[^12] eines Synth-Klangs. Der `:tb303`-Emulator ist 
 ein guter Synth, um das auszuprobieren:
 
 ```
@@ -84,7 +84,7 @@ loop do
 ## Startpunkt der Zufallsfolge (random seed)
 
 Was aber, wenn Du die Abfolge von Zufallszahlen, die Sonic Pi Dir 
-liefert, nicht magst? Nun, mit `use_random_seed`[^5] kannst Du 
+liefert, nicht magst? Nun, mit `use_random_seed`[^13] kannst Du 
 unterschiedliche Startpunkte für diese Folge angeben. Der 
 Standard-Startpunkt ist die 0. Wähle also einfach einen anderen 
 Startpunkt und mache eine andere Zufallserfahrung!
@@ -147,7 +147,7 @@ aber ohne diese Werte selbst; man sagt auch *exklusiv* dieser beiden
 Werte. Das bedeutet, dass sowohl der minimale als auch der maximale 
 Wert niemals ausgegeben werden, immer nur eine Zahl *zwischen* diesen 
 beiden Werten. Die Zahl wird immer eine Gleitkommazahl (engl. *Float*) 
-sein, also keine ganze Zahl, sondern eine mit einem Komma[^6]. Einige 
+sein, also keine ganze Zahl, sondern eine mit einem Komma[^14]. Einige 
 Beispiele für Gleitkommazahlen, die der wiederholte Aufruf von 
 `rrand(20, 110)` ausgeben könnte:
 
@@ -158,7 +158,7 @@ Beispiele für Gleitkommazahlen, die der wiederholte Aufruf von
 ## rrand_i
 
 Manchmal braucht man eine zufällige aber ganze Zahl, eben keine 
-Gleitkommazahl. Hier rettet einen `rrand_i`[^7]. Es funktioniert 
+Gleitkommazahl. Hier rettet einen `rrand_i`[^15]. Es funktioniert 
 ähnlich `rrand`, kann jedoch auch den minimalen oder maximalen Wert, 
 den man übergeben hat, als mögliche Zufallszahl auswählen (man kann 
 auch sagen: es ist *inklusiv*, also nicht exklusive der Werte, mit 
@@ -214,28 +214,28 @@ folgenden Kapitel dieses Tutorials besprechen.
 Jetzt los, bring' Deinen Code mit ein paar Zufälligkeiten
 durcheinander!
 
-[^1]: Randomisierung (engl. *Randomisation*) bedeutet hier, dass man 
+[^9]: Randomisierung (engl. *Randomisation*) bedeutet hier, dass man 
     eine Auswahl von Zahlen zufällig gestaltet, also jedesmal eine
     andere Zahl bekommt.
 
-[^2]: Im Film *Groundhog Day* (deutsch: *Und täglich grüßt das
+[^10]: Im Film *Groundhog Day* (deutsch: *Und täglich grüßt das
     Murmeltier*) erlebt Bill Murray immer wieder denselben Tag.
 
-[^3]: Ein Schleife wird mit dem Ausdruck `loop` eingeleitet. Alles was
+[^11]: Ein Schleife wird mit dem Ausdruck `loop` eingeleitet. Alles was
     innerhalb der Schleife steht, wird so oft wie angegeben oder
     unendlich oft wiederholt. 
 
-[^4]: In Sonic Pi wird das das Abschneiden oder Verkürzen mit dem
+[^12]: In Sonic Pi wird das das Abschneiden oder Verkürzen mit dem
     Ausdruck `cutoff` bezeichnet.
 
-[^5]: Das englische Wort *Seed* bedeutet im Deutschen *Keim* oder
+[^13]: Das englische Wort *Seed* bedeutet im Deutschen *Keim* oder
     *Samen*; hier wird es als *Startpunkt* übersetzt. 
 
-[^6]: Die Sache wird noch dadurch ein wenig komplizierter, dass im
+[^14]: Die Sache wird noch dadurch ein wenig komplizierter, dass im
     Englischen anstelle eines Kommas ein Punkt steht. Die Gleitkommazahl
     `5,978` ist also im Englischen die *Floating Point Number* (kurz:
     *Float*) `5.978`. Alle Zahlen mit Kommawerten werden also in Sonic
     Pi mit einem Punkt dargestellt.
 
-[^7]: Das kleine *i* in `rrand_i` steht für englisch *Integer* als eine
+[^15]: Das kleine *i* in `rrand_i` steht für englisch *Integer* als eine
     ganze Zahl im Unterschied zu den Gleitkommazahlen.

--- a/etc/doc/tutorial/de/05.4-Threads.md
+++ b/etc/doc/tutorial/de/05.4-Threads.md
@@ -1,6 +1,6 @@
 5.4 Threads
 
-# Threads[^1]
+# Threads[^16]
 
 Mal angenommen, Du hast eine Killer-Basslinie und einen krassen Beat 
 gebaut. Wie kannst Du beides zur selben Zeit spielen lassen? Eine 
@@ -122,7 +122,7 @@ abläuft. Deshalb entstehen immer neue Soundschichten, wenn Du den
 Ausführen-Button wiederholt klickst. Weil die Abläufe Threads sind, 
 werden sie automatisch die Sounds verflechten.
 
-## Geltungsbereich[^2]
+## Geltungsbereich[^17]
 
 Wenn Du Dich besser mit Sonic Pi auskennst, wirst Du herausfinden, dass 
 Threads die wichtigsten Bausteine für Deine Musik sind. Eine 
@@ -256,14 +256,14 @@ Vielleicht erscheint Dir dieses Verhalten im Moment noch nicht sinnvoll
 - aber es wird sehr nützlich sein, wenn wir ins Live-Coding 
 einsteigen...
 
-[^1]: Im Deutschen bedeutet *thread* *Kette*, *Faden* oder *Strang*.
+[^16]: Im Deutschen bedeutet *thread* *Kette*, *Faden* oder *Strang*.
     Der *Thread* ist jedoch für Programmiersprachen eine so typische
     Idee, dass eine Übersetzung nur insoweit sinnvoll ist, dass Du Dir
     die Idee, die hinter diesem Begriff steht, besser merken kannst.
     Weil niemand beim Programmieren über eine Kette oder einen Faden
     spricht, werden wir hier nur den englischen Begriff benutzen.
 
-[^2]: *Scope* bedeutet ins Deutsche übersetzt soviel wie
+[^17]: *Scope* bedeutet ins Deutsche übersetzt soviel wie
     *Geltungsbereich*. Für die Zukunft ist es aber ganz gut, sich den
     englischen Begriff zu merken, da auch dieser im Programmierbereich
     häufig vorkommt.

--- a/etc/doc/tutorial/de/07.3-Sliding-Parameters.md
+++ b/etc/doc/tutorial/de/07.3-Sliding-Parameters.md
@@ -45,7 +45,7 @@ Oder ihn mit einer längeren Slide-Dauer verlangsamen.
 Jeder steuerbare Parameter hat einen entsprechenden `_slide`-Parameter,
 mit dem Du spielen kannst.
 
-# Gleiten ist klebrig
+## Gleiten ist klebrig
 
 Nachdem Du einmal einen `_slide` Parameter auf einem laufenden Synth 
 angegeben hast, bleibt er bestehen und wird jedesmal genutzt, wenn Du 
@@ -53,7 +53,7 @@ den entsprechenden Parameter steuerst. Um das Gleiten auszuschalten,
 musst Du den `_slide` Wert vor dem nächsten `control`-Aufruf auf 0 
 setzen.
 
-# Gleitende Effekt-Parameter
+## Gleitende Effekt-Parameter
 
 Genauso ist es möglich, Effekt-Parameter gleiten zu lassen:
 

--- a/etc/doc/tutorial/en/01.2-Exploring-the-Interface.md
+++ b/etc/doc/tutorial/en/01.2-Exploring-the-Interface.md
@@ -5,7 +5,7 @@
 Sonic Pi has a very simple interface for coding music. Let's spend a
 little time exploring it.
 
-![Sonic Pi Interface](:/images/tutorial/GUI.png)
+![Sonic Pi Interface](../images/tutorial/GUI.png)
 
 
 * *A* - Play Controls

--- a/etc/doc/tutorial/en/02.4-Durations-with-Envelopes.md
+++ b/etc/doc/tutorial/en/02.4-Durations-with-Envelopes.md
@@ -60,7 +60,7 @@ full amplitude (typically a value of 1) to zero amplitude. This is
 called the *release phase* and it's a linear transition (i.e. a straight
 line). The following diagram illustrates this transition:
 
-![release envelope](:/images/tutorial/env-release.png)
+![release envelope](../images/tutorial/env-release.png)
 
 The vertical line at the far left of the diagram shows that the sound
 starts at 0 amplitude, but goes up to full amplitude immediately (this
@@ -95,7 +95,7 @@ play 60, attack: 0.7, release: 4
 This short attack and long release envelope is illustrated in the
 following diagram:
 
-![attack release envelope](:/images/tutorial/env-attack-release.png)
+![attack release envelope](../images/tutorial/env-attack-release.png)
 
 Of course, you may switch things around. Try a long attack and a short
 release:
@@ -104,7 +104,7 @@ release:
 play 60, attack: 4, release: 0.7
 ```
 
-![long attack short release envelope](:/images/tutorial/env-long-attack-short-release.png)
+![long attack short release envelope](../images/tutorial/env-long-attack-short-release.png)
 
 Finally, you can also have both short attack and release times for
 shorter sounds.
@@ -113,7 +113,7 @@ shorter sounds.
 play 60, attack: 0.5, release: 0.5
 ```
 
-![short attack short release envelope](:/images/tutorial/env-short-attack-short-release.png)
+![short attack short release envelope](../images/tutorial/env-short-attack-short-release.png)
 
 ## Sustain Time
 
@@ -125,7 +125,7 @@ maintained at full amplitude between the attack and release phases.
 play 60, attack: 0.3, sustain: 1, release: 1
 ```
 
-![ASR envelope](:/images/tutorial/env-attack-sustain-release.png)
+![ASR envelope](../images/tutorial/env-attack-sustain-release.png)
 
 The sustain time is useful for important sounds you wish to give full
 presence in the mix before entering an optional release phase. Of
@@ -149,7 +149,7 @@ effect:
 play 60, attack: 0.1, attack_level: 1, decay: 0.2, sustain_level: 0.4, sustain: 1, release: 0.5
 ```
 
-![ADSR envelope](:/images/tutorial/env-attack-decay-sustain-release.png)
+![ADSR envelope](../images/tutorial/env-attack-decay-sustain-release.png)
 
 ## ADSR Envelopes
 

--- a/etc/doc/tutorial/en/03.3-Stretching-Samples.md
+++ b/etc/doc/tutorial/en/03.3-Stretching-Samples.md
@@ -100,7 +100,7 @@ representing where the speaker should be through time. We can take this
 list of numbers and use it to draw a graph which would look similar to
 this:
 
-![sample graph](:/images/tutorial/sample.png)
+![sample graph](../images/tutorial/sample.png)
 
 You might have seen pictures like this before. It's called the
 *waveform* of a sample. It's just a graph of numbers. Typically a

--- a/etc/doc/tutorial/en/07.3-Sliding-Parameters.md
+++ b/etc/doc/tutorial/en/07.3-Sliding-Parameters.md
@@ -43,14 +43,14 @@ time.
 Every parameter that can be controlled has a corresponding `_slide`
 parameter for you to play with.
 
-# Sliding is sticky
+## Sliding is sticky
 
 Once you've set a `_slide` parameter on a running synth, it will be
 remembered and used every time you slide the corresponding
 parameter. To stop sliding you must set the `_slide` value to 0 before
 the next `control` call.
 
-# Sliding FX Parameters
+## Sliding FX Parameters
 
 It is also possible to slide FX parameters:
 


### PR DESCRIPTION
This patch modifies `qt-doc.rb` to create a subfolder `book/` during build, which then contains multipage HTML files of each doc pane.

Calling `./create-pdf` after build, these HTML files will then be converted to PDFs using [wkhtmltopdf](http://wkhtmltopdf.org), which also adds a nice PDF table-of-contents to the document.

It's still a bit hacky, but it works and the result is fairly nice.

Please have a look.