### PR TITLE
prototype for Play Example button

### DIFF
--- a/app/gui/qt/mainwindow.cpp
+++ b/app/gui/qt/mainwindow.cpp
@@ -379,8 +379,11 @@ MainWindow::MainWindow(QApplication &app, bool i18n, QSplashScreen* splash)
   policy.setHorizontalStretch(QSizePolicy::Maximum);
   docPane->setSizePolicy(policy);
   docPane->setMinimumHeight(200);
+  docPane->setOpenLinks(false); // send to anchorClicked instead
   docPane->setOpenExternalLinks(true);
   docPane->setStyleSheet(defaultTextBrowserStyle);
+  connect(docPane, SIGNAL(anchorClicked(QUrl)), this,
+	  SLOT(docAnchorClicked(QUrl)));
 
   QShortcut *up = new QShortcut(ctrlKey('p'), docPane);
   up->setContext(Qt::WidgetShortcut);
@@ -462,6 +465,10 @@ MainWindow::MainWindow(QApplication &app, bool i18n, QSplashScreen* splash)
   updateLogVisibility();
   updateDarkMode();
   requestVersion();
+}
+
+void MainWindow::docAnchorClicked(const QUrl &url) {
+  std::cout << "anchor clicked: " << url.toString().toStdString() << std::endl;
 }
 
 void MainWindow::changeTab(int id){

--- a/app/gui/qt/mainwindow.h
+++ b/app/gui/qt/mainwindow.h
@@ -144,6 +144,7 @@ private slots:
     void helpScrollDown();
     void docScrollUp();
     void docScrollDown();
+    void docAnchorClicked(const QUrl &);
     void helpClosed(bool visible);
     void updateFullScreenMode();
     void toggleFullScreenMode();

--- a/app/server/bin/qt-doc.rb
+++ b/app/server/bin/qt-doc.rb
@@ -186,7 +186,7 @@ example_dirs.each do |ex_dir|
     html << "<body class=\"example\">\n"
     html << '<h1>'
     html << "# #{bname}"
-    html << '</h1>'
+    html << ' <a href="#play" class="play">Play Example</a></h1>'
     html << "<p><pre><code>\n"
 
     html << "#{lines.join("\n")}\n\n</code></pre></p>\n"


### PR DESCRIPTION
- [x] add Qt mechanism to trigger on links
Result is "anchor clicked: qrc:///help/examples_item_101.html#play"
- [ ] CSS styling for links (button style?)
- [ ] figure out what to do with play/preview buttons
- [ ] do it
- [ ] unbreak external links (they call the same slot now)