### PR TITLE
Remove the frame completely.

### DIFF
--- a/app/gui/qt/mainwindow.cpp
+++ b/app/gui/qt/mainwindow.cpp
@@ -1274,7 +1274,7 @@ void MainWindow::changeTheme(){
 
     for(int i=0; i < tabs->count(); i++){
       SonicPiScintilla *ws = (SonicPiScintilla *)tabs->widget(i);
-      ws->setFrameShape(QFrame::Panel);
+      ws->setFrameShape(QFrame::NoFrame);
     }
 
     foreach(QTextBrowser* pane, infoPanes) {


### PR DESCRIPTION
Fixes OS X overlapping tabs.

Might need a macro wrapping if it messes with RP.

Further work on #520