### PR TITLE
set loaded_workspaces false initially, true when we replace buffers

### DIFF
--- a/app/gui/qt/mainwindow.h
+++ b/app/gui/qt/mainwindow.h
@@ -74,6 +74,7 @@ public:
     SonicPiServer *sonicPiServer;
     enum {UDP=0, TCP=1};
     QCheckBox *dark_mode;
+    bool loaded_workspaces = false;
 
 protected:
     void closeEvent(QCloseEvent *event);
@@ -188,7 +189,6 @@ private:
     bool startup_error_reported;
     bool is_recording;
     bool show_rec_icon_a;
-    bool loaded_workspaces;
     QTimer *rec_flash_timer;
 
 #ifdef Q_OS_MAC

--- a/app/gui/qt/oschandler.cpp
+++ b/app/gui/qt/oschandler.cpp
@@ -152,6 +152,7 @@ void OscHandler::oscMessage(std::vector<char> buffer){
         if (msg->arg().popStr(id).popStr(content).popInt32(line).popInt32(index).popInt32(line_number).isOkNoMoreArgs()) {
 
           QMetaObject::invokeMethod( window, "replaceBuffer", Qt::QueuedConnection, Q_ARG(QString, QString::fromStdString(id)), Q_ARG(QString, QString::fromStdString(content)), Q_ARG(int, line), Q_ARG(int, index), Q_ARG(int, line_number));
+	  window->loaded_workspaces = true; // it's now safe to save the buffers
         } else {
           std::cout << "[GUI] - error: unhandled OSC msg /replace-buffer: "<< std::endl;
         }


### PR DESCRIPTION
loaded_workspaces is intended to keep the GUI from trying to save buffers that have never properly been loaded (the effect of which is #loading... in every workspace).  I haven't identified the chain of failures that can cause this to happen, but loaded_workspaces is there to prevent it.  False at startup, set to true when we receive a valid /replace-buffer message.

Oh, and it's currently uninitialized, so something needs to happen to it even if it isn't this.