### PR TITLE
WIP: move to QPlainTextEdit for logging

### DIFF
--- a/app/gui/qt/mainwindow.cpp
+++ b/app/gui/qt/mainwindow.cpp
@@ -318,22 +318,24 @@ MainWindow::MainWindow(QApplication &app, bool i18n, QSplashScreen* splash)
   errorPane->setReadOnly(true);
   outputPane->setLineWrapMode(QPlainTextEdit::NoWrap);
 #if defined(Q_OS_WIN)
-  // outputPane->setFontFamily("Courier New");
+  outputPane->setFontFamily("Courier New");
 #elif defined(Q_OS_MAC)
-  // outputPane->setFontFamily("Menlo");
+  outputPane->setFontFamily("Menlo");
 #else
-  // outputPane->setFontFamily("Bitstream Vera Sans Mono");
+  outputPane->setFontFamily("Bitstream Vera Sans Mono");
 #endif
 
-  //if(!theme->font("LogFace").isEmpty()){
-  //    outputPane->setFontFamily(theme->font("LogFace"));
-  //}
+  if(!theme->font("LogFace").isEmpty()){
+      outputPane->setFontFamily(theme->font("LogFace"));
+  }
 
   outputPane->document()->setMaximumBlockCount(1000);
   errorPane->document()->setMaximumBlockCount(1000);
 
   outputPane->zoomIn(1);
-  //outputPane->setTextColor(QColor(theme->color("LogDefaultForeground")));
+  //outputPane->setBackgroundVisible(true);
+  //outputPane->setAutoFillBackground(true);
+  outputPane->setTextColor(QColor(theme->color("LogInfoForeground")));
   outputPane->appendPlainText("\n");
   //outputPane->append(asciiArtLogo());
 
@@ -1565,6 +1567,7 @@ void MainWindow::updateDarkMode(){
 
     QString windowColor = currentTheme->color("WindowBackground").name();
     QString windowForegroundColor = currentTheme->color("WindowForeground").name();
+    QString logInfoForegroundColor = currentTheme->color("LogInfoForeground").name();
     QString paneColor = currentTheme->color("PaneBackground").name();
     QString windowBorder = currentTheme->color("WindowBorder").name();
     QString selectedTab = "deeppink";
@@ -1580,7 +1583,8 @@ void MainWindow::updateDarkMode(){
 
     this->setStyleSheet(QString(buttonStyling + splitterStyling+ toolTipStyling+scrollStyling + "QToolButton:hover{background: transparent;} QSlider::groove:vertical{margin: 2px 0; background: dodgerblue; border-radius: 3px;} QSlider::handle:vertical {border: 1px solid #222; border-radius: 3px; height: 30px; background: #333;} QMenu{background: #929292; color: #000; } QMenu:selected{background: deeppink;} QMainWindow::separator{border: 1px solid %1;} QMainWindow{background-color: %1; color: white;}").arg(windowColor));
     statusBar()->setStyleSheet( QString("QWidget{background-color: %1; color: #808080;} QStatusBar{background-color: %1; border-top: 1px solid %2;}").arg(windowColor, windowBorder));
-    outputPane->setStyleSheet(  QString("QTextEdit{background-color: %1; color: %2; border: 0px;}").arg(paneColor, windowForegroundColor));
+    // Colour log messages as info by default
+    outputPane->setStyleSheet(  QString("QPlainTextEdit{background-color: %1; color: %2; border: 0px;}").arg(paneColor, logInfoForegroundColor));
     outputWidget->setStyleSheet(widgetTitleStyling);
     prefsWidget->setStyleSheet( QString(widgetTitleStyling + "QGroupBox:title{subcontrol-origin: margin; top:0px; padding: 0px 0 20px 5px; font-size: 11px; color: %1; background-color: transparent;} QGroupBox{padding: 0 0 0 0; subcontrol-origin: margin; margin-top: 15px; margin-bottom: 0px; font-size: 11px; background-color:#1c2325; border: 1px solid #1c2529; color: %1;} QWidget{background-color: %2;}" + buttonStyling).arg(windowForegroundColor, windowColor));
     tabs->setStyleSheet(tabStyling);
@@ -1624,6 +1628,7 @@ void MainWindow::updateDarkMode(){
     QString l_windowColor = currentTheme->color("WindowBackground").name();
     QString l_windowForegroundColor = currentTheme->color("WindowForeground").name();
     QString l_foregroundColor = currentTheme->color("Foreground").name();
+    QString l_logInfoForegroundColor = currentTheme->color("LogInfoForeground").name();
     QString l_paneColor = currentTheme->color("PaneBackground").name();
     QString l_windowBorder = currentTheme->color("WindowBorder").name();
     QString l_selectedTab = "deeppink";
@@ -1667,7 +1672,8 @@ void MainWindow::updateDarkMode(){
     this->setStyleSheet(QString(l_buttonStyling + l_splitterStyling+ l_toolTipStyling+l_scrollStyling + "QSlider::groove:vertical{margin: 2px 0; background: dodgerblue; border-radius: 3px;} QSlider::handle:vertical {border: 1px solid #222; border-radius: 3px; height: 30px; background: #333;} QMenu{background: #929292; color: #000; } QMenu:selected{background: deeppink;} QMainWindow::separator{border: 1px solid %1;} QMainWindow{background-color: %1; color: white;}").arg(l_windowColor));
 
     statusBar()->setStyleSheet( QString("QStatusBar{background-color: %1; border-top: 1px solid %2;}").arg(l_windowColor, l_windowBorder));
-    outputPane->setStyleSheet(  QString("QTextEdit{background-color: %1; color: %2; border: 0px;}").arg(l_paneColor, l_windowForegroundColor));
+    // Colour log messages as info by default
+    outputPane->setStyleSheet(  QString("QPlainTextEdit{background-color: %1; color: %2; border: 0px;}").arg(l_paneColor, l_logInfoForegroundColor));
     outputWidget->setStyleSheet(l_widgetTitleStyling);
     prefsWidget->setStyleSheet( QString(l_buttonStyling + l_widgetTitleStyling + "QGroupBox:title{subcontrol-origin: margin; top:0px; padding: 0px 0 20px 5px; font-size: 11px; color: %1; background-color: transparent;} QGroupBox{padding: 0 0 0 0; subcontrol-origin: margin; margin-top: 15px; margin-bottom: 0px; font-size: 11px; background-color: %2; border: 1px solid lightgray; color: %1;}").arg(l_windowForegroundColor, l_windowColor));
     tabs->setStyleSheet(        l_tabStyling);

--- a/app/gui/qt/mainwindow.cpp
+++ b/app/gui/qt/mainwindow.cpp
@@ -332,7 +332,10 @@ MainWindow::MainWindow(QApplication &app, bool i18n, QSplashScreen* splash)
   outputPane->document()->setMaximumBlockCount(1000);
   errorPane->document()->setMaximumBlockCount(1000);
 
-  //outputPane->zoomIn(1);
+#if QT_VERSION >= 0x050400
+  //zoomable QPlainTextEdit requires QT 5.4
+  outputPane->zoomIn(1);
+#endif
   outputPane->setTextColor(QColor(theme->color("LogInfoForeground")));
   outputPane->appendPlainText("\n");
   //outputPane->append(asciiArtLogo());

--- a/app/gui/qt/mainwindow.cpp
+++ b/app/gui/qt/mainwindow.cpp
@@ -316,25 +316,25 @@ MainWindow::MainWindow(QApplication &app, bool i18n, QSplashScreen* splash)
   addUniversalCopyShortcuts(errorPane);
   outputPane->setReadOnly(true);
   errorPane->setReadOnly(true);
-  outputPane->setLineWrapMode(QTextEdit::NoWrap);
+  outputPane->setLineWrapMode(QPlainTextEdit::NoWrap);
 #if defined(Q_OS_WIN)
-  outputPane->setFontFamily("Courier New");
+  // outputPane->setFontFamily("Courier New");
 #elif defined(Q_OS_MAC)
-  outputPane->setFontFamily("Menlo");
+  // outputPane->setFontFamily("Menlo");
 #else
-  outputPane->setFontFamily("Bitstream Vera Sans Mono");
+  // outputPane->setFontFamily("Bitstream Vera Sans Mono");
 #endif
 
-  if(!theme->font("LogFace").isEmpty()){
-      outputPane->setFontFamily(theme->font("LogFace"));
-  }
+  //if(!theme->font("LogFace").isEmpty()){
+  //    outputPane->setFontFamily(theme->font("LogFace"));
+  //}
 
   outputPane->document()->setMaximumBlockCount(1000);
   errorPane->document()->setMaximumBlockCount(1000);
 
   outputPane->zoomIn(1);
-  outputPane->setTextColor(QColor(theme->color("LogDefaultForeground")));
-  outputPane->append("\n");
+  //outputPane->setTextColor(QColor(theme->color("LogDefaultForeground")));
+  outputPane->appendPlainText("\n");
   //outputPane->append(asciiArtLogo());
 
   errorPane->zoomIn(1);

--- a/app/gui/qt/mainwindow.cpp
+++ b/app/gui/qt/mainwindow.cpp
@@ -332,9 +332,7 @@ MainWindow::MainWindow(QApplication &app, bool i18n, QSplashScreen* splash)
   outputPane->document()->setMaximumBlockCount(1000);
   errorPane->document()->setMaximumBlockCount(1000);
 
-  outputPane->zoomIn(1);
-  //outputPane->setBackgroundVisible(true);
-  //outputPane->setAutoFillBackground(true);
+  //outputPane->zoomIn(1);
   outputPane->setTextColor(QColor(theme->color("LogInfoForeground")));
   outputPane->appendPlainText("\n");
   //outputPane->append(asciiArtLogo());

--- a/app/gui/qt/oschandler.cpp
+++ b/app/gui/qt/oschandler.cpp
@@ -51,9 +51,9 @@ void OscHandler::oscMessage(std::vector<char> buffer){
           QMetaObject::invokeMethod( out, "setTextColor",           Qt::QueuedConnection, Q_ARG(QColor, theme->color("LogInfoForeground")));
           QMetaObject::invokeMethod( out, "setTextBackgroundColor", Qt::QueuedConnection, Q_ARG(QColor, theme->color("LogInfoBackground")));
 
-          QMetaObject::invokeMethod( out, "append",                 Qt::QueuedConnection, Q_ARG(QString, QString::fromStdString("=> " + s + "\n")) );
+          QMetaObject::invokeMethod( out, "appendPlainText",        Qt::QueuedConnection, Q_ARG(QString, QString::fromStdString("=> " + s + "\n")) );
 
-          QMetaObject::invokeMethod( out, "setTextColor",           Qt::QueuedConnection, Q_ARG(QColor, QColor("#5e5e5e")));
+          QMetaObject::invokeMethod( out, "setTextColor",           Qt::QueuedConnection, Q_ARG(QColor, theme->color("LogDefaultForeground")));
           QMetaObject::invokeMethod( out, "setTextBackgroundColor", Qt::QueuedConnection, Q_ARG(QColor, theme->color("LogBackground")));
         } else {
           std::cout << "[GUI] - error: unhandled OSC msg /info "<< std::endl;

--- a/app/gui/qt/sonicpilog.cpp
+++ b/app/gui/qt/sonicpilog.cpp
@@ -2,31 +2,31 @@
 
 // Standard stuff
 #include <vector>
-#include "sonicpitheme.h"
+// #include "sonicpitheme.h"
 
-SonicPiLog::SonicPiLog(QWidget *parent) : QTextEdit(parent)
+SonicPiLog::SonicPiLog(QWidget *parent) : QPlainTextEdit(parent)
 {
 }
 
 void SonicPiLog::handleMultiMessage(SonicPiLog::MultiMessage mm)
 {
     int msg_count = mm.messages.size();
-    SonicPiTheme *theme = mm.theme;
+    // SonicPiTheme *theme = mm.theme;
 
     QString ss;
 
-    setTextColor(theme->color("LogDefaultForeground"));
+    //setTextColor(theme->color("LogDefaultForeground"));
     ss.append("[Run ").append(QString::number(mm.job_id));
     ss.append(", Time ").append(QString::fromStdString(mm.runtime));
     if(!mm.thread_name.empty()) {
       ss.append(", Thread :").append(QString::fromStdString(mm.thread_name));
     }
     ss.append("]");
-    append(ss);
+    appendPlainText(ss);
 
     for(int i = 0 ; i < msg_count ; i++) {
       ss = "";
-      int msg_type = mm.messages[i].msg_type;
+      //int msg_type = mm.messages[i].msg_type;
       std::string s = mm.messages[i].s;
 
       if(i == (msg_count - 1)) {
@@ -35,45 +35,45 @@ void SonicPiLog::handleMultiMessage(SonicPiLog::MultiMessage mm)
         ss.append(QString::fromUtf8(" ├─ "));
       }
 
-      append(ss);
+      appendPlainText(ss);
 
       ss = "";
-      switch(msg_type)
-      {
-      case 0:
-        setTextColor(QColor("deeppink"));
-        break;
-      case 1:
-        setTextColor(QColor("dodgerblue"));
-        break;
-      case 2:
-        setTextColor(QColor("darkorange"));
-        break;
-      case 3:
-        setTextColor(QColor("red"));
-        break;
-      case 4:
-        setTextColor(QColor("white"));
-        setTextBackgroundColor(QColor("deeppink"));
-        break;
-      case 5:
-        setTextColor(QColor("white"));
-        setTextBackgroundColor(QColor("dodgerblue"));
-        break;
-      case 6:
-        setTextColor(QColor("white"));
-        setTextBackgroundColor(QColor("darkorange"));
-        break;
-      default:
-        setTextColor(QColor("green"));
-      }
+      //switch(msg_type)
+      //{
+      //case 0:
+      //  setTextColor(QColor("deeppink"));
+      //  break;
+      //case 1:
+      //  setTextColor(QColor("dodgerblue"));
+      //  break;
+      //case 2:
+      //  setTextColor(QColor("darkorange"));
+      //  break;
+      //case 3:
+      //  setTextColor(QColor("red"));
+      //  break;
+      //case 4:
+      //  setTextColor(QColor("white"));
+      //  setTextBackgroundColor(QColor("deeppink"));
+      //  break;
+      //case 5:
+      //  setTextColor(QColor("white"));
+      //  setTextBackgroundColor(QColor("dodgerblue"));
+      //  break;
+      //case 6:
+      //  setTextColor(QColor("white"));
+      //  setTextBackgroundColor(QColor("darkorange"));
+      //  break;
+      //default:
+      //  setTextColor(QColor("green"));
+      //}
 
       ss.append(QString::fromUtf8(s.c_str()));
 
       insertPlainText(ss);
 
-      setTextColor(theme->color("LogDefaultForeground"));
-      setTextBackgroundColor(theme->color("LogBackground"));
+      //setTextColor(theme->color("LogDefaultForeground"));
+      //setTextBackgroundColor(theme->color("LogBackground"));
     }
-    append(QString::fromStdString(" "));
+    appendPlainText(QString::fromStdString(" "));
 }

--- a/app/gui/qt/sonicpilog.cpp
+++ b/app/gui/qt/sonicpilog.cpp
@@ -2,20 +2,43 @@
 
 // Standard stuff
 #include <vector>
-// #include "sonicpitheme.h"
+#include "sonicpitheme.h"
 
 SonicPiLog::SonicPiLog(QWidget *parent) : QPlainTextEdit(parent)
 {
 }
 
+void SonicPiLog::setTextColor(QColor c)
+{
+  QTextCharFormat tf;
+  tf.setForeground(c);
+  setCurrentCharFormat(tf);
+}
+
+void SonicPiLog::setTextBackgroundColor(QColor c)
+{
+  QTextCharFormat tf;
+  tf.setBackground(c);
+  setCurrentCharFormat(tf);
+}
+
+void SonicPiLog::setFontFamily(QString font_name)
+{
+  setFont(QFont(font_name));
+}
+
 void SonicPiLog::handleMultiMessage(SonicPiLog::MultiMessage mm)
 {
     int msg_count = mm.messages.size();
-    // SonicPiTheme *theme = mm.theme;
+    SonicPiTheme *theme = mm.theme;
 
+    QTextCharFormat tf;
     QString ss;
 
-    //setTextColor(theme->color("LogDefaultForeground"));
+    tf.setForeground(theme->color("LogDefaultForeground"));
+    tf.setBackground(theme->color("LogBackground"));
+    setCurrentCharFormat(tf);
+
     ss.append("[Run ").append(QString::number(mm.job_id));
     ss.append(", Time ").append(QString::fromStdString(mm.runtime));
     if(!mm.thread_name.empty()) {
@@ -26,7 +49,7 @@ void SonicPiLog::handleMultiMessage(SonicPiLog::MultiMessage mm)
 
     for(int i = 0 ; i < msg_count ; i++) {
       ss = "";
-      //int msg_type = mm.messages[i].msg_type;
+      int msg_type = mm.messages[i].msg_type;
       std::string s = mm.messages[i].s;
 
       if(i == (msg_count - 1)) {
@@ -38,42 +61,45 @@ void SonicPiLog::handleMultiMessage(SonicPiLog::MultiMessage mm)
       appendPlainText(ss);
 
       ss = "";
-      //switch(msg_type)
-      //{
-      //case 0:
-      //  setTextColor(QColor("deeppink"));
-      //  break;
-      //case 1:
-      //  setTextColor(QColor("dodgerblue"));
-      //  break;
-      //case 2:
-      //  setTextColor(QColor("darkorange"));
-      //  break;
-      //case 3:
-      //  setTextColor(QColor("red"));
-      //  break;
-      //case 4:
-      //  setTextColor(QColor("white"));
-      //  setTextBackgroundColor(QColor("deeppink"));
-      //  break;
-      //case 5:
-      //  setTextColor(QColor("white"));
-      //  setTextBackgroundColor(QColor("dodgerblue"));
-      //  break;
-      //case 6:
-      //  setTextColor(QColor("white"));
-      //  setTextBackgroundColor(QColor("darkorange"));
-      //  break;
-      //default:
-      //  setTextColor(QColor("green"));
-      //}
+      switch(msg_type)
+      {
+      case 0:
+        tf.setForeground(QColor("deeppink"));
+        break;
+      case 1:
+        tf.setForeground(QColor("dodgerblue"));
+        break;
+      case 2:
+        tf.setForeground(QColor("darkorange"));
+        break;
+      case 3:
+        tf.setForeground(QColor("red"));
+        break;
+      case 4:
+        tf.setForeground(QColor("white"));
+        tf.setBackground(QColor("deeppink"));
+        break;
+      case 5:
+        tf.setForeground(QColor("white"));
+        tf.setBackground(QColor("dodgerblue"));
+        break;
+      case 6:
+        tf.setForeground(QColor("white"));
+        tf.setBackground(QColor("darkorange"));
+        break;
+      default:
+        tf.setForeground(QColor("green"));
+      }
+
+      setCurrentCharFormat(tf);
 
       ss.append(QString::fromUtf8(s.c_str()));
 
       insertPlainText(ss);
 
-      //setTextColor(theme->color("LogDefaultForeground"));
-      //setTextBackgroundColor(theme->color("LogBackground"));
+      tf.setForeground(theme->color("LogDefaultForeground"));
+      tf.setBackground(theme->color("LogBackground"));
+      setCurrentCharFormat(tf);
     }
     appendPlainText(QString::fromStdString(" "));
 }

--- a/app/gui/qt/sonicpilog.h
+++ b/app/gui/qt/sonicpilog.h
@@ -30,6 +30,9 @@ public:
 signals:
 
 public slots:
+    void setTextColor(QColor c);
+    void setTextBackgroundColor(QColor c);
+    void setFontFamily(QString font_name);
     void handleMultiMessage(SonicPiLog::MultiMessage mm);
 
 protected:

--- a/app/gui/qt/sonicpilog.h
+++ b/app/gui/qt/sonicpilog.h
@@ -1,11 +1,11 @@
 #ifndef SONICPILOG_H
 #define SONICPILOG_H
 
-#include <QTextEdit>
+#include <QPlainTextEdit>
 
 class SonicPiTheme;
 
-class SonicPiLog : public QTextEdit
+class SonicPiLog : public QPlainTextEdit
 {
     Q_OBJECT
 public:


### PR DESCRIPTION
Apparently `QPlainTextEdit` is more suited to logging performance wise
that the `QTextEdit` we are currently using.

Sources:

http://stackoverflow.com/a/6914301/2618015
http://stackoverflow.com/questions/17466046/qtextedit-vs-qplaintextedit

This commit swaps out the widget but loses the formatting. Apparently it
does work with HTML and stylesheets as it's designed for coloured
logging.

Formatting is probably best achieved with either `setCurrentCharFormat`
or [QSyntaxHighlighter](http://doc.qt.io/qt-4.8/qsyntaxhighlighter.html)

# Todo

- [ ] get formatting to work
- [ ] check performance/memory usage