### PR TITLE
[POC] Interpret notes as ranks on a scale.

### DIFF
--- a/app/server/sonicpi/lib/sonicpi/lang/core.rb
+++ b/app/server/sonicpi/lib/sonicpi/lang/core.rb
@@ -1728,6 +1728,18 @@ end
 
 
 
+      def use_key(tonic, name)
+        pitches = scale(tonic, name)
+        key = lambda do |index|
+                rank = index % 7
+                octave = index / 7
+                pitches[rank] + 12 * octave
+              end
+        Thread.current.thread_variable_set(:sonic_pi_spider_key, key)
+      end
+      doc name:           :use_key,
+          summary:        "Set the key",
+          doc:            "Sets the key for everything afterwards."
 
 
 

--- a/app/server/sonicpi/lib/sonicpi/lang/sound.rb
+++ b/app/server/sonicpi/lib/sonicpi/lang/sound.rb
@@ -2513,9 +2513,14 @@ puts status # Returns something similar to:
       def note(n, *args)
         # Short circuit out if possible.
         # Also recurse if necessary.
+
         case n
         when Numeric
-          return n
+          if (key = Thread.current.thread_variable_get(:sonic_pi_spider_key))
+            return key.call(n)
+          else
+            return n
+          end
         when Symbol
           return nil if(n == :r || n == :rest)
         when NilClass
@@ -2539,24 +2544,29 @@ puts status # Returns something similar to:
       doc name:          :note,
       introduced:    Version.new(2,0,0),
       summary:       "Describe note",
-      doc:           "Takes a midi note, a symbol (e.g. `:C`) or a string (e.g. `\"C\"`) and resolves it to a midi note. You can also pass an optional `octave:` parameter to get the midi note for a given octave. Please note - `octave:` param overrides any octave specified in a symbol i.e. `:c3`. If the note is `nil`, `:r` or `:rest`, then `nil` is returned (`nil` represents a rest)",
+      doc:           "Takes a note, a symbol (e.g. `:C`) or a string (e.g. `\"C\"`) and resolves it to a midi note. You can also pass an optional `octave:` parameter to get the midi note for a given octave. Please note - `octave:` param overrides any octave specified in a symbol i.e. `:c3`. If the note is `nil`, `:r` or `:rest`, then `nil` is returned (`nil` represents a rest)",
       args:          [[:note, :symbol_or_number]],
       opts:          {:octave => "The octave of the note. Overrides any octave declaration in the note symbol such as :c2. Default is 4"},
       accepts_block: false,
       examples:      ["
 # These all return 60 which is the midi number for middle C (octave 4)
-puts note(60)
 puts note(:C)
 puts note(:C4)
 puts note('C')
+
+# And when the key is C major
+puts note(0)
 ",
         "# returns 60 - octave param has no effect if we pass in a number
-puts note(60, octave: 2)
+puts note(0, octave: 2)
 
 # These all return 36 which is the midi number for C2 (two octaves below middle C)
 puts note(:C, octave: 2)
 puts note(:C4, octave: 2) # note the octave param overrides any octaves specified in a symbol
 puts note('C', octave: 2)
+
+# And when the key is C major
+puts note(-14)
 "]
 
 


### PR DESCRIPTION
I find calculating midi pitches tedious and difficult. I need to have a strong understanding of scales, and I have to work with awkwardly large numbers ~50 - ~80.

With this patch, simple counting numbers sound musical. I find that working within a defined scale makes experimentation a lot more likely to hit upon something that I like: 

    use_key(:G, :major)

    live_loop :melody do
      with_synth :blade do
        play_pattern([0, 1, 2, 3, 4, 5, 6, 7])
      end
    end

This is only a proof-of-concept, and would need more work to be safely merged. Some things to consider if it were taken further:
  * Should scales be zero-indexed, or one-indexed? The former makes it easier to calculate the tonic across octaves (multiples of seven), but might confound the expectations of someone new to programming.
  * Should the method actually be `use_scale` and take a whole scale as an argument - `use_scale scale(:C, :major)`? This is more extensible, as users can supply their own scales.
  * Should we support accidentals via fractions e.g. `1.5` is the accidental between `1` and `2`?
  * Should there be a `with_key` for symmetry?