### PR TITLE
Checking note info on nil returns C4. Correcting

### DIFF
--- a/app/server/sonicpi/lib/sonicpi/mods/sound.rb
+++ b/app/server/sonicpi/lib/sonicpi/mods/sound.rb
@@ -2345,6 +2345,7 @@ end"
 
 
        def note_info(n, *args)
+         raise Exception.new("note_info argument must be a valid note. Got nil.") if(n.nil?)
          args_h = resolve_synth_opts_hash_or_array(args)
          octave = args_h[:octave]
          SonicPi::Note.new(SonicPi::Note.resolve_note_name(n, octave), octave)


### PR DESCRIPTION
This had me stumped for a while. I kept playing a C4 randomly and had no idea why. I'm mapping notes to samples.

Currently.

```ruby
note_info(nil) => C4
```

With patch:

```ruby
note_info(nil) => Error: note_info argument must be a valid note.
```

While defaults make sense for notes, I think a default is confusing when asking for note_info.