### PR TITLE
Fix for bad character encoding in one Polish markdown file

### DIFF
--- a/etc/doc/tutorial/pl/03.2-Sample-Params.md
+++ b/etc/doc/tutorial/pl/03.2-Sample-Params.md
@@ -2,26 +2,26 @@
 
 # Parametry Sampli: Amp i Pan
 
-Tak samo jak w przypadku Syntezatorów, mo¿emy ³atwo kontrolowaæ
-nasze d¼wiêki za pomoc± parametrów. Sample wspieraj± takie sam
-mechanizm parametrów. Przyjrzyjmy siê ponownie naszym kolegom
+Tak samo jak w przypadku SyntezatorÃ³w, moÅ¼emy Å‚atwo kontrolowaÄ‡
+nasze dÅºwiÄ™ki za pomocÄ… parametrÃ³w. Sample wspierajÄ… takie sam
+mechanizm parametrÃ³w. Przyjrzyjmy siÄ™ ponownie naszym kolegom
 `amp:` i `pan:`.
 
-## Zmiana g³o¶no¶ci sampli
+## Zmiana gÅ‚oÅ›noÅ›ci sampli
 
-Mo¿esz zmieniaæ g³o¶no¶æ sampli dok³adnie w taki sam sposób
-jakiego u¿ywa³e¶ dla syntezatorów:
+MoÅ¼esz zmieniaÄ‡ gÅ‚oÅ›noÅ›Ä‡ sampli dokÅ‚adnie w taki sam sposÃ³b
+jakiego uÅ¼ywaÅ‚eÅ› dla syntezatorÃ³w:
 
 ```
 sample :ambi_lunar_land, amp: 0.5
 ```
 
-## Przesuwanie sampli na ró¿ne kana³y
+## Przesuwanie sampli na rÃ³Å¼ne kanaÅ‚y
 
-Mo¿emy równie¿ u¿ywaæ parametru `pan:` dla sampli. Na przyk³ad,
-oto jak mo¿emy zagraæ breakbeat amen aby brzmia³ tylko w lewym
-g³o¶niku, a potem w po³owie czasu, ¿eby zacz±³ graæ te¿ w prawym
-glo¶niku:
+MoÅ¼emy rÃ³wnieÅ¼ uÅ¼ywaÄ‡ parametru `pan:` dla sampli. Na przykÅ‚ad,
+oto jak moÅ¼emy zagraÄ‡ breakbeat amen aby brzmiaÅ‚ tylko w lewym
+gÅ‚oÅ›niku, a potem w poÅ‚owie czasu, Å¼eby zaczÄ…Å‚ graÄ‡ teÅ¼ w prawym
+gloÅ›niku:
 
 ```
 sample :loop_amen, pan: -1
@@ -29,9 +29,9 @@ sleep 0.877
 sample :loop_amen, pan: 1
 ```
 
-Zauwa¿, ¿e liczba 0.877 jest po³ow± czasu trwania pêtli `loop_amen`
-wyra¿on± w sekundach.
+ZauwaÅ¼, Å¼e liczba 0.877 jest poÅ‚owÄ… czasu trwania pÄ™tli `loop_amen`
+wyraÅ¼onÄ… w sekundach.
 
-Na koniec nale¿y zauwa¿yæ, ¿e je¶li ustawisz pewne warto¶ci domy¶lne
-syntezatorów za pomoc± parametru `use_synth_defaults` (zostanie on
-omówiony pó¼niej), to bêd± one ignorowane przez polecenie `sample`.
+Na koniec naleÅ¼y zauwaÅ¼yÄ‡, Å¼e jeÅ›li ustawisz pewne wartoÅ›ci domyÅ›lne
+syntezatorÃ³w za pomocÄ… parametru `use_synth_defaults` (zostanie on
+omÃ³wiony pÃ³Åºniej), to bÄ™dÄ… one ignorowane przez polecenie `sample`.


### PR DESCRIPTION
A character encoding adventure for you all...

Once upon a time, @JosephWilk noticed that the latest Sonic Pi wasn't
building on master. It was howling at him with the message

```
+ ../../server/bin/qt-doc.rb -o ruby_help.h
/home/foo/sonic-pi/app/server/sonicpi/lib/sonicpi/markdown_converter.rb:10:in `gsub!': invalid byte sequence in UTF-8 (ArgumentError)
        from /Users/xavierriley/Projects/sonic-pi/app/server/sonicpi/lib/sonicpi/markdown_converter.rb:10:in `convert'
        from ../../server/bin/qt-doc.rb:169:in `block (2 levels) in <main>'
        from ../../server/bin/qt-doc.rb:161:in `each'
        from ../../server/bin/qt-doc.rb:161:in `block in <main>'
        from ../../server/bin/qt-doc.rb:219:in `call'
        from ../../server/bin/qt-doc.rb:219:in `block in <main>'
        from ../../server/bin/qt-doc.rb:217:in `each'
        from ../../server/bin/qt-doc.rb:217:in `<main>'
```

He reached for his trusty sword, which he called `git bisect`, and managed to narrow down the error to this commit: [https://github.com/samaaron/sonic-pi/commit/866e5f7cefc6e994576f04c40db63bd5d352fd62](https://github.com/samaaron/sonic-pi/commit/866e5f7cefc6e994576f04c40db63bd5d352fd62)

I heard his rallying battle cry and stepped in with `iconv` and my noble steed Google.

From battles past, I suspected my old foe "character encoding on Windows".
As we knew we were dealing with Polish text, a quick Google suggested
they use the "Windows-1250" encoding. I ran that through `iconv` to
check:

```
$ cat etc/doc/tutorial/pl/03.2-Sample-Params.md | iconv -f 'Windows-1250' -t 'UTF-8'
3.2 Parametry Sampli

Tak samo jak w przypadku Syntezatorów, możemy łatwo kontrolować
nasze dĽwięki za pomoc± parametrów. Sample wspieraj± takie sam
mechanizm parametrów. Przyjrzyjmy się ponownie naszym kolegom
`amp:` i `pan:`.

Możesz zmieniać gło¶no¶ć sampli dokładnie w taki sam sposób
jakiego używałe¶ dla syntezatorów:

sample :ambi_lunar_land, amp: 0.5

Możemy również używać parametru `pan:` dla sampli. Na przykład,
oto jak możemy zagrać breakbeat amen aby brzmiał tylko w lewym
gło¶niku, a potem w połowie czasu, żeby zacz±ł grać też w prawym
glo¶niku:

sample :loop_amen, pan: -1
sleep 0.877
sample :loop_amen, pan: 1

Zauważ, że liczba 0.877 jest połow± czasu trwania pętli `loop_amen`
wyrażon± w sekundach.

Na koniec należy zauważyć, że je¶li ustawisz pewne warto¶ci domy¶lne
syntezatorów za pomoc± parametru `use_synth_defaults` (zostanie on
omówiony póĽniej), to będ± one ignorowane przez polecenie `sample`.
```

The output looked pretty good except for the ¶ and ± characters. I know
Polish is a bit weird sometimes, but "gło¶no¶ć" is taking is a bit
far...

After googling for "gło¶no¶ć" I found a page where Google has indexed it
as that. Was I going crazy? Visiting the page I saw the real word was
displayed as "głośność" - much more like it.

So now I knew that "ś" characters were being translated to "¶" I could
narrow things down. Another Google lead me to a Polish forum post
complaining of this same problem
[http://forum.joomla.pl/showthread.php%3F1367-Zamiast-%25C5%259B-to-%25C2%25B6-itp-!&prev=search](http://forum.joomla.pl/showthread.php%3F1367-Zamiast-%25C5%259B-to-%25C2%25B6-itp-!&prev=search)

They suggested the right encoding was `ISO-8859-2`. Let's see:

```
$ cat etc/doc/tutorial/pl/03.2-Sample-Params.md | iconv -f 'ISO-8859-2' -t 'UTF-8'
3.2 Parametry Sampli

Tak samo jak w przypadku Syntezatorów, możemy łatwo kontrolować
nasze dźwięki za pomocą parametrów. Sample wspierają takie sam
mechanizm parametrów. Przyjrzyjmy się ponownie naszym kolegom
`amp:` i `pan:`.

Możesz zmieniać głośność sampli dokładnie w taki sam sposób
jakiego używałeś dla syntezatorów:

sample :ambi_lunar_land, amp: 0.5

Możemy również używać parametru `pan:` dla sampli. Na przykład,
oto jak możemy zagrać breakbeat amen aby brzmiał tylko w lewym
głośniku, a potem w połowie czasu, żeby zaczął grać też w prawym
glośniku:

sample :loop_amen, pan: -1
sleep 0.877
sample :loop_amen, pan: 1

Zauważ, że liczba 0.877 jest połową czasu trwania pętli `loop_amen`
wyrażoną w sekundach.

Na koniec należy zauważyć, że jeśli ustawisz pewne wartości domyślne
syntezatorów za pomocą parametru `use_synth_defaults` (zostanie on
omówiony później), to będą one ignorowane przez polecenie `sample`.
```

:metal:

Looks like it was just this one file as, with this PR, we can now build on master once more. Thus concludeth my epic tale. Fixes #690