### PR TITLE
BREAKING CHANGE: Change behaviour of invert_chord

### DIFF
--- a/app/server/sonicpi/lib/sonicpi/mods/sound.rb
+++ b/app/server/sonicpi/lib/sonicpi/mods/sound.rb
@@ -2723,9 +2723,9 @@ sleep 1
         raise "Inversion shift value must be a number, got #{shift.inspect}" unless shift.is_a?(Numeric)
         raise "Notes must be a list of notes, got #{notes.inspect}" unless (notes.is_a?(SonicPi::Core::RingVector) || notes.is_a?(Array))
         if(shift > 0)
-          invert_chord(notes[1..-1] + [notes[0]+12], shift-1)
+          invert_chord(notes.to_a[1..-1] + [notes.to_a[0]+12], shift-1)
         elsif(shift < 0)
-          invert_chord(notes[1..-1] + [notes[0]-12], shift+1)
+          invert_chord((notes.to_a[0..-2] + [notes.to_a[-1]-12]).sort, shift+1)
         else
           notes.ring
         end

--- a/app/server/sonicpi/test/test_invert_chord.rb
+++ b/app/server/sonicpi/test/test_invert_chord.rb
@@ -1,0 +1,44 @@
+#--
+# This file is part of Sonic Pi: http://sonic-pi.net
+# Full project source: https://github.com/samaaron/sonic-pi
+# License: https://github.com/samaaron/sonic-pi/blob/master/LICENSE.md
+#
+# Copyright 2013, 2014, 2015 by Sam Aaron (http://sam.aaron.name).
+# All rights reserved.
+#
+# Permission is granted for use, copying, modification, and
+# distribution of modified versions of this work as long as this
+# notice is included.
+#++
+
+require 'test/unit'
+require_relative "../../core"
+require_relative "../lib/sonicpi/chord"
+require_relative "../lib/sonicpi/mods/sound"
+
+module SonicPi
+  module Mods
+    module Sound
+      module_function :invert_chord
+      module_function :chord
+    end
+  end
+  class InvertChordTester < Test::Unit::TestCase
+
+    def test_inversion_of_basic_major
+      assert_equal(Mods::Sound.invert_chord(Chord.new(:C4, :major), 0), [60, 64, 67])
+      assert_equal(Mods::Sound.invert_chord(Chord.new(:C4, :major), 1), [64, 67, 72])
+      assert_equal(Mods::Sound.invert_chord(Chord.new(:C4, :major), 2), [67, 72, 76])
+
+      # what should happen the other way...
+      assert_equal(Mods::Sound.invert_chord(Chord.new(:C4, :major), -1).sort, [55, 60, 64])
+      assert_equal(Mods::Sound.invert_chord(Chord.new(:C4, :major), -2).sort, [52, 55, 60])
+      assert_equal(Mods::Sound.invert_chord(Chord.new(:C4, :major), -3).sort, [48, 52, 55])
+
+      # edge case
+      assert_equal(Mods::Sound.invert_chord(Mods::Sound.chord(:C4, "1"), 1), [72])
+      assert_equal(Mods::Sound.invert_chord(Mods::Sound.chord(:C4, "1"), -1), [48])
+    end
+
+  end
+end


### PR DESCRIPTION
This commit does two things:

  a) Guards against an error calling rings with out of range index
ranges
  b) Makes a breaking change to the behaviour of negative inversions

Prior to this, the implementation of `invert_chord`, when given an
argument of say -1 for the no. of inversions would do this:

```
puts invert_chord([60, 64, 67], -1) # => [64,67,48]
puts invert_chord([60, 64, 67], -2) # => [67,48,52]
```

Musically speaking, it makes more sense to move the top voice down an
octave first, so that the chord is voiced as closely together as
possible i.e. `[:g3, :c4, :e4]` - this voicing is skipped over by the
previous implementation.

See added tests for more details. Fixes #635 