### PR TITLE
Support a custom font for the Editor+log via theme.

### DIFF
--- a/app/gui/qt/mainwindow.cpp
+++ b/app/gui/qt/mainwindow.cpp
@@ -323,6 +323,10 @@ MainWindow::MainWindow(QApplication &app, bool i18n, QSplashScreen* splash)
   outputPane->setFontFamily("Bitstream Vera Sans Mono");
 #endif
 
+  if(!theme->font("LogFace").isEmpty()){
+      outputPane->setFontFamily(theme->font("LogFace"));
+  }
+
   outputPane->document()->setMaximumBlockCount(1000);
   errorPane->document()->setMaximumBlockCount(1000);
 

--- a/app/gui/qt/sonicpilexer.cpp
+++ b/app/gui/qt/sonicpilexer.cpp
@@ -207,14 +207,19 @@ QColor SonicPiLexer::defaultPaper(int style) const
 
 
 // Returns the font of the text for a style.
-QFont QsciLexerRuby::defaultFont(int style) const
+QFont SonicPiLexer::defaultFont(int style) const
 {
     QFont f;
+    QString activeFont = default_font;
+
+    if(!theme->font("EditorFace").isEmpty()){
+        activeFont = theme->font("EditorFace");
+    }
 
     switch (style)
     {
     case Comment:
-      f = QFont(default_font, 15, -1, true);
+      f = QFont(activeFont, 15, -1, true);
 	  break;
 
     case POD:
@@ -229,7 +234,7 @@ QFont QsciLexerRuby::defaultFont(int style) const
     case ModuleName:
     case DemotedKeyword:
     default:
-        f = QFont(default_font, 15);
+        f = QFont(activeFont, 15);
     }
 
     return f;

--- a/app/gui/qt/sonicpilexer.h
+++ b/app/gui/qt/sonicpilexer.h
@@ -22,6 +22,7 @@ public:
   SonicPiLexer(SonicPiTheme *customTheme);
   QColor defaultColor(int style) const;
   QColor defaultPaper(int style) const;
+  QFont defaultFont(int style) const;
   void highlightAll();
   void unhighlightAll();
   SonicPiTheme *theme;

--- a/app/gui/qt/sonicpitheme.cpp
+++ b/app/gui/qt/sonicpitheme.cpp
@@ -211,4 +211,8 @@ QColor SonicPiTheme::color(QString key){
     return theme[key];
 }
 
+QString SonicPiTheme::font(QString key){
+    return theme[key];
+}
+
 SonicPiTheme::~SonicPiTheme(){}

--- a/app/gui/qt/sonicpitheme.h
+++ b/app/gui/qt/sonicpitheme.h
@@ -12,6 +12,7 @@ public:
     explicit SonicPiTheme(QObject *parent = 0, QSettings *settings = 0, bool dark = false);
     ~SonicPiTheme();
     QColor color(QString);
+    QString font(QString);
     void darkMode();
     void lightMode();
 


### PR DESCRIPTION
### What

Theming now supports changing the font of the Editor + Log output. 

```
EditorFace=monospace
LogFace=monospace
```

Eventually we want all fonts to be specified via the theme file but this is the first little step.

Also means Joe can stop maintaining a fork just so he can have a nice font.