### PR TITLE
Ensure we show the splash screen

### DIFF
--- a/app/gui/qt/mainwindow.cpp
+++ b/app/gui/qt/mainwindow.cpp
@@ -103,6 +103,7 @@ MainWindow::MainWindow(QApplication &app, bool i18n, QSplashScreen* splash)
 #endif
 {
   app.installEventFilter(this);
+  app.processEvents();
 
   setupLogPathAndRedirectStdOut();
   std::cout << "\n\n\n";


### PR DESCRIPTION
On OS X this gets me the splash-screen back.
The event loop in app.exec is blocking and the splash window won't show within the main fn. Though it did before...

