### PR TITLE
Document need to install cmake to build on windows (See #563)

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -174,6 +174,7 @@ ln -s `which ruby` app/server/native/osx/ruby/bin/ruby
 
 ### Server extensions
 
+* Download & Install [CMake](http://www.cmake.org/download/), ensuring it is added to your PATH
 * Download & Install [Ruby 2.1.x](http://rubyinstaller.org/downloads/)
 * [Download](http://rubyinstaller.org/downloads/) & [Install](https://github.com/oneclick/rubyinstaller/wiki/Development-Kit) Ruby Development Kit
 * Compile native extensions: 


### PR DESCRIPTION
Before I installed cmake and put it in my path, following the current build instructions for server extensions gave:

    ERROR: CMake is required to build Rugged.