### PR TITLE
Make sample method accept hashes and lambdas

### DIFF
--- a/app/server/sonicpi/lib/sonicpi/lang/sound.rb
+++ b/app/server/sonicpi/lib/sonicpi/lang/sound.rb
@@ -2313,6 +2313,24 @@ sample :loop_amen                    # starting it again
 
       def sample(path, *args_a_or_h)
         return if path == nil
+
+        # Allow for hash only variant with :sample_name
+        # and procs as sample name inline with note()
+        case path
+        when Proc
+          return sample(path.call, *args_a_or_h)
+        when Hash
+          if path.has_key? :name
+            # handle case where sample receives Hash and args
+            new_path = path.delete(:name)
+            new_args = path.tap {|myhash| myhash.delete :name }
+            args_h = resolve_synth_opts_hash_or_array(args_a_or_h)
+            return sample(new_path, new_args.merge(args_h))
+          else
+            return nil
+          end
+        end
+
         ensure_good_timing!
         buf_info = load_sample(path)
         args_h = resolve_synth_opts_hash_or_array(args_a_or_h)
@@ -2431,7 +2449,14 @@ sample :loop_amen, start: 0.5, finish: 1 # play the last half of a sample",
         "
 # You can also play part of any sample backwards by using a start value that's
 # higher than the finish
-sample :loop_amen, start: 1, finish: 0.5 # play the last half backwards"]
+sample :loop_amen, start: 1, finish: 0.5 # play the last half backwards",
+        "
+# You can also specify the sample using a Hash with a `:sample_name` key
+sample {sample_name: :loop_amen, rate: 2}",
+        "
+# You can also specify the sample using a lambda that yields a symbol
+# although you probably don't need a lambda for this in most cases.
+sample lambda { [:loop_amen, :loop_garzul].choose }"]
 
 
 

--- a/app/server/sonicpi/test/lang/sound/test_sample.rb
+++ b/app/server/sonicpi/test/lang/sound/test_sample.rb
@@ -1,0 +1,52 @@
+#--
+# This file is part of Sonic Pi: http://sonic-pi.net
+# Full project source: https://github.com/samaaron/sonic-pi
+# License: https://github.com/samaaron/sonic-pi/blob/master/LICENSE.md
+#
+# Copyright 2013, 2014, 2015 by Sam Aaron (http://sam.aaron.name).
+# All rights reserved.
+#
+# Permission is granted for use, copying, modification, and
+# distribution of modified versions of this work as long as this
+# notice is included.
+#++
+
+require_relative "../../setup_test"
+require_relative "../../../lib/sonicpi/atom"
+require_relative "../../../lib/sonicpi/lang/core"
+require_relative "../../../lib/sonicpi/lang/sound"
+require 'mocha/setup'
+require 'ostruct'
+
+module SonicPi
+  class SampleTester < Test::Unit::TestCase
+    def setup
+      @mock_sound = Object.new
+      @mock_sound.extend(Lang::Sound)
+      @mock_sound.extend(Lang::Core)
+      @mock_sound.stubs(:sleep) # avoid loading Spider class
+      @mock_sound.stubs(:ensure_good_timing!) # avoid loading Spider class
+      @mock_sound.stubs(:load_sample).returns(OpenStruct.new({id: 42, num_chans: 2}))
+    end
+
+    def test_sample_with_various_args
+      @mock_sound.expects(:trigger_sampler).with(:loop_amen, 42, 2, {})
+      @mock_sound.sample :loop_amen
+
+      @mock_sound.expects(:trigger_sampler).with(:loop_amen, 42, 2, {rate: 2})
+      @mock_sound.sample :loop_amen, rate: 2
+
+      @mock_sound.expects(:trigger_sampler).with(:loop_amen, 42, 2, {rate: 2})
+      @mock_sound.sample lambda { :loop_amen }, rate: 2
+
+      # Single hash
+      @mock_sound.expects(:trigger_sampler).with(:loop_amen, 42, 2, {rate: 2})
+      @mock_sound.sample name: :loop_amen, rate: 2
+
+      # Hash and args
+      @mock_sound.expects(:trigger_sampler).with(:loop_amen, 42, 2, {rate: 2})
+      @mock_sound.sample({name: :loop_amen}, {rate: 2})
+    end
+
+  end
+end


### PR DESCRIPTION
This commit extends the functionality of the `sample` method to bring it
inline with the current `play` implementation.

Up to now in `play` you could call it with a single hash, provided the
hash contained a note argument like so:

```
play note: :c4, release: 0.1
```

With this commit you can now do something similar with `sample`,
although the required key is `:name` e.g.

```
sample name: :loop_amen, rate: 2
```

For completeness you can also can also use a lambda which will get
called automatically, although I'm yet to think of a sensible example
case.

```
sample lambda { [:loop_amen, :loop_garzul].choose }
```

This is mainly for consistency between `play` and `sample` which
are two of the most widely used methods in Sonic Pi.