### PR TITLE
[i18n] turn on Japanese GUI translation

### DIFF
--- a/app/gui/qt/SonicPi.pro
+++ b/app/gui/qt/SonicPi.pro
@@ -83,7 +83,8 @@ HEADERS  += mainwindow.h \
             sonicpitheme.h
 
 TRANSLATIONS = lang/sonic-pi_de.ts \
-               lang/sonic-pi_is.ts
+               lang/sonic-pi_is.ts \
+               lang/sonic-pi_ja.ts
 
 OTHER_FILES += \
     images/copy.png \

--- a/app/gui/qt/SonicPi.qrc
+++ b/app/gui/qt/SonicPi.qrc
@@ -48,5 +48,6 @@
 
         <file>lang/sonic-pi_de.qm</file>
         <file>lang/sonic-pi_is.qm</file>
+        <file>lang/sonic-pi_ja.qm</file>
     </qresource>
 </RCC>


### PR DESCRIPTION
This adds the Japanese GUI translation by @keikomachiya to the QT build process.

You can try it using `LANG=ja_JP.UTF-8 ./sonic-pi` in Linux if you have the locale installed on your system.

![japanese-gui](https://cloud.githubusercontent.com/assets/1705654/10216928/d05b3a46-682c-11e5-9d03-0f16e6a00e2c.png)

Thanks a lot, @keikomachiya , this is great! However, the GUI translation isn't fully complete yet, some few English words remain. QT linguist can tell you which strings are missing.