### PR TITLE
I18n pl gui

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,7 @@ app/gui/qt/moc_*
 
 *.DS_Store
 *.log
+*.swp
 \.#*
 .lein-plugins
 *~

--- a/app/gui/qt/SonicPi.pro
+++ b/app/gui/qt/SonicPi.pro
@@ -84,7 +84,8 @@ HEADERS  += mainwindow.h \
 
 TRANSLATIONS = lang/sonic-pi_de.ts \
                lang/sonic-pi_is.ts \
-               lang/sonic-pi_ja.ts
+               lang/sonic-pi_ja.ts \
+               lang/sonic-pi_pl.ts
 
 OTHER_FILES += \
     images/copy.png \

--- a/app/gui/qt/SonicPi.qrc
+++ b/app/gui/qt/SonicPi.qrc
@@ -49,5 +49,6 @@
         <file>lang/sonic-pi_de.qm</file>
         <file>lang/sonic-pi_is.qm</file>
         <file>lang/sonic-pi_ja.qm</file>
+        <file>lang/sonic-pi_pl.qm</file>
     </qresource>
 </RCC>

--- a/app/gui/qt/lang/sonic-pi_pl.ts
+++ b/app/gui/qt/lang/sonic-pi_pl.ts
@@ -1,0 +1,764 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.0" language="pl_PL">
+<defaultcodec>UTF-8</defaultcodec>
+<context>
+    <name>MainWindow</name>
+    <message>
+        <location filename="../mainwindow.cpp" line="152"/>
+        <source>Sonic Pi update info</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="295"/>
+        <source>Buffer %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="356"/>
+        <source>Preferences</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="369"/>
+        <source>Log</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="410"/>
+        <location filename="../mainwindow.cpp" line="1912"/>
+        <source>Help</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="441"/>
+        <location filename="../mainwindow.cpp" line="2144"/>
+        <location filename="../mainwindow.cpp" line="2162"/>
+        <source>Sonic Pi</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="455"/>
+        <source>Welcome to Sonic Pi</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="597"/>
+        <source>Indenting selection...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="601"/>
+        <source>Indenting line...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="630"/>
+        <source>Commenting selection...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="634"/>
+        <source>Commenting line...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="713"/>
+        <source>Ruby could not be started, is it installed and in your PATH?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="799"/>
+        <source>Raspberry Pi System Volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="800"/>
+        <source>Use this slider to change the system volume of your Raspberry Pi.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="802"/>
+        <source>Advanced Audio</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="803"/>
+        <source>Advanced audio settings for working with
+external PA systems when performing with Sonic Pi.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="804"/>
+        <source>Invert Stereo</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="805"/>
+        <source>Toggle stereo inversion.
+If enabled, audio sent to the left speaker will
+be routed to the right speaker and visa versa.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="807"/>
+        <source>Force Mono</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="808"/>
+        <source>Toggle mono mode.
+If enabled both right and left audio is mixed and
+the same signal is sent to both speakers.
+Useful when working with external systems that
+can only handle mono.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="811"/>
+        <source>Safe mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="812"/>
+        <source>Toggle synth argument checking functions.
+If disabled, certain synth opt values may
+create unexpectedly loud or uncomfortable sounds.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="824"/>
+        <source>Raspberry Pi Audio Output</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="825"/>
+        <source>Your Raspberry Pi has two forms of audio output.
+Firstly, there is the headphone jack of the Raspberry Pi itself.
+Secondly, some HDMI monitors/TVs support audio through the HDMI port.
+Use these buttons to force the output to the one you want.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="826"/>
+        <source>&amp;Default</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="827"/>
+        <source>&amp;Headphones</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="828"/>
+        <source>&amp;HDMI</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="848"/>
+        <source>Logging</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="849"/>
+        <source>Configure debug behaviour</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="851"/>
+        <source>Log synths</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="852"/>
+        <source>Toggle log messages.
+If disabled, activity such as synth and sample
+triggering will not be printed to the log by default.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="854"/>
+        <source>Clear log on run</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="855"/>
+        <source>Toggle log clearing on run.
+If enabled, the log is cleared each
+time the run button is pressed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="857"/>
+        <source>Log cues</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="858"/>
+        <source>Enable or disable logging of cues.
+If disabled, cues will still trigger.
+However, they will not be visible in the logs.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="867"/>
+        <source>Transparency</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="878"/>
+        <location filename="../mainwindow.cpp" line="1000"/>
+        <source>Updates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="880"/>
+        <source>Check for updates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="882"/>
+        <source>Toggle automatic update checking.
+This check involves sending anonymous information about your platform and version.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="883"/>
+        <source>Check now</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="884"/>
+        <source>Force a check for updates now.
+This check involves sending anonymous information about your platform and version.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="885"/>
+        <source>Get update</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="886"/>
+        <source>Visit http://sonic-pi.net to download new version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="891"/>
+        <source>Update Info</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="910"/>
+        <source>Show and Hide</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="911"/>
+        <source>Configure editor display options.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="912"/>
+        <source>Look and Feel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="913"/>
+        <source>Configure editor look and feel.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="914"/>
+        <source>Automation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="915"/>
+        <source>Configure automation features.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="916"/>
+        <source>Auto-align</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="917"/>
+        <source>Automatically align code on Run</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="919"/>
+        <source>Show line numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="920"/>
+        <source>Toggle line number visibility.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="921"/>
+        <source>Show log</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="922"/>
+        <source>Toggle visibility of the log.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="924"/>
+        <source>Show buttons</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="925"/>
+        <source>Toggle visibility of the control buttons.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="927"/>
+        <source>Show tabs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="929"/>
+        <source>Toggle visibility of the buffer selection tabs.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="930"/>
+        <source>Full screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="931"/>
+        <source>Toggle full screen mode.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="932"/>
+        <source>Dark mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="933"/>
+        <source>Toggle dark mode.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="933"/>
+        <source>
+Dark mode is perfect for live coding in night clubs.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="972"/>
+        <source>Audio</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="984"/>
+        <source>Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="985"/>
+        <source>Studio</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="987"/>
+        <location filename="../mainwindow.cpp" line="992"/>
+        <source>Performance</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="988"/>
+        <source>Settings useful for performing with Sonic Pi</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1083"/>
+        <source>Server boot error...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1083"/>
+        <source>Apologies, a critical error occurred during startup</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1083"/>
+        <source>Please consider reporting a bug at</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1177"/>
+        <source>Save Current Buffer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1245"/>
+        <source>Running Code...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1271"/>
+        <source>Workspace %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1287"/>
+        <source>Zooming In...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1294"/>
+        <source>Zooming Out...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1301"/>
+        <source>Beautifying...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1321"/>
+        <source>Reloading...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1328"/>
+        <source>Checking for updates...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1336"/>
+        <source>Enabling update checking...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1344"/>
+        <source>Disabling update checking...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1352"/>
+        <source>Enabling Mixer HPF...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1361"/>
+        <source>Disabling Mixer HPF...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1369"/>
+        <source>Enabling Mixer LPF...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1378"/>
+        <source>Disabling Mixer LPF...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1386"/>
+        <source>Enabling Inverted Stereo...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1394"/>
+        <source>Enabling Standard Stereo...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1402"/>
+        <source>Mono Mode...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1410"/>
+        <source>Stereo Mode...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1419"/>
+        <source>Stopping...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1503"/>
+        <source>Updating System Volume...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1721"/>
+        <source>Switching To Headphone Audio Output...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1737"/>
+        <source>Switching To HDMI Audio Output...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1752"/>
+        <source>Switching To Default Audio Output...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1894"/>
+        <source>Run</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1895"/>
+        <source>Run the code in the current workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1899"/>
+        <source>Stop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1900"/>
+        <source>Stop all running code</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1903"/>
+        <source>Save As...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1904"/>
+        <source>Save current buffer as an external file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1907"/>
+        <source>Info</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1908"/>
+        <source>See information about Sonic Pi</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1913"/>
+        <source>Toggle help pane</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1916"/>
+        <source>Prefs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1917"/>
+        <source>Toggle preferences pane</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1921"/>
+        <location filename="../mainwindow.cpp" line="2043"/>
+        <location filename="../mainwindow.cpp" line="2044"/>
+        <source>Start Recording</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1922"/>
+        <source>Start recording to WAV audio file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1926"/>
+        <source>Auto-Align Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1927"/>
+        <source>Improve readability of code</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1931"/>
+        <location filename="../mainwindow.cpp" line="1932"/>
+        <source>Increase Text Size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1936"/>
+        <location filename="../mainwindow.cpp" line="1937"/>
+        <source>Decrease Text Size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1942"/>
+        <source>Tools</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1989"/>
+        <source>About</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1990"/>
+        <source>Core Team</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1991"/>
+        <source>Contributors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1992"/>
+        <source>Community</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1993"/>
+        <source>License</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1994"/>
+        <source>History</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2015"/>
+        <source>Sonic Pi - Info</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2035"/>
+        <location filename="../mainwindow.cpp" line="2036"/>
+        <source>Stop Recording</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2049"/>
+        <source>Save Recording</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2068"/>
+        <source>Ready...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2145"/>
+        <source>Cannot read file %1:
+%2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2155"/>
+        <source>File loaded...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2163"/>
+        <source>Cannot write file %1:
+%2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2180"/>
+        <source>File saved...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2405"/>
+        <source>Last checked %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2407"/>
+        <source>Sonic Pi checks for updates
+every two weeks.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2409"/>
+        <source>This is Sonic Pi %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2410"/>
+        <source>Version %2 is now available!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2414"/>
+        <source>New version available!
+Get Sonic Pi %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2440"/>
+        <source>Welcome back. Now get your live code on...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ruby_help.h" line="80"/>
+        <location filename="../ruby_help.h" line="140"/>
+        <location filename="../ruby_help.h" line="151"/>
+        <location filename="../ruby_help.h" line="210"/>
+        <location filename="../ruby_help.h" line="229"/>
+        <location filename="../ruby_help.h" line="289"/>
+        <source>Tutorial</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ruby_help.h" line="321"/>
+        <source>Examples</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ruby_help.h" line="361"/>
+        <source>Synths</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ruby_help.h" line="397"/>
+        <source>Fx</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ruby_help.h" line="414"/>
+        <source>Samples</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ruby_help.h" line="580"/>
+        <source>Lang</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../main.cpp" line="43"/>
+        <source>Sonic Pi</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SonicPiUDPServer</name>
+    <message>
+        <location filename="../sonicpiudpserver.cpp" line="24"/>
+        <source>Is Sonic Pi already running?  Can&apos;t open UDP port 4558.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+</TS>

--- a/app/gui/qt/lang/sonic-pi_pl.ts
+++ b/app/gui/qt/lang/sonic-pi_pl.ts
@@ -7,103 +7,105 @@
     <message>
         <location filename="../mainwindow.cpp" line="152"/>
         <source>Sonic Pi update info</source>
-        <translation type="unfinished"></translation>
+        <translation>Sonic PI informacje o aktualizacjach</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="295"/>
         <source>Buffer %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Bufor %1</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="356"/>
         <source>Preferences</source>
-        <translation type="unfinished"></translation>
+        <translation>Ustawienia</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="369"/>
         <source>Log</source>
-        <translation type="unfinished"></translation>
+        <translation>Log</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="410"/>
         <location filename="../mainwindow.cpp" line="1912"/>
         <source>Help</source>
-        <translation type="unfinished"></translation>
+        <translation>Pomoc</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="441"/>
         <location filename="../mainwindow.cpp" line="2144"/>
         <location filename="../mainwindow.cpp" line="2162"/>
         <source>Sonic Pi</source>
-        <translation type="unfinished"></translation>
+        <translation>Sonic Pi</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="455"/>
         <source>Welcome to Sonic Pi</source>
-        <translation type="unfinished"></translation>
+        <translation>Witaj w Sonic Pi</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="597"/>
         <source>Indenting selection...</source>
-        <translation type="unfinished"></translation>
+        <translation>Formatowanie zaznaczenia...</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="601"/>
         <source>Indenting line...</source>
-        <translation type="unfinished"></translation>
+        <translation>Formatowanie linii...</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="630"/>
         <source>Commenting selection...</source>
-        <translation type="unfinished"></translation>
+        <translation>Komentowanie zaznaczenia...</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="634"/>
         <source>Commenting line...</source>
-        <translation type="unfinished"></translation>
+        <translation>Komentowanie linii...</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="713"/>
         <source>Ruby could not be started, is it installed and in your PATH?</source>
-        <translation type="unfinished"></translation>
+        <translation>Ruby nie mógł zostać uruchomiony, czy został on dodany do twojej ścieżki PATH?</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="799"/>
         <source>Raspberry Pi System Volume</source>
-        <translation type="unfinished"></translation>
+        <translation>Raspberry Pi Głośność Systemu</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="800"/>
         <source>Use this slider to change the system volume of your Raspberry Pi.</source>
-        <translation type="unfinished"></translation>
+        <translation>Użyj tego suwaka aby zmienić poziom głośności w twoim Raspberry Pi.</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="802"/>
         <source>Advanced Audio</source>
-        <translation type="unfinished"></translation>
+        <translation>Zaawansowane Ustawienia Dźwięku</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="803"/>
         <source>Advanced audio settings for working with
 external PA systems when performing with Sonic Pi.</source>
-        <translation type="unfinished"></translation>
+        <translation>Zaawansowane ustawienia audio pozwalające na pracę z zewnętrznymi profesjonalnymi sytemami audio używanymi podczas występów na scenie z Sonic Pi. </translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="804"/>
         <source>Invert Stereo</source>
-        <translation type="unfinished"></translation>
+        <translation>Odwrócone Stereo</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="805"/>
         <source>Toggle stereo inversion.
 If enabled, audio sent to the left speaker will
 be routed to the right speaker and visa versa.</source>
-        <translation type="unfinished"></translation>
+        <translation>Włącz lub wyłącz odwrócone stereo.
+Jeśli jest włączone, dźwięĸ wysyłany do lewego głośnika 
+zostanie wysłany do prawego i vice versa.</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="807"/>
         <source>Force Mono</source>
-        <translation type="unfinished"></translation>
+        <translation>Wymuś Mono</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="808"/>
@@ -112,24 +114,30 @@ If enabled both right and left audio is mixed and
 the same signal is sent to both speakers.
 Useful when working with external systems that
 can only handle mono.</source>
-        <translation type="unfinished"></translation>
+        <translation>Włącza i wyłącza tryb mono.
+Jeśłi jest włączony to oba kanały (lewy i prawy) są wymieszane i 
+na oba głośniki zostaje wysłany taki sam sygnał.
+Bardzo przydatne podczas pracy z zewnętrznymi systemami 
+audio, które potrafią obsługiwać tylko dźwięk mono.</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="811"/>
         <source>Safe mode</source>
-        <translation type="unfinished"></translation>
+        <translation>Tryb bezpieczny</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="812"/>
         <source>Toggle synth argument checking functions.
 If disabled, certain synth opt values may
 create unexpectedly loud or uncomfortable sounds.</source>
-        <translation type="unfinished"></translation>
+        <translation>Włącza lub wyłącza funkcje sprawdzające argumenty syntezatorów.
+Jeśłi nie jest włączona, pewne opcje syntezatorów mogą 
+spowodować dźwięki o nieoczekiwanej głośności lub nieprzyjemnym brzmieniu. </translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="824"/>
         <source>Raspberry Pi Audio Output</source>
-        <translation type="unfinished"></translation>
+        <translation>Raspberry Pi Wyjście Audio</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="825"/>
@@ -137,577 +145,596 @@ create unexpectedly loud or uncomfortable sounds.</source>
 Firstly, there is the headphone jack of the Raspberry Pi itself.
 Secondly, some HDMI monitors/TVs support audio through the HDMI port.
 Use these buttons to force the output to the one you want.</source>
-        <translation type="unfinished"></translation>
+        <translation>Twoje Raspberry Pi posiada dwa typy wyjść audio.
+Po pierwsze na Raspberry Pi jest dostępne gniazdo słuchawkowe jack.
+Po drugie, pewne monitory/telewizory z wejśćiem HDMI wspierają obsługę 
+dźwięĸu przez port HDMI.
+Użyj tych przycisków aby wymusić wyjście na takie urządzenie, które chesz.</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="826"/>
         <source>&amp;Default</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Domyślnie</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="827"/>
         <source>&amp;Headphones</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Słuchawki</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="828"/>
         <source>&amp;HDMI</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;HDMI</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="848"/>
         <source>Logging</source>
-        <translation type="unfinished"></translation>
+        <translation>Logowanie</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="849"/>
         <source>Configure debug behaviour</source>
-        <translation type="unfinished"></translation>
+        <translation>Konfiguracja zachowania debugowanych informacji</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="851"/>
         <source>Log synths</source>
-        <translation type="unfinished"></translation>
+        <translation>Logowanie syntezatorów</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="852"/>
         <source>Toggle log messages.
 If disabled, activity such as synth and sample
 triggering will not be printed to the log by default.</source>
-        <translation type="unfinished"></translation>
+        <translation>Włącz lub wyłącz informacje w oknie logowania.
+Jeśłi jest wyłączone, aktywności takie jak uruchomiania syntezatorów 
+i samplerów nie będą domyślnie powodowały prezentowania informacji 
+w oknie logowania.</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="854"/>
         <source>Clear log on run</source>
-        <translation type="unfinished"></translation>
+        <translation>Wyczyść okno logowania przy uruchomieniu</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="855"/>
         <source>Toggle log clearing on run.
 If enabled, the log is cleared each
 time the run button is pressed.</source>
-        <translation type="unfinished"></translation>
+        <translation>Włącza lub wyłącza czyszczenia okna 
+Log przy uruchomieniu kodu.
+Jeśli jest włączony, to okno logowania 
+jest czyszczone przy każdym naciśnięciu 
+przycisku Run.</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="857"/>
         <source>Log cues</source>
-        <translation type="unfinished"></translation>
+        <translation>Loguj punkty cue</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="858"/>
         <source>Enable or disable logging of cues.
 If disabled, cues will still trigger.
 However, they will not be visible in the logs.</source>
-        <translation type="unfinished"></translation>
+        <translation>Włącza lub wyłącza logowanie punktów cue. 
+Jeśłi jest wyłączone, punkty cue wciąż będą uruchamiane.
+Jednakżę, nie będą one widoczne panelu logowania.</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="867"/>
         <source>Transparency</source>
-        <translation type="unfinished"></translation>
+        <translation>Przezroczystość</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="878"/>
         <location filename="../mainwindow.cpp" line="1000"/>
         <source>Updates</source>
-        <translation type="unfinished"></translation>
+        <translation>Aktualizacje</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="880"/>
         <source>Check for updates</source>
-        <translation type="unfinished"></translation>
+        <translation>Sprawdź dostępność aktualizacji</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="882"/>
         <source>Toggle automatic update checking.
 This check involves sending anonymous information about your platform and version.</source>
-        <translation type="unfinished"></translation>
+        <translation>Włącza lub wyłącza automatyczne sprawdzanie aktualizacji.
+Włączenie spowoduje wysyłanie anonimowych informacji o plaftormie 
+i wersji z której korzystasz.</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="883"/>
         <source>Check now</source>
-        <translation type="unfinished"></translation>
+        <translation>Sprawdź teraz</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="884"/>
         <source>Force a check for updates now.
 This check involves sending anonymous information about your platform and version.</source>
-        <translation type="unfinished"></translation>
+        <translation>Wymusza sprawdzenie aktualizacji w tej chwili.
+Zaznaczenie powoduje wysłanie anonimowych informacji o twojej platformie i wersji.</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="885"/>
         <source>Get update</source>
-        <translation type="unfinished"></translation>
+        <translation>Pobierz aktualizację</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="886"/>
         <source>Visit http://sonic-pi.net to download new version</source>
-        <translation type="unfinished"></translation>
+        <translation>Wejdź na stronę http://sonic-pi.net aby pobrać nową wersję</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="891"/>
         <source>Update Info</source>
-        <translation type="unfinished"></translation>
+        <translation>Informacje dot. Aktualizacji</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="910"/>
         <source>Show and Hide</source>
-        <translation type="unfinished"></translation>
+        <translation>Pokaż i Ukryj</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="911"/>
         <source>Configure editor display options.</source>
-        <translation type="unfinished"></translation>
+        <translation>Skonfiguruj opcje dot. wyświetlania edytora.</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="912"/>
         <source>Look and Feel</source>
-        <translation type="unfinished"></translation>
+        <translation>Wygląd i Wrażenia</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="913"/>
         <source>Configure editor look and feel.</source>
-        <translation type="unfinished"></translation>
+        <translation>Konfiguracja wyglądu i wrażeń dot. edytora.</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="914"/>
         <source>Automation</source>
-        <translation type="unfinished"></translation>
+        <translation>Automatyzacja</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="915"/>
         <source>Configure automation features.</source>
-        <translation type="unfinished"></translation>
+        <translation>Konfiguracja opcji dot. automatyzacji.</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="916"/>
         <source>Auto-align</source>
-        <translation type="unfinished"></translation>
+        <translation>Auto wyrównanie</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="917"/>
         <source>Automatically align code on Run</source>
-        <translation type="unfinished"></translation>
+        <translation>Automatycznie wyrównanie (formatowanie) przy uruchomieniu kodu (Run)</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="919"/>
         <source>Show line numbers</source>
-        <translation type="unfinished"></translation>
+        <translation>Pokaż numery linii</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="920"/>
         <source>Toggle line number visibility.</source>
-        <translation type="unfinished"></translation>
+        <translation>Włącza i wyłącza widoczność numerów linii.</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="921"/>
         <source>Show log</source>
-        <translation type="unfinished"></translation>
+        <translation>Pokaż log</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="922"/>
         <source>Toggle visibility of the log.</source>
-        <translation type="unfinished"></translation>
+        <translation>Włącza i wyłącza widoczność panelu logowania (log).</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="924"/>
         <source>Show buttons</source>
-        <translation type="unfinished"></translation>
+        <translation>Pokaż przyciski</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="925"/>
         <source>Toggle visibility of the control buttons.</source>
-        <translation type="unfinished"></translation>
+        <translation>Włącza i wyłącza widoczność przycisków.</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="927"/>
         <source>Show tabs</source>
-        <translation type="unfinished"></translation>
+        <translation>Pokazuj zakładki</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="929"/>
         <source>Toggle visibility of the buffer selection tabs.</source>
-        <translation type="unfinished"></translation>
+        <translation>Włącza i wyłącza widoczność zakładek prezentujących bufory.</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="930"/>
         <source>Full screen</source>
-        <translation type="unfinished"></translation>
+        <translation>Pełny ekran</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="931"/>
         <source>Toggle full screen mode.</source>
-        <translation type="unfinished"></translation>
+        <translation>Włącza i wyłącza tryb pełnoekranowy.</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="932"/>
         <source>Dark mode</source>
-        <translation type="unfinished"></translation>
+        <translation>Tryb nocny</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="933"/>
         <source>Toggle dark mode.</source>
-        <translation type="unfinished"></translation>
+        <translation>Włącza i wyłącza tryb nocny.</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="933"/>
         <source>
 Dark mode is perfect for live coding in night clubs.</source>
-        <translation type="unfinished"></translation>
+        <translation>
+Tryb nocny jest idealny do kodowania na żywo w klubach.</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="972"/>
         <source>Audio</source>
-        <translation type="unfinished"></translation>
+        <translation>Audio</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="984"/>
         <source>Editor</source>
-        <translation type="unfinished"></translation>
+        <translation>Edytor</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="985"/>
         <source>Studio</source>
-        <translation type="unfinished"></translation>
+        <translation>Studio</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="987"/>
         <location filename="../mainwindow.cpp" line="992"/>
         <source>Performance</source>
-        <translation type="unfinished"></translation>
+        <translation>Koncert</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="988"/>
         <source>Settings useful for performing with Sonic Pi</source>
-        <translation type="unfinished"></translation>
+        <translation>Ustawienia przydatne gdy korzystasz z Sonic Pi na koncertach/podczas występów</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="1083"/>
         <source>Server boot error...</source>
-        <translation type="unfinished"></translation>
+        <translation>Błąd przy uruchamianiu serwera...</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="1083"/>
         <source>Apologies, a critical error occurred during startup</source>
-        <translation type="unfinished"></translation>
+        <translation>Przepraszamy, wystąpił krytyczny błąd podczas uruchamiania</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="1083"/>
         <source>Please consider reporting a bug at</source>
-        <translation type="unfinished"></translation>
+        <translation>Proszę, spróbuj zgłosić ten błąd na stronie</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="1177"/>
         <source>Save Current Buffer</source>
-        <translation type="unfinished"></translation>
+        <translation>Zapisz Aktualny Bufor</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="1245"/>
         <source>Running Code...</source>
-        <translation type="unfinished"></translation>
+        <translation>Uruchamianie Kodu...</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="1271"/>
         <source>Workspace %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Bufor %1</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="1287"/>
         <source>Zooming In...</source>
-        <translation type="unfinished"></translation>
+        <translation>Powiększanie...</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="1294"/>
         <source>Zooming Out...</source>
-        <translation type="unfinished"></translation>
+        <translation>Zmniejszanie...</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="1301"/>
         <source>Beautifying...</source>
-        <translation type="unfinished"></translation>
+        <translation>Upiększanie...</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="1321"/>
         <source>Reloading...</source>
-        <translation type="unfinished"></translation>
+        <translation>Trwa Przeładowanie...</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="1328"/>
         <source>Checking for updates...</source>
-        <translation type="unfinished"></translation>
+        <translation>Sprawdzam aktualizacje...</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="1336"/>
         <source>Enabling update checking...</source>
-        <translation type="unfinished"></translation>
+        <translation>Włączam sprawdzanie aktualizacji...</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="1344"/>
         <source>Disabling update checking...</source>
-        <translation type="unfinished"></translation>
+        <translation>Wyłączam sprawdzanie aktualizacji...</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="1352"/>
         <source>Enabling Mixer HPF...</source>
-        <translation type="unfinished"></translation>
+        <translatorcomment>HPF - High Pass Filter (Filtr górnoprzepustowy)</translatorcomment>
+        <translation>Włączanie Miksera HPF...</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="1361"/>
         <source>Disabling Mixer HPF...</source>
-        <translation type="unfinished"></translation>
+        <translation>Wyłączam Mikser HPF...</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="1369"/>
         <source>Enabling Mixer LPF...</source>
-        <translation type="unfinished"></translation>
+        <translation>Włączam Mikser LPF...</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="1378"/>
         <source>Disabling Mixer LPF...</source>
-        <translation type="unfinished"></translation>
+        <translation>Wyłączam Mikser LPF...</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="1386"/>
         <source>Enabling Inverted Stereo...</source>
-        <translation type="unfinished"></translation>
+        <translation>Włączam Odwrócone Stereo...</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="1394"/>
         <source>Enabling Standard Stereo...</source>
-        <translation type="unfinished"></translation>
+        <translation>Włączam Standardowe Stereo...</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="1402"/>
         <source>Mono Mode...</source>
-        <translation type="unfinished"></translation>
+        <translation>Tryb Mono...</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="1410"/>
         <source>Stereo Mode...</source>
-        <translation type="unfinished"></translation>
+        <translation>Tryb Stereo...</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="1419"/>
         <source>Stopping...</source>
-        <translation type="unfinished"></translation>
+        <translation>Zatrzymuję...</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="1503"/>
         <source>Updating System Volume...</source>
-        <translation type="unfinished"></translation>
+        <translation>Aktualizuję Głośność Systemu...</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="1721"/>
         <source>Switching To Headphone Audio Output...</source>
-        <translation type="unfinished"></translation>
+        <translation>Zmieniam Wyjśćie Na Słuchawkowe...</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="1737"/>
         <source>Switching To HDMI Audio Output...</source>
-        <translation type="unfinished"></translation>
+        <translation>Zmieniam Wyjśćie na HDMI...</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="1752"/>
         <source>Switching To Default Audio Output...</source>
-        <translation type="unfinished"></translation>
+        <translation>Zmieniam Wyjście Na Domyślne Wyjście Audio...</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="1894"/>
         <source>Run</source>
-        <translation type="unfinished"></translation>
+        <translation>Run (Uruchom)</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="1895"/>
         <source>Run the code in the current workspace</source>
-        <translation type="unfinished"></translation>
+        <translation>Uruchom kod znajdujący się aktualnym buforze</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="1899"/>
         <source>Stop</source>
-        <translation type="unfinished"></translation>
+        <translation>Stop</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="1900"/>
         <source>Stop all running code</source>
-        <translation type="unfinished"></translation>
+        <translation>Zatrzymuje jakikolwiek kod, który jest aktualnie uruchomiony</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="1903"/>
         <source>Save As...</source>
-        <translation type="unfinished"></translation>
+        <translation>Zapisz jako...</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="1904"/>
         <source>Save current buffer as an external file</source>
-        <translation type="unfinished"></translation>
+        <translation>Zapisz aktualny bufor jako zewnętrzny plik</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="1907"/>
         <source>Info</source>
-        <translation type="unfinished"></translation>
+        <translation>Info</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="1908"/>
         <source>See information about Sonic Pi</source>
-        <translation type="unfinished"></translation>
+        <translation>Zobacz informacje o Sonic Pi</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="1913"/>
         <source>Toggle help pane</source>
-        <translation type="unfinished"></translation>
+        <translation>Włącza i wyłącza panel pomocy</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="1916"/>
         <source>Prefs</source>
-        <translation type="unfinished"></translation>
+        <translation>Ustawienia</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="1917"/>
         <source>Toggle preferences pane</source>
-        <translation type="unfinished"></translation>
+        <translation>Włącza i wyłącza panel ustawień</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="1921"/>
         <location filename="../mainwindow.cpp" line="2043"/>
         <location filename="../mainwindow.cpp" line="2044"/>
         <source>Start Recording</source>
-        <translation type="unfinished"></translation>
+        <translation>Uruchom Nagrywanie</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="1922"/>
         <source>Start recording to WAV audio file</source>
-        <translation type="unfinished"></translation>
+        <translation>Uruchamiana nagrywanie dźwięku do pliku WAV</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="1926"/>
         <source>Auto-Align Text</source>
-        <translation type="unfinished"></translation>
+        <translation>Automatyczne Wyrównanie Tekstu</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="1927"/>
         <source>Improve readability of code</source>
-        <translation type="unfinished"></translation>
+        <translation>Poprawia czytelność kodu</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="1931"/>
         <location filename="../mainwindow.cpp" line="1932"/>
         <source>Increase Text Size</source>
-        <translation type="unfinished"></translation>
+        <translation>Zwiększa Wielkość Tekstu</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="1936"/>
         <location filename="../mainwindow.cpp" line="1937"/>
         <source>Decrease Text Size</source>
-        <translation type="unfinished"></translation>
+        <translation>Zmniejsza Wielkość Tekstu</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="1942"/>
         <source>Tools</source>
-        <translation type="unfinished"></translation>
+        <translation>Narzędzia</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="1989"/>
         <source>About</source>
-        <translation type="unfinished"></translation>
+        <translation>Informacje</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="1990"/>
         <source>Core Team</source>
-        <translation type="unfinished"></translation>
+        <translation>Zespół Podstawowy</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="1991"/>
         <source>Contributors</source>
-        <translation type="unfinished"></translation>
+        <translation>Osoby, które wniosły wkład</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="1992"/>
         <source>Community</source>
-        <translation type="unfinished"></translation>
+        <translation>Społeczność</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="1993"/>
         <source>License</source>
-        <translation type="unfinished"></translation>
+        <translation>Licencja</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="1994"/>
         <source>History</source>
-        <translation type="unfinished"></translation>
+        <translation>HIstoria</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="2015"/>
         <source>Sonic Pi - Info</source>
-        <translation type="unfinished"></translation>
+        <translation>Sonic Pi - Info</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="2035"/>
         <location filename="../mainwindow.cpp" line="2036"/>
         <source>Stop Recording</source>
-        <translation type="unfinished"></translation>
+        <translation>Zakończ Nagrywanie</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="2049"/>
         <source>Save Recording</source>
-        <translation type="unfinished"></translation>
+        <translation>Zapisz Nagranie</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="2068"/>
         <source>Ready...</source>
-        <translation type="unfinished"></translation>
+        <translation>Gotowy....</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="2145"/>
         <source>Cannot read file %1:
 %2.</source>
-        <translation type="unfinished"></translation>
+        <translation>NIe można odczytać pliku %1: %2.</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="2155"/>
         <source>File loaded...</source>
-        <translation type="unfinished"></translation>
+        <translation>Plik wczytany....</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="2163"/>
         <source>Cannot write file %1:
 %2.</source>
-        <translation type="unfinished"></translation>
+        <translation>Nie można zapisać pliku %1: %2.</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="2180"/>
         <source>File saved...</source>
-        <translation type="unfinished"></translation>
+        <translation>Plik zapisany....</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="2405"/>
         <source>Last checked %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Ostatnio sprawdzono %1</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="2407"/>
         <source>Sonic Pi checks for updates
 every two weeks.</source>
-        <translation type="unfinished"></translation>
+        <translation>Sonic Pi sprawdza aktualizacje
+co dwa tygodnie.</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="2409"/>
         <source>This is Sonic Pi %1</source>
-        <translation type="unfinished"></translation>
+        <translation>To jest Sonic Pi %1</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="2410"/>
         <source>Version %2 is now available!</source>
-        <translation type="unfinished"></translation>
+        <translation>Wersja %2 jest dostępna!</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="2414"/>
         <source>New version available!
 Get Sonic Pi %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Nowa wersja jest już dostępna! Pobierz Sonic Pi %1</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="2440"/>
         <source>Welcome back. Now get your live code on...</source>
-        <translation type="unfinished"></translation>
+        <translation>Witaj ponownie. A teraz spraw aby twój kod ożył...</translation>
     </message>
     <message>
         <location filename="../ruby_help.h" line="80"/>
@@ -717,32 +744,32 @@ Get Sonic Pi %1</source>
         <location filename="../ruby_help.h" line="229"/>
         <location filename="../ruby_help.h" line="289"/>
         <source>Tutorial</source>
-        <translation type="unfinished"></translation>
+        <translation>Samouczek</translation>
     </message>
     <message>
         <location filename="../ruby_help.h" line="321"/>
         <source>Examples</source>
-        <translation type="unfinished"></translation>
+        <translation>Przykłady</translation>
     </message>
     <message>
         <location filename="../ruby_help.h" line="361"/>
         <source>Synths</source>
-        <translation type="unfinished"></translation>
+        <translation>Syntezatory</translation>
     </message>
     <message>
         <location filename="../ruby_help.h" line="397"/>
         <source>Fx</source>
-        <translation type="unfinished"></translation>
+        <translation>Efekty</translation>
     </message>
     <message>
         <location filename="../ruby_help.h" line="414"/>
         <source>Samples</source>
-        <translation type="unfinished"></translation>
+        <translation>Sample</translation>
     </message>
     <message>
         <location filename="../ruby_help.h" line="580"/>
         <source>Lang</source>
-        <translation type="unfinished"></translation>
+        <translation>Język</translation>
     </message>
 </context>
 <context>
@@ -750,7 +777,7 @@ Get Sonic Pi %1</source>
     <message>
         <location filename="../main.cpp" line="43"/>
         <source>Sonic Pi</source>
-        <translation type="unfinished"></translation>
+        <translation>Sonic Pi</translation>
     </message>
 </context>
 <context>
@@ -758,7 +785,7 @@ Get Sonic Pi %1</source>
     <message>
         <location filename="../sonicpiudpserver.cpp" line="24"/>
         <source>Is Sonic Pi already running?  Can&apos;t open UDP port 4558.</source>
-        <translation type="unfinished"></translation>
+        <translation>Czy Sonic Pi nie jest już uruchoiony? Nie można otworzyć portu UDP o numerze 4558.</translation>
     </message>
 </context>
 </TS>


### PR DESCRIPTION
I've tested it a little bit on my RPi & it work quite nice. Issues I've founded: 

* GUI translations for DE, IT & JP are out of date
* After building latest version & running `git status` I've found that there are some "uncommited changes" on vendor tree
* It looks like in current version under pl locale shortcuts for changing buffers `M->, M-<` doesn't work at all, instead of it I was able to use `C-Tab & C-S-Tab` to do this
* stop all shortcut `M-s` sometimes doesn't work & sometimes work

Regards, 
Luke.