### PR TITLE
Add __run_tests method for running tests from GUI

### DIFF
--- a/app/server/sonicpi/lib/sonicpi/spider.rb
+++ b/app/server/sonicpi/lib/sonicpi/spider.rb
@@ -346,6 +346,8 @@ module SonicPi
 
     def __extract_line_of_error(e)
       trace = e.backtrace
+      return -1 unless trace
+
       l = trace.find {|line| line.include?("in __spider_eval")}
       unless l
         return -1
@@ -681,6 +683,18 @@ module SonicPi
 
     def __enable_update_checker
       @settings.del(:no_update_checking)
+    end
+
+    def __run_tests
+      path_to_test_folder = File.join(server_path, "sonicpi", "test")
+      test_paths = Dir.glob(File.join(path_to_test_folder, "test_*.rb"))
+      __info "Running tests, hold tight..."
+      #output = []
+      test_paths.each do |test_path|
+        __info "Running #{File.basename(test_path)}"
+        __info `#{ruby_path} #{test_path} 2>&1`
+      end
+      #__error(Exception.new(output.join("\n")))
     end
 
     def __spider_eval(code, info={})

--- a/app/server/sonicpi/lib/sonicpi/util.rb
+++ b/app/server/sonicpi/lib/sonicpi/util.rb
@@ -199,6 +199,16 @@ module SonicPi
       File.absolute_path("#{server_path}/native/#{os}")
     end
 
+    def ruby_path
+      # For running tests
+      case os
+      when :windows
+        File.join(native_path, "bin", "ruby.exe")
+      when :osx, :raspberry, :linux
+        File.join(native_path, "ruby", "bin", "ruby")
+      end
+    end
+
     def user_settings_path
       File.absolute_path("#{home_dir}/settings.json")
     end


### PR DESCRIPTION
Having a workspace with the following contents

```
__run_tests
```

and hitting the "Run" button will run the test suite and report the
results back the the GUI.

The formatting is not ideal at the moment. Without TCP a concatenated output
is too long for the OSC protocol we for comms between the Ruby server
and the GUI.

The comments have been left in as a suggestion for an output format. The
guard against `Exception` objects with `nil` backtraces is to facilitate
the option of displaying the test results in the GUIs error window.

NB some tests fail because they are being run directly with Ruby instead
of Rake. This means that files have to be required explicitly which is a
fix up job for a future commit.