### PR TITLE
Bug: Ensure scale degrees <= 0 are rejected.

### DIFF
--- a/app/server/sonicpi/lib/sonicpi/scale.rb
+++ b/app/server/sonicpi/lib/sonicpi/scale.rb
@@ -111,7 +111,9 @@ module SonicPi
                :xii  => 11}
 
     def self.resolve_degree_index(degree)
-      if idx = DEGREES[degree]
+      if degree.is_a?(Numeric) && degree <= 0
+        raise InvalidDegreeError, "Invalid scale degree #{degree.inspect}, if scale degree is a number it must be greater than 0"
+      elsif idx = DEGREES[degree]
         return idx
       elsif degree.is_a? Numeric
         return degree - 1

--- a/app/server/sonicpi/test/test_scale.rb
+++ b/app/server/sonicpi/test/test_scale.rb
@@ -14,6 +14,7 @@
 require 'test/unit'
 require_relative "../../core"
 require_relative "../lib/sonicpi/scale"
+require_relative "../lib/sonicpi/note"
 
 module SonicPi
   class NoteTester < Test::Unit::TestCase
@@ -48,6 +49,12 @@ module SonicPi
     def test_degree_invalid
       assert_raise Scale::InvalidDegreeError do
         Scale.resolve_degree(:joe, :A3, :major)
+      end
+    end
+
+    def test_too_low_degree
+      assert_raise Scale::InvalidDegreeError do
+        Scale.resolve_degree(-1, :A3, :major)
       end
     end
 


### PR DESCRIPTION
## What

Negative scale degrees return very strange results.

## Example

```ruby
degree(-1, :F3, :major) #is actually saying => degree(11, :F3, :major)
```
This happens as -1 is Rubys way of saying the end of a list so the degree lookup pulls the largest degree which is 11. 