### PR TITLE
Add current line indication

### DIFF
--- a/app/gui/qt/mainwindow.cpp
+++ b/app/gui/qt/mainwindow.cpp
@@ -855,6 +855,23 @@ void MainWindow::replaceLines(QString id, QString content, int start_line, int f
   ws->setCursorPosition(point_line, point_index);
 }
 
+void MainWindow::setLineMarker(QString mixedArgs) {
+  std::string workspaceName = "workspace_" + number_name(mixedArgs.split(":")[0].toInt());
+  int lineNumber            = mixedArgs.split(":")[1].toInt();
+
+  SonicPiScintilla* ws = filenameToWorkspace(workspaceName);
+  ws->setLineMarker(lineNumber - 1);
+}
+
+void MainWindow::clearLineMarkers() {
+  for(int i = 0; i < workspace_max; i++) {
+    Message msg("/load-buffer");
+    std::string s = "workspace_" + number_name(i);
+    SonicPiScintilla* ws = filenameToWorkspace(s);
+    ws->clearLineMarkers();
+  }
+}
+
 std::string MainWindow::number_name(int i) {
   switch(i) {
   case 0: return "zero";
@@ -1127,6 +1144,7 @@ void MainWindow::mixerStereoMode()
 void MainWindow::stopCode()
 {
   stopRunningSynths();
+  clearLineMarkers();
   statusBar()->showMessage(tr("Stopping..."), 2000);
 }
 

--- a/app/gui/qt/mainwindow.h
+++ b/app/gui/qt/mainwindow.h
@@ -128,6 +128,8 @@ private slots:
     void startupError(QString msg);
     void replaceBuffer(QString id, QString content, int line, int index, int first_line);
     void replaceLines(QString id, QString content, int first_line, int finish_line, int point_line, int point_index);
+    void setLineMarker(QString mixedArgs);
+    void clearLineMarkers();
     void tabNext();
     void tabPrev();
     void helpContext();

--- a/app/gui/qt/oschandler.cpp
+++ b/app/gui/qt/oschandler.cpp
@@ -89,8 +89,7 @@ void OscHandler::oscMessage(std::vector<char> buffer){
             QMetaObject::invokeMethod( out, "setTextBackgroundColor", Qt::QueuedConnection, Q_ARG(QColor, QColor("darkorange")));
             break;
           case 7:
-            QMetaObject::invokeMethod( out, "setTextColor", Qt::QueuedConnection, Q_ARG(QColor, QColor("white")));
-            QMetaObject::invokeMethod( out, "setTextBackgroundColor", Qt::QueuedConnection, Q_ARG(QColor, QColor("darkorange")));
+            QMetaObject::invokeMethod( window, "setLineMarker", Qt::QueuedConnection, Q_ARG(QString, QString::fromUtf8(s.c_str())));
             break;
           default:
             QMetaObject::invokeMethod( out, "setTextColor", Qt::QueuedConnection, Q_ARG(QColor, QColor("green")));

--- a/app/gui/qt/oschandler.cpp
+++ b/app/gui/qt/oschandler.cpp
@@ -88,6 +88,10 @@ void OscHandler::oscMessage(std::vector<char> buffer){
             QMetaObject::invokeMethod( out, "setTextColor", Qt::QueuedConnection, Q_ARG(QColor, QColor("white")));
             QMetaObject::invokeMethod( out, "setTextBackgroundColor", Qt::QueuedConnection, Q_ARG(QColor, QColor("darkorange")));
             break;
+          case 7:
+            QMetaObject::invokeMethod( out, "setTextColor", Qt::QueuedConnection, Q_ARG(QColor, QColor("white")));
+            QMetaObject::invokeMethod( out, "setTextBackgroundColor", Qt::QueuedConnection, Q_ARG(QColor, QColor("darkorange")));
+            break;
           default:
             QMetaObject::invokeMethod( out, "setTextColor", Qt::QueuedConnection, Q_ARG(QColor, QColor("green")));
           }

--- a/app/gui/qt/sonicpiscintilla.cpp
+++ b/app/gui/qt/sonicpiscintilla.cpp
@@ -132,6 +132,9 @@ SonicPiScintilla::SonicPiScintilla(SonicPiLexer *lexer, SonicPiTheme *theme)
   setText("#loading...");
   setLexer((QsciLexer *)lexer);
 
+  markerDefine(RightArrow, 8);
+  setMarkerBackgroundColor("deeppink", 8);
+
   setAutoCompletionThreshold(1);
   setAutoCompletionSource(SonicPiScintilla::AcsAPIs);
   setAutoCompletionCaseSensitivity(false);
@@ -177,6 +180,15 @@ void SonicPiScintilla::showLineNumbers(){
   setMarginLineNumbers(0, true);
   setMarginWidth(0, "1000");
   SendScintilla(SCI_SHOWLINES);
+}
+
+void SonicPiScintilla::setLineMarker(int lineNumber){
+  markerDeleteAll(-1);
+  markerAdd(lineNumber, 8);
+}
+
+void SonicPiScintilla::clearLineMarkers(){
+  markerDeleteAll(-1);
 }
 
 void SonicPiScintilla::addOtherKeyBinding(QSettings &qs, int cmd, int key)

--- a/app/gui/qt/sonicpiscintilla.h
+++ b/app/gui/qt/sonicpiscintilla.h
@@ -39,6 +39,8 @@ class SonicPiScintilla : public QsciScintilla
     void copyClear();
     void hideLineNumbers();
     void showLineNumbers();
+    void setLineMarker(int lineNumber);
+    void clearLineMarkers();
     void replaceLine(int lineNumber, QString newLine);
     void replaceLines(int lineStart, int lineFinish, QString newLines);
     void forwardLines(int numLines);

--- a/app/server/sonicpi/lib/sonicpi/mods/sound.rb
+++ b/app/server/sonicpi/lib/sonicpi/mods/sound.rb
@@ -843,15 +843,6 @@ synth :dsaw, note: 50 # Play note 50 of the :dsaw synth with a release of 5"]
 
 
 
-       def __send_current_line_to_gui
-         workspace_line = caller.grep(/Workspace/).first
-         if not workspace_line.nil?
-           workspace_no, active_line_no = workspace_line.match(/Workspace (\d+):(\d+)/)[1..2]
-           __delayed_current_line_info("#{workspace_no}:#{active_line_no}")
-         end
-       end
-
-
        def play(n, *args)
          ensure_good_timing!
          __send_current_line_to_gui
@@ -2133,6 +2124,7 @@ puts sample_duration(:loop_amen) #=> 1
 
 
        def sample(path, *args_a_or_h)
+         __send_current_line_to_gui
          return if path == nil
          ensure_good_timing!
          buf_info = load_sample(path)

--- a/app/server/sonicpi/lib/sonicpi/mods/sound.rb
+++ b/app/server/sonicpi/lib/sonicpi/mods/sound.rb
@@ -843,9 +843,19 @@ synth :dsaw, note: 50 # Play note 50 of the :dsaw synth with a release of 5"]
 
 
 
+       def __send_current_line_to_gui
+         workspace_line = caller.grep(/Workspace/).first
+         if not workspace_line.nil?
+           workspace_no, active_line_no = workspace_line.match(/Workspace (\d+):(\d+)/)[1..2]
+           __delayed_current_line_info("#{workspace_no}:#{active_line_no}")
+         end
+       end
+
 
        def play(n, *args)
          ensure_good_timing!
+         __send_current_line_to_gui
+
          case n
          when Array, SonicPi::Core::RingVector
            return play_chord(n, *args)

--- a/app/server/sonicpi/lib/sonicpi/spider.rb
+++ b/app/server/sonicpi/lib/sonicpi/spider.rb
@@ -228,6 +228,10 @@ module SonicPi
       __enqueue_multi_message(2, s)
     end
 
+    def __delayed_current_line_info(s)
+      __enqueue_multi_message(7, s)
+    end
+
     def __schedule_delayed_blocks_and_messages!
       delayed_messages = Thread.current.thread_variable_get :sonic_pi_spider_delayed_messages
       delayed_blocks = Thread.current.thread_variable_get(:sonic_pi_spider_delayed_blocks) || []

--- a/app/server/sonicpi/lib/sonicpi/util.rb
+++ b/app/server/sonicpi/lib/sonicpi/util.rb
@@ -263,5 +263,14 @@ module SonicPi
     end
 
 
+    def __send_current_line_to_gui
+      workspace_line = caller.grep(/Workspace/).first
+      if not workspace_line.nil?
+        workspace_no, active_line_no = workspace_line.match(/Workspace (\d+):(\d+)/)[1..2]
+        __delayed_current_line_info("#{workspace_no}:#{active_line_no}")
+      end
+    end
+
+
   end
 end


### PR DESCRIPTION
This adds a line marker into the GUI for `play` and `sample` commands.
It probably needs it's own osc endpoint. Also need to address what to do
with multiple threads in a workspace (probably using thread_id somehow)
and what to do with error messages in terms of marking the line of the
error.