### PR TITLE
Performance optimisations for OSC encoding

### DIFF
--- a/app/server/sonicpi/test/performance/test_osc_perf.rb
+++ b/app/server/sonicpi/test/performance/test_osc_perf.rb
@@ -15,20 +15,33 @@
 # Uncomment this file if you want to run benchmark tests
 # requires benchmark/ips gem to be installed
 
+if ENV['RUN_PERF_TESTS']
+  require_relative '../setup_test.rb'
+  require_relative "../../lib/sonicpi/oscdecode"
+  require_relative "../../lib/sonicpi/oscencode"
+  require 'benchmark/ips'
+  require 'osc-ruby'
 
-# require_relative '../setup_test.rb'
-# require_relative "../../lib/sonicpi/oscdecode"
-# require 'benchmark/ips'
-# require 'osc-ruby'
+  samosc = SonicPi::OscDecode.new(false)
+  samoscenc = SonicPi::OscEncode.new(false)
+  oscruby = OSC::OSCPacket
 
-# samosc = SonicPi::OscDecode.new
-# oscruby = OSC::OSCPacket
+  address = "/feeooblah"
+  args = ["beans", 1, 2.0] 
+  msg = OSC::Message.new(address, *args)
+  test_message = msg.encode
 
-# test_message = OSC::Message.new("/foo", ["beans", 1, 2.0]).encode
+  Benchmark.ips do |bencher|
+    bencher.report("samsosc") { samoscenc.encode_single_message(address, args) }
+    bencher.report("oscruby") { msg.encode }
 
-# Benchmark.ips do |bencher|
-#   bencher.report("samsosc") { samosc.decode_single_message(test_message) }
-#   bencher.report("oscruby") { oscruby.messages_from_network(test_message) }
+    bencher.compare
+  end
 
-#   bencher.compare
-# end
+  # Benchmark.ips do |bencher|
+  #   bencher.report("samsosc") { samosc.decode_single_message(test_message) }
+  #   bencher.report("oscruby") { oscruby.messages_from_network(test_message) }
+  # 
+  #   bencher.compare
+  # end
+end


### PR DESCRIPTION
This is part of an ongoing effort to achieve reasonable performance on
the Raspberry Pi model B+. From profiling with RubyProf and stackprof I
had identified that the encoding of OSC messages was a hot spot in the
code.

The encoding process is basically turning an array of Ruby objects
(ints, floats and strings) into a binary string representation. The
trickiest bit of this performance-wise is the string encoding.

The Open Sound Control spec says that strings need to end with a null
byte (`"\x00"` in Ruby) and the length of the encoded string also needs
to be a multiple of four. For example:

```
s = "/data"
s.bytesize # => 5
```

becomes

```
s = "/data\x00\x00\x00"
s.bytesize # => 8
```

The string was originally 5 bytes long, but we pad it with nulls up to
the nearest multiple of 4 - in this case 8 bytes.

Doing this in a performant way turns out to be tricky. The previous
implementation involved 3 string assignments, a regex substitution and
string concatenation which is perfectly reasonable approach, but not
particularly fast.

The main advance of this commit was to switch to a more concise method
using `pack`. `["/data"].pack('Z8')` will produce a null padded string
like this: `"/data\x00\x00\x00"`. `Z` makes the null padded format and
`8` specifies the length in bytes.

In order to calculate the next nearest multiple of 4 I'm using a hacky
hack

```
s = "/data"
4*((s.bytesize.zero? ? 0 : s.bytesize.to_f + 0.01)/4).ceil
```

We have to special case the zero length string to return 0, otherwise we
convert to a float, add a little bit and then round up with `.ceil`.
Whilst this isn't good code, it is a lot faster than the string
assignment version.