### PR TITLE
Add `play_nested_pattern` method

### DIFF
--- a/app/server/sonicpi/lib/sonicpi/mods/sound.rb
+++ b/app/server/sonicpi/lib/sonicpi/mods/sound.rb
@@ -1109,6 +1109,118 @@ play 44"]
 
 
 
+          def play_nested_pattern(pattern, *args)
+            args_h = resolve_synth_opts_hash_or_array(args)
+            args_h[:mode] = :notes unless args_h[:mode]
+            args_h[:beat_length] = 1 unless args_h[:beat_length]
+
+            if [:notes, :samples, :lambdas].none? {|x| x == args_h[:mode] }
+              raise "Unrecognized :mode for play_nested_pattern. Must be one of [:notes, :samples, :lambdas]"
+            end
+
+            get_nested_beat(pattern).each do |mul, val|
+              with_bpm_mul mul do
+                case args_h[:mode]
+                when :notes
+                  play val
+                when :samples
+                  sample val
+                when :lambdas
+                  val.call
+                end
+                sleep args_h[:beat_length] # this is scaled by the bpm mul
+              end
+            end
+          end
+          doc name:          :play_nested_pattern,
+              introduced:    Version.new(2,8,0),
+              summary:       "Play a nested pattern of notes, samples or lambdas",
+              doc:           "Using a nested array to represent rhythm, you can use this method to structure melodies, beats and other rhythmic patterns.
+
+A nested array is just an array that contains other arrays inside it e.g. `[1, [2, 2], 1, 1]`. Here we can see three elements at the top level of the array (the ones) and two elements which are nested two arrays deep (the twos).
+
+We can use this nesting to play through the contents of the array at faster and faster rates. Things nested at the second level will play twice as fast, things nested at the third level will play four times as fast and so on.
+
+It might help to think about music notation - if the level 1 is a crotchet/quarter note, then level two is like a quaver/eigth note and so on, all the way down to hemidemisemiquavers and beyond.
+
+If you want to use a triplet rhythm you can use a special notation to spread across multiple beats e.g. `[:d5, :cs5, {over: 2, val: [:c5,:c5,:c5]}, :b4, :bb4, :a4]`. This spaces the three `:c5` notes over the space of two normal notes which gives you a quaver triplet rhythm. You might recognize this from Bizet's opera Carmen.",
+              args:          [[:pattern]],
+              opts:          {beat_length: "Length of a single (top level) beat - defaults to 1",
+                              mode: "One of `:notes`, `:samples` or `:lambdas` depending on what is in your nested pattern. See examples below."},
+              accepts_block: false,
+              examples:      ["
+    play_nested_pattern [:c, [:d, :f], :e, :c]
+                              # Same as:
+                              #   play :c
+                              #   sleep 1
+                              #   play :d
+                              #   sleep 0.5
+                              #   play :f
+                              #   sleep 0.5
+                              #   play :e
+                              #   sleep 1
+                              #   play :c
+                              #   sleep 1
+    ","
+    # We can also use sample names with `:samples` as the mode option
+    rock_you_pattern =
+      [:bd_haus, :elec_snare, [:bd_haus, :bd_haus], :elec_snare]
+
+    play_nested_pattern(rock_you_pattern, mode: :samples) # Same as:
+                              #   sample :bd_haus
+                              #   sleep 1
+                              #   sample :elec_snare
+                              #   sleep 1
+                              #   sample :bd_haus
+                              #   sleep 0.5
+                              #   sample :bd_haus
+                              #   sleep 0.5
+                              #   sample :elec_snare
+                              #   sleep 1
+    ","
+    # We can also use lambdas with `:lambdas` as the mode option
+    rand_notes = lambda {
+      notes = scale(:c3, :minor_pentatonic, num_octaves: 3)
+      play_pattern_timed(notes.shuffle.take(3), 0.33)
+    }
+    random_pattern = [rand_notes, rand_notes, [rand_notes, rand_notes], rand_notes]
+    loop do
+      # because we already sleep inside play_pattern_timed,
+      # we set the :beath_length to zero
+      play_nested_pattern(random_pattern, mode: :lambdas, beat_length: 0)
+    end
+    ","
+    # Triplets and cross rhythms
+    # By using a hash with :over and :val keys, we can spread, for example, three notes over the space of two
+    # This creates the equivalent of triplets in music
+    carmen_pattern = [:d5, :cs5, {over: 2, val: [:c5,:c5,:c5]}, :b4, :bb4, :a4]
+    # This spaces the three `:c5` notes (our `:val`) over the space of two (our `:over`) normal notes which gives you a quaver triplet rhythm.
+    # You might recognize this from Bizet's opera Carmen.
+    play_nested_pattern(carmen_pattern, beat_length: 0.5)
+    ",
+    "
+    # Advanced version - a randomised drum beat
+    live_loop :beatz do
+      use_bpm 120
+
+      bd = lambda { sample :bd_haus, rate: 2}
+      sn = lambda { sample :drum_snare_hard, rate: 4 }
+      hh = lambda { sample :drum_cymbal_closed, rate: rrand(3,4)}
+      rest = lambda { nil }
+
+      drumbeat = [bd, sn, [bd, [bd,bd]], [sn, hh]]
+      drumbreak = [[bd,bd,bd,bd], {over: 2, val: [sn,sn,sn]}, [rest,hh,rest,hh]]
+
+      3.times do
+        play_nested_pattern(drumbeat, mode: :lambdas)
+      end
+      # We use .shuffle to get a different break each time
+      play_nested_pattern(drumbreak.shuffle, mode: :lambdas)
+    end"]
+
+
+
+
       def play_chord(notes, *args)
         ensure_good_timing!
 
@@ -3635,6 +3747,53 @@ If you wish your synth to work with Sonic Pi's automatic stereo sound infrastruc
 
       def set_current_synth(name)
         Thread.current.thread_variable_set(:sonic_pi_mod_sound_current_synth_name, name)
+      end
+
+      def nested_beat(el, beat_length=nil)
+        if el.kind_of? Hash and el.keys == [:over, :val]
+          # We have a triple syntax hash
+          no_of_beats = calculate_number_of_beats(el[:val])
+          if beat_length.nil?
+            # Top level beats are always 1 in length
+            beat_length = 1.0
+          else
+            # This is different for triplet rhythms
+            beat_length = (beat_length*el[:over].to_f)/no_of_beats
+          end
+
+          el[:val].map {|x| nested_beat(x, beat_length)}
+        elsif el.kind_of? Array
+          no_of_beats = calculate_number_of_beats(el)
+          if beat_length.nil?
+            # Top level beats are always 1 in length
+            beat_length = 1.0
+          else
+            beat_length = beat_length/no_of_beats
+          end
+
+          el.map {|x| nested_beat(x, beat_length) }
+        else
+          {level: beat_length, step: el}
+        end
+      end
+
+      def calculate_number_of_beats(arr)
+        # Calculate the number of beats a pattern
+        # takes up, accounting for the size of the
+        # triplet hash :over param
+        arr.reduce(0.0) {|acc,x|
+          if(x.kind_of?(Hash) and x.keys == [:over, :val])
+            acc + x[:over]
+          else
+           acc + 1
+          end
+        }
+      end
+
+      def get_nested_beat(pattern)
+        output = nested_beat(pattern).flatten.map do |step|
+          [(1.0/step[:level]), step[:step]]
+        end
       end
 
       def __freesound_path(id)

--- a/app/server/sonicpi/test/setup_test.rb
+++ b/app/server/sonicpi/test/setup_test.rb
@@ -1,0 +1,3 @@
+# core.rb sets up the $LOAD_PATH for vendored gems
+require_relative "../../core"
+require 'test/unit'

--- a/app/server/sonicpi/test/test_chance.rb
+++ b/app/server/sonicpi/test/test_chance.rb
@@ -11,8 +11,7 @@
 # notice is included.
 #++
 
-require 'test/unit'
-require_relative "../../core"
+require_relative "./setup_test"
 require_relative "../lib/sonicpi/spiderapi"
 
 module SonicPi

--- a/app/server/sonicpi/test/test_chord.rb
+++ b/app/server/sonicpi/test/test_chord.rb
@@ -11,8 +11,7 @@
 # notice is included.
 #++
 
-require 'test/unit'
-require_relative "../../core"
+require_relative "./setup_test"
 require_relative "../lib/sonicpi/chord"
 
 module SonicPi

--- a/app/server/sonicpi/test/test_invert_chord.rb
+++ b/app/server/sonicpi/test/test_invert_chord.rb
@@ -11,8 +11,7 @@
 # notice is included.
 #++
 
-require 'test/unit'
-require_relative "../../core"
+require_relative "./setup_test"
 require_relative "../lib/sonicpi/chord"
 require_relative "../lib/sonicpi/mods/sound"
 

--- a/app/server/sonicpi/test/test_note.rb
+++ b/app/server/sonicpi/test/test_note.rb
@@ -11,8 +11,7 @@
 # notice is included.
 #++
 
-require 'test/unit'
-require_relative "../../core"
+require_relative "./setup_test"
 require_relative "../lib/sonicpi/note"
 
 module SonicPi

--- a/app/server/sonicpi/test/test_note_info.rb
+++ b/app/server/sonicpi/test/test_note_info.rb
@@ -11,8 +11,7 @@
 # notice is included.
 #++
 
-require 'test/unit'
-require_relative "../../core"
+require_relative "./setup_test"
 require_relative "../lib/sonicpi/mods/sound"
 
 module SonicPi

--- a/app/server/sonicpi/test/test_note_range.rb
+++ b/app/server/sonicpi/test/test_note_range.rb
@@ -11,8 +11,7 @@
 # notice is included.
 #++
 
-require 'test/unit'
-require_relative "../../core"
+require_relative "./setup_test"
 require_relative "../lib/sonicpi/mods/sound"
 
 module SonicPi

--- a/app/server/sonicpi/test/test_osc.rb
+++ b/app/server/sonicpi/test/test_osc.rb
@@ -10,9 +10,7 @@
 # distribution of modified versions of this work as long as this
 # notice is included.
 #++
-require_relative "../../core"
-
-require 'test/unit'
+require_relative "./setup_test"
 require 'osc-ruby'
 
 require_relative "../lib/sonicpi/oscencode"

--- a/app/server/sonicpi/test/test_play_nested_pattern.rb
+++ b/app/server/sonicpi/test/test_play_nested_pattern.rb
@@ -11,9 +11,9 @@
 # notice is included.
 #++
 
-require 'test/unit'
+require_relative "./setup_test"
 require 'mocha/setup'
-require_relative "../../core"
+
 require_relative "../lib/sonicpi/mods/sound"
 require_relative "../lib/sonicpi/spiderapi"
 

--- a/app/server/sonicpi/test/test_play_nested_pattern.rb
+++ b/app/server/sonicpi/test/test_play_nested_pattern.rb
@@ -19,7 +19,7 @@ require_relative "../lib/sonicpi/spiderapi"
 
 module SonicPi
   class PlayNestedPatternTester < Test::Unit::TestCase
-    setup do
+    def setup
       @mock_sound = Object.new
       @mock_sound.extend(Mods::Sound)
       @mock_sound.extend(SpiderAPI)

--- a/app/server/sonicpi/test/test_play_nested_pattern.rb
+++ b/app/server/sonicpi/test/test_play_nested_pattern.rb
@@ -1,0 +1,112 @@
+#--
+# This file is part of Sonic Pi: http://sonic-pi.net
+# Full project source: https://github.com/samaaron/sonic-pi
+# License: https://github.com/samaaron/sonic-pi/blob/master/LICENSE.md
+#
+# Copyright 2013, 2014, 2015 by Sam Aaron (http://sam.aaron.name).
+# All rights reserved.
+#
+# Permission is granted for use, copying, modification, and
+# distribution of modified versions of this work as long as this
+# notice is included.
+#++
+
+require 'test/unit'
+require 'mocha/setup'
+require_relative "../../core"
+require_relative "../lib/sonicpi/mods/sound"
+require_relative "../lib/sonicpi/spiderapi"
+
+module SonicPi
+  class PlayNestedPatternTester < Test::Unit::TestCase
+    setup do
+      @mock_sound = Object.new
+      @mock_sound.extend(Mods::Sound)
+      @mock_sound.extend(SpiderAPI)
+      @mock_sound.stubs(:sleep) # avoid loading Spider class
+    end
+
+    def test_nested_pattern_basic
+      # We're testing that the maths for
+      # nested patterns works, so we can
+      # ignore sleep and play for now
+      @mock_sound.stubs(:play)
+
+      test_pattern = [:c, [:d, :f], :e, :c]
+      bpm_muls     = [ 1,   2,  2,   1,  1]
+
+      @mock_sound.expects(:with_bpm_mul).at_most(5).with do |bpm_mul|
+        bpm_mul == bpm_muls.shift
+      end
+      @mock_sound.play_nested_pattern(test_pattern)
+    end
+
+    def test_nested_pattern_triplet
+      # We're testing that the maths for
+      # nested patterns works, so we can
+      # ignore sleep and play for now
+      @mock_sound.stubs(:play)
+
+      test_pattern = [:c, {over: 2, val: [:d,  :f,  :a]}, :c]
+      bpm_muls     = [ 1,                  1.5, 1.5, 1.5,  1]
+
+      @mock_sound.expects(:with_bpm_mul).times(5).with do |bpm_mul|
+        bpm_mul == bpm_muls.shift
+      end
+      @mock_sound.play_nested_pattern(test_pattern)
+    end
+
+    def test_nested_pattern_modes
+      @mock_sound.expects(:play).with(:c).times(4)
+      @mock_sound.play_nested_pattern([:c, :c, :c, :c], mode: :notes)
+
+      @mock_sound.expects(:sample).with(:loop_amen).times(2)
+      @mock_sound.play_nested_pattern([:loop_amen, [:loop_amen]], mode: :samples)
+
+      test_lambda = lambda { "Doing stuff" }
+      test_lambda.expects(:call).times(2)
+      @mock_sound.play_nested_pattern([test_lambda, [test_lambda]], mode: :lambdas)
+    end
+
+    def test_nested_pattern_beat_length
+      @mock_sound.expects(:play).with(:c).times(4)
+      @mock_sound.expects(:sleep).with(0.5).times(4)
+      @mock_sound.play_nested_pattern([:c, [:c, :c], :c], beat_length: 0.5)
+    end
+
+    def test_nested_pattern_edge_cases
+      @mock_sound.expects(:play).with(:c).never
+      @mock_sound.play_nested_pattern([])
+    end
+
+    def test_nested_pattern_with_hashes
+      test_hash = {note: :c, release: 0.1}
+      @mock_sound.expects(:play).with(test_hash).times(4)
+      @mock_sound.play_nested_pattern([test_hash, [test_hash, test_hash], test_hash])
+    end
+
+    def test_nested_pattern_crazy_nesting
+      # We're testing that the maths for
+      # nested patterns works, so we can
+      # ignore sleep and play for now
+      @mock_sound.stubs(:play)
+
+      # This is a 4 beat bar
+      # because there are 4 top level beats
+      # NB the over: 2 counts as two beats
+      test_pattern = [:c, {over: 2, val: [:d,  :f,  :a]}, [:c, [:c, :c, [:c, :c, :c, {over: 2, val: [:c, :c, :c]}]]]]
+      bpm_muls     = [ 1,                  1.5, 1.5, 1.5,   2,   6,  6,  30, 30, 30,                 45, 45, 45]
+
+      # To prove test is correct
+      assert_equal(test_pattern.length + 1, 4) # account for the :over beat
+      # The bpm muls add up to 4 beats
+      assert_equal(bpm_muls.reduce(0) {|acc, el| acc + (1.0/el) }.round(6), 4)
+
+      bpm_muls.each do |mul|
+        @mock_sound.expects(:with_bpm_mul).with(mul)
+      end
+
+      @mock_sound.play_nested_pattern(test_pattern)
+    end
+  end
+end

--- a/app/server/sonicpi/test/test_preparser.rb
+++ b/app/server/sonicpi/test/test_preparser.rb
@@ -11,8 +11,7 @@
 # notice is included.
 #++
 
-require 'test/unit'
-require_relative "../../core"
+require_relative "./setup_test"
 require_relative "../lib/sonicpi/preparser"
 
 module SonicPi

--- a/app/server/sonicpi/test/test_promise.rb
+++ b/app/server/sonicpi/test/test_promise.rb
@@ -11,8 +11,7 @@
 # notice is included.
 #++
 
-require 'test/unit'
-require_relative "../../core"
+require_relative "./setup_test"
 require_relative "../lib/sonicpi/promise"
 
 module SonicPi

--- a/app/server/sonicpi/test/test_random.rb
+++ b/app/server/sonicpi/test/test_random.rb
@@ -1,5 +1,4 @@
-require 'test/unit'
-require_relative "../../core"
+require_relative "./setup_test"
 require_relative "../lib/sonicpi/spiderapi"
 
 module SonicPi

--- a/app/server/sonicpi/test/test_ring.rb
+++ b/app/server/sonicpi/test/test_ring.rb
@@ -11,8 +11,7 @@
 # notice is included.
 #++
 
-require 'test/unit'
-require_relative "../../core"
+require_relative "./setup_test"
 require_relative "../lib/sonicpi/spiderapi"
 
 module SonicPi

--- a/app/server/sonicpi/test/test_sample_duration.rb
+++ b/app/server/sonicpi/test/test_sample_duration.rb
@@ -11,8 +11,7 @@
 # notice is included.
 #++
 
-require 'test/unit'
-require_relative "../../core"
+require_relative "./setup_test"
 require_relative "../lib/sonicpi/mods/sound"
 
 module SonicPi

--- a/app/server/sonicpi/test/test_scale.rb
+++ b/app/server/sonicpi/test/test_scale.rb
@@ -11,8 +11,7 @@
 # notice is included.
 #++
 
-require 'test/unit'
-require_relative "../../core"
+require_relative "./setup_test"
 require_relative "../lib/sonicpi/scale"
 require_relative "../lib/sonicpi/note"
 

--- a/app/server/sonicpi/test/test_spark.rb
+++ b/app/server/sonicpi/test/test_spark.rb
@@ -12,8 +12,7 @@
 # notice is included.
 #++
 
-require 'test/unit'
-require_relative "../../core"
+require_relative "./setup_test"
 require_relative "../lib/sonicpi/spiderapi"
 
 module SonicPi

--- a/app/server/sonicpi/test/test_spiderapi.rb
+++ b/app/server/sonicpi/test/test_spiderapi.rb
@@ -11,8 +11,7 @@
 # notice is included.
 #++
 
-require 'test/unit'
-require_relative "../../core"
+require_relative "./setup_test"
 require_relative "../lib/sonicpi/spiderapi"
 
 module SonicPi

--- a/app/server/sonicpi/test/test_tick.rb
+++ b/app/server/sonicpi/test/test_tick.rb
@@ -11,8 +11,7 @@
 # notice is included.
 #++
 
-require 'test/unit'
-require_relative "../../core"
+require_relative "./setup_test"
 require_relative "../lib/sonicpi/spiderapi"
 
 module SonicPi

--- a/app/server/sonicpi/test/test_tuning.rb
+++ b/app/server/sonicpi/test/test_tuning.rb
@@ -11,8 +11,7 @@
 # notice is included.
 #++
 
-require 'test/unit'
-require_relative "../../core"
+require_relative "./setup_test"
 require_relative "../lib/sonicpi/note"
 require_relative "../lib/sonicpi/tuning"
 

--- a/app/server/sonicpi/test/test_util.rb
+++ b/app/server/sonicpi/test/test_util.rb
@@ -11,8 +11,7 @@
 # notice is included.
 #++
 
-require 'test/unit'
-require_relative "../../core"
+require_relative "./setup_test"
 require_relative "../lib/sonicpi/util"
 
 module SonicPi

--- a/app/server/sonicpi/test/test_version.rb
+++ b/app/server/sonicpi/test/test_version.rb
@@ -11,8 +11,7 @@
 # notice is included.
 #++
 
-require 'test/unit'
-require_relative "../../core"
+require_relative "./setup_test"
 require_relative "../lib/sonicpi/note"
 
 module SonicPi


### PR DESCRIPTION
This commit adds a method to support his kind of nested array notation
used in other live coding music environments like Overtone, Tidal and ixi lang

```
[bass, clap, [bass, bass], clap]
```

That's the intro to "We will rock you" by Queen, as represented by this
nested array notation. The array has four top level elements and these
all occupy the same amount of time - lets call it 1 second.

The third element in the array is itself an array. It has two elements
which need to fit into the 1 second that it has from the top level,
which means it needs to play each of them in 0.5 seconds.

The `play_nested_pattern` works with notes, samples and lambdas and has
a special "triplet" syntax for notating rhythms that spread across
multiple beats e.g.

```
play_nested_pattern([:d5, :cs5, {over: 2, val: [:c5,:c5,:c5]}, :b4, :bb4, :a4])
```

See the docstrings and tests for more details.