### PR TITLE
Fixup osc empty strings

### DIFF
--- a/app/server/sonicpi/lib/sonicpi/oscencode.rb
+++ b/app/server/sonicpi/lib/sonicpi/oscencode.rb
@@ -101,7 +101,7 @@ module SonicPi
 
       tags_encoded = get_from_or_add_to_string_cache(tags)
       # Address here needs to be a new string, not sure why
-      String.new(address) << tags_encoded << args_encoded
+      "#{address}#{tags_encoded}#{args_encoded}"
     end
 
     def encode_single_bundle(ts, address, args=[])

--- a/app/server/sonicpi/lib/sonicpi/oscencode.rb
+++ b/app/server/sonicpi/lib/sonicpi/oscencode.rb
@@ -118,7 +118,7 @@ module SonicPi
         # Forgive me father, for I have sinned...
         # This makes a null padded string rounded up to the nearest
         # multiple of four
-        res = [s].pack("Z#{4*((s.bytesize.zero? ? 0 : s.bytesize.to_f+0.01)/4).ceil}")
+        res = [s].pack("Z#{4*((s.bytesize.to_f+0.01)/4).ceil}")
         if @num_cached_strings < @cache_size
           # only cache the first @cache_size strings to avoid a memory
           # memory leak.

--- a/app/server/sonicpi/test/test_osc.rb
+++ b/app/server/sonicpi/test/test_osc.rb
@@ -35,8 +35,8 @@ module SonicPi
       encoder = OscEncode.new
       decoder = OscDecode.new
 
-      address = "/foobar"
-      args = ["beans"]
+      address = "/multi_message"
+      args = [1, "", "0.0", 1, 0, "synth :beep, {note: 60.0}"]
 
       m = encoder.encode_single_message(address, args)
       m2 = OSC::Message.new(address, *args).encode


### PR DESCRIPTION
Empty strings should be encoded as four null bytes in OSC like so

```
"\x00\x00\x00\x00"
```

This commit is correcting my misunderstanding of the OSC spec.

`osc-ruby` for example, makes sure that the empty strings always have a '\x00' on the end which means when their length is calculated it is always padded up to four bytes when they are "empty", as per the OSC spec.