### PR TITLE
Performance tweak for osc decoding

### DIFF
--- a/app/server/sonicpi/lib/sonicpi/oscdecode.rb
+++ b/app/server/sonicpi/lib/sonicpi/oscdecode.rb
@@ -34,7 +34,7 @@ module SonicPi
 
       # Get OSC address e.g. /foo
       orig_idx = idx
-      idx += 1 while m[idx] != string_terminator
+      idx = m.index(string_terminator, orig_idx)
       address, idx =  m[orig_idx...idx], idx + 1 + ((4 - ((idx + 1) % 4)) % 4)
 
       sep, idx = m[idx], idx + 1
@@ -44,7 +44,7 @@ module SonicPi
 
         # Get type tags
         orig_idx = idx
-        idx += 1 while m[idx] != string_terminator
+        idx = m.index(string_terminator, orig_idx)
         tags, idx = m[orig_idx...idx], idx + 1 + ((4 - ((idx + 1) % 4)) % 4)
 
         tags.each_char do |t|
@@ -79,7 +79,7 @@ module SonicPi
           when "s"
             # string
             orig_idx = idx
-            idx += 1 while m[idx] != string_terminator
+            idx = m.index(string_terminator, orig_idx)
             arg, idx =  m[orig_idx...idx], idx + 1 + ((4 - ((idx + 1) % 4)) % 4)
           when "d"
             # double64

--- a/app/server/sonicpi/test/performance/test_osc_perf.rb
+++ b/app/server/sonicpi/test/performance/test_osc_perf.rb
@@ -1,0 +1,16 @@
+require_relative '../setup_test.rb'
+require_relative "../../lib/sonicpi/oscdecode"
+require 'benchmark/ips'
+require 'osc-ruby'
+
+samosc = SonicPi::OscDecode.new
+oscruby = OSC::OSCPacket
+
+test_message = OSC::Message.new("/foo", ["beans", 1, 2.0]).encode
+
+Benchmark.ips do |bencher|
+  bencher.report("samsosc") { samosc.decode_single_message(test_message) }
+  bencher.report("oscruby") { oscruby.messages_from_network(test_message) }
+
+  bencher.compare
+end


### PR DESCRIPTION
Before

```
Calculating -------------------------------------
             samsosc    15.105k i/100ms
             oscruby     4.702k i/100ms
-------------------------------------------------
             samsosc    202.655k (± 3.5%) i/s -      1.012M
             oscruby     51.812k (± 4.3%) i/s -    258.610k
```

After

```
Calculating -------------------------------------
             samsosc    19.156k i/100ms
             oscruby     4.627k i/100ms
-------------------------------------------------
             samsosc    294.909k (± 3.9%) i/s -      1.475M
             oscruby     51.510k (± 3.9%) i/s -    259.112k
```

:metal:

To run you'll need to `gem install benchmark-ips`