### PR TITLE
Fixup play and add tests for note

### DIFF
--- a/app/server/sonicpi/lib/sonicpi/lang/sound.rb
+++ b/app/server/sonicpi/lib/sonicpi/lang/sound.rb
@@ -958,7 +958,12 @@ synth :dsaw, note: 50 # Play note 50 of the :dsaw synth with a release of 5"]
           return play_chord(n, *args)
         when Hash
           # Allow a single hash argument to function unsurprisingly
-          args = n if args.empty?
+          if args.empty?
+            args = n
+          else
+            args_h = resolve_synth_opts_hash_or_array(args)
+            args = n.merge(args_h)
+          end
         end
 
         n = note(n)

--- a/app/server/sonicpi/test/lang/sound/test_note.rb
+++ b/app/server/sonicpi/test/lang/sound/test_note.rb
@@ -1,0 +1,37 @@
+#--
+# This file is part of Sonic Pi: http://sonic-pi.net
+# Full project source: https://github.com/samaaron/sonic-pi
+# License: https://github.com/samaaron/sonic-pi/blob/master/LICENSE.md
+#
+# Copyright 2013, 2014, 2015 by Sam Aaron (http://sam.aaron.name).
+# All rights reserved.
+#
+# Permission is granted for use, copying, modification, and
+# distribution of modified versions of this work as long as this
+# notice is included.
+#++
+
+require_relative "../../setup_test"
+require_relative "../../../lib/sonicpi/lang/core"
+require_relative "../../../lib/sonicpi/lang/sound"
+require 'mocha/setup'
+
+module SonicPi
+  class SampleTester < Test::Unit::TestCase
+
+    def setup
+      @mock_sound = Object.new
+      @mock_sound.extend(Lang::Sound)
+      @mock_sound.extend(Lang::Core)
+    end
+
+    def test_sample_with_various_args
+      Note.expects(:resolve_midi_note_without_octave).with(:c4)
+      @mock_sound.note :c4
+
+      Note.expects(:resolve_midi_note).with(:c, 5)
+      @mock_sound.note :c, octave: 5
+    end
+
+  end
+end

--- a/app/server/sonicpi/test/lang/sound/test_play.rb
+++ b/app/server/sonicpi/test/lang/sound/test_play.rb
@@ -1,0 +1,49 @@
+#--
+# This file is part of Sonic Pi: http://sonic-pi.net
+# Full project source: https://github.com/samaaron/sonic-pi
+# License: https://github.com/samaaron/sonic-pi/blob/master/LICENSE.md
+#
+# Copyright 2013, 2014, 2015 by Sam Aaron (http://sam.aaron.name).
+# All rights reserved.
+#
+# Permission is granted for use, copying, modification, and
+# distribution of modified versions of this work as long as this
+# notice is included.
+#++
+
+require_relative "../../setup_test"
+require_relative "../../../lib/sonicpi/atom"
+require_relative "../../../lib/sonicpi/lang/core"
+require_relative "../../../lib/sonicpi/lang/sound"
+require 'mocha/setup'
+require 'ostruct'
+
+module SonicPi
+  class PlayTester < Test::Unit::TestCase
+    def setup
+      @mock_sound = Object.new
+      @mock_sound.extend(Lang::Sound)
+      @mock_sound.extend(Lang::Core)
+      @mock_sound.stubs(:sleep) # avoid loading Spider class
+      @mock_sound.stubs(:ensure_good_timing!) # avoid loading Spider class
+      @mock_sound.stubs(:current_synth_name).returns(:beep)
+    end
+
+    def test_play_with_various_args
+      @mock_sound.expects(:trigger_inst).with(:beep, {note: 60.0})
+      @mock_sound.play :c
+
+      @mock_sound.expects(:trigger_inst).with(:beep, {note: 60.0, release: 0.1})
+      @mock_sound.play :c, release: 0.1
+
+      # Single hash
+      @mock_sound.expects(:trigger_inst).with(:beep, {note: 60.0, release: 0.1})
+      @mock_sound.play({note: :c, release: 0.1})
+
+      # Hash and args
+      @mock_sound.expects(:trigger_inst).with(:beep, {note: 60.0, amp: 1, release: 0.1})
+      @mock_sound.play({note: :c, amp: 1}, {release: 0.1})
+    end
+
+  end
+end


### PR DESCRIPTION
This commit fixes a counterintuitive syntax issue with `play` where the
first argument is a hash

```
play({note: :c, amp: 1}, {release: 0.1})
```

Up to now, this would have silently dropped any other args from the
first hash other than `:note`. This commit fixes that.

Also adds some tests for the `note` method as I started looking there
and already wrote the tests anyway.