### PR TITLE
Update mainwindow.h

### DIFF
--- a/app/gui/qt/mainwindow.h
+++ b/app/gui/qt/mainwindow.h
@@ -279,9 +279,7 @@ private:
     QList<QListWidget *> helpLists;
     QHash<QString, help_entry> helpKeywords;
     std::streambuf *coutbuf;
-#if defined(Q_OS_WIN) || defined(Q_OS_MAC)
     std::ofstream stdlog;
-#endif
 
     SonicPiAPIs *autocomplete;
     QString sample_path, log_path;


### PR DESCRIPTION
remove restriction on std::ofstream stdlog; so the definition apples to ALL platforms and not just MAC )S and WIN. stdlog is now referenced in function setupLogPathAndRedirectStdOut() which is used by all platforms.
closes #649