### PR TITLE
Tick supports string names like live_loop

### DIFF
--- a/app/server/core.rb
+++ b/app/server/core.rb
@@ -69,6 +69,7 @@ module SonicPi
       end
 
       def self.tick(k = :___sonic_pi_default_tick_key___, *args)
+        k = (k && k.is_a?(String)) ? k.to_sym : k
         if k.is_a? Symbol
           opts = args.first || {}
         else
@@ -92,6 +93,7 @@ module SonicPi
       end
 
       def self.look(k = :___sonic_pi_default_tick_key___, *args)
+        k = (k && k.is_a?(String)) ? k.to_sym : k
         if k.is_a? Symbol
           opts = args.first || {}
         else

--- a/app/server/sonicpi/test/test_tick.rb
+++ b/app/server/sonicpi/test/test_tick.rb
@@ -118,6 +118,15 @@ module SonicPi
       assert_equal(0, tick(:baz))
     end
 
+    def test_string_keyed_ticks
+      tick_reset_all
+      assert_equal(0, tick("foo"))
+      assert_equal(1, tick(:foo))
+
+      assert_equal(1, hook("foo"))
+      assert_equal(1, hook(:foo))
+    end
+
     def test_incremented_ticks
       tick_reset_all
 

--- a/app/server/sonicpi/test/test_tick.rb
+++ b/app/server/sonicpi/test/test_tick.rb
@@ -123,8 +123,8 @@ module SonicPi
       assert_equal(0, tick("foo"))
       assert_equal(1, tick(:foo))
 
-      assert_equal(1, hook("foo"))
-      assert_equal(1, hook(:foo))
+      assert_equal(1, look("foo"))
+      assert_equal(1, look(:foo))
     end
 
     def test_incremented_ticks


### PR DESCRIPTION
```ruby
(ring 1).tick("a") #fails
(ring 1).hook("a") #fails
```
With patch a string is a valid param just like a symbol for `tick` and `hook`

```ruby
(ring 1).tick("a") 
(ring 1).hook(:a) == (ring 1).hook("a")
```