### PR TITLE
double quotes removed in tutorial titles and french gui translation

### DIFF
--- a/app/gui/qt/SonicPi.pro
+++ b/app/gui/qt/SonicPi.pro
@@ -85,7 +85,8 @@ HEADERS  += mainwindow.h \
 TRANSLATIONS = lang/sonic-pi_de.ts \
                lang/sonic-pi_is.ts \
                lang/sonic-pi_ja.ts \
-               lang/sonic-pi_pl.ts
+               lang/sonic-pi_pl.ts \
+               lang/sonic-pi_fr.ts
 
 OTHER_FILES += \
     images/copy.png \

--- a/app/gui/qt/SonicPi.qrc
+++ b/app/gui/qt/SonicPi.qrc
@@ -50,5 +50,6 @@
         <file>lang/sonic-pi_is.qm</file>
         <file>lang/sonic-pi_ja.qm</file>
         <file>lang/sonic-pi_pl.qm</file>
+        <file>lang/sonic-pi_fr.qm</file>
     </qresource>
 </RCC>

--- a/app/gui/qt/lang/sonic-pi_de.ts
+++ b/app/gui/qt/lang/sonic-pi_de.ts
@@ -5,29 +5,29 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../mainwindow.cpp" line="350"/>
+        <location filename="../mainwindow.cpp" line="360"/>
         <source>Preferences</source>
         <translation>Einstellungen</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="363"/>
+        <location filename="../mainwindow.cpp" line="373"/>
         <source>Log</source>
         <translation>Protokoll</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="435"/>
-        <location filename="../mainwindow.cpp" line="2138"/>
-        <location filename="../mainwindow.cpp" line="2156"/>
+        <location filename="../mainwindow.cpp" line="445"/>
+        <location filename="../mainwindow.cpp" line="2152"/>
+        <location filename="../mainwindow.cpp" line="2170"/>
         <source>Sonic Pi</source>
         <translation>Sonic Pi</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="793"/>
+        <location filename="../mainwindow.cpp" line="803"/>
         <source>Raspberry Pi System Volume</source>
         <translation>Raspberry Pi Lautstärke</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="799"/>
+        <location filename="../mainwindow.cpp" line="809"/>
         <source>Toggle stereo inversion.
 If enabled, audio sent to the left speaker will
 be routed to the right speaker and visa versa.</source>
@@ -36,7 +36,7 @@ Der Ton des linken Kanals wird zum rechten
 Lautsprecher geschickt und umgekehrt.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="802"/>
+        <location filename="../mainwindow.cpp" line="812"/>
         <source>Toggle mono mode.
 If enabled both right and left audio is mixed and
 the same signal is sent to both speakers.
@@ -50,32 +50,32 @@ Praktisch, wenn der externe Verstärker nur
 Mono-Ton verarbeiten kann.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="818"/>
+        <location filename="../mainwindow.cpp" line="828"/>
         <source>Raspberry Pi Audio Output</source>
         <translation>Raspberry Pi Audio-Ausgabe</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="820"/>
+        <location filename="../mainwindow.cpp" line="830"/>
         <source>&amp;Default</source>
         <translation>&amp;Standard</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="821"/>
+        <location filename="../mainwindow.cpp" line="831"/>
         <source>&amp;Headphones</source>
         <translation>&amp;Kopfhörerbuchse</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="822"/>
+        <location filename="../mainwindow.cpp" line="832"/>
         <source>&amp;HDMI</source>
         <translation>&amp;HDMI</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="843"/>
+        <location filename="../mainwindow.cpp" line="853"/>
         <source>Configure debug behaviour</source>
         <translation>Debug-Optionen bearbeiten</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="846"/>
+        <location filename="../mainwindow.cpp" line="856"/>
         <source>Toggle log messages.
 If disabled, activity such as synth and sample
 triggering will not be printed to the log by default.</source>
@@ -84,17 +84,17 @@ Die Protokoll-Nachrichten, wenn ein Synth oder
 Sample ausgelöst wird, lassen sich hier abschalten.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="805"/>
+        <location filename="../mainwindow.cpp" line="815"/>
         <source>Safe mode</source>
         <translation>Sichere Synth-Parameter</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="848"/>
+        <location filename="../mainwindow.cpp" line="858"/>
         <source>Clear log on run</source>
         <translation>Protokoll vor Ausführen leeren</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="849"/>
+        <location filename="../mainwindow.cpp" line="859"/>
         <source>Toggle log clearing on run.
 If enabled, the log is cleared each
 time the run button is pressed.</source>
@@ -103,78 +103,78 @@ Löscht das alte Protokoll bei jedem
 Klick auf den Ausführen-Button.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="914"/>
+        <location filename="../mainwindow.cpp" line="924"/>
         <source>Toggle line number visibility.</source>
         <translation>Anzeige der Zeilennummern an-/abschalten.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="926"/>
+        <location filename="../mainwindow.cpp" line="936"/>
         <source>Dark mode</source>
         <translation>Dunkle Oberfläche</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1239"/>
+        <location filename="../mainwindow.cpp" line="1249"/>
         <source>Running Code...</source>
         <oldsource>Running Code....</oldsource>
         <translation>Führe Programm aus...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1295"/>
+        <location filename="../mainwindow.cpp" line="1305"/>
         <source>Beautifying...</source>
         <oldsource>Beautifying....</oldsource>
         <translation>Textausrichtung...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1315"/>
+        <location filename="../mainwindow.cpp" line="1325"/>
         <source>Reloading...</source>
         <oldsource>Reloading....</oldsource>
         <translation>Neu laden...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1346"/>
+        <location filename="../mainwindow.cpp" line="1356"/>
         <source>Enabling Mixer HPF...</source>
         <oldsource>Enabling Mixer HPF....</oldsource>
         <translation>Mixer-Hochpassfilter aktiv...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1355"/>
+        <location filename="../mainwindow.cpp" line="1365"/>
         <source>Disabling Mixer HPF...</source>
         <oldsource>Disabling Mixer HPF....</oldsource>
         <translation>Mixer-Hochpassfilter inaktiv...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1265"/>
+        <location filename="../mainwindow.cpp" line="1275"/>
         <source>Workspace %1</source>
         <translation>Arbeitsbereich %1</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="295"/>
+        <location filename="../mainwindow.cpp" line="296"/>
         <source>Buffer %1</source>
         <translation>Buffer %1</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="449"/>
+        <location filename="../mainwindow.cpp" line="459"/>
         <source>Welcome to Sonic Pi</source>
         <translation>Sonic Pi begrüßt Dich!</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="591"/>
+        <location filename="../mainwindow.cpp" line="601"/>
         <source>Indenting selection...</source>
         <translation>Auswahl einrücken...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="595"/>
+        <location filename="../mainwindow.cpp" line="605"/>
         <source>Indenting line...</source>
         <translation>Zeile einrücken...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="794"/>
+        <location filename="../mainwindow.cpp" line="804"/>
         <source>Use this slider to change the system volume of your Raspberry Pi.</source>
         <oldsource>Use this slider to change the system volume of your Raspberry Pi</oldsource>
         <translation>Hier veränderst Du die Systemlautstärke Deines Raspberry Pi.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="797"/>
+        <location filename="../mainwindow.cpp" line="807"/>
         <source>Advanced audio settings for working with
 external PA systems when performing with Sonic Pi.</source>
         <oldsource>Advanced audio settings for working with external PA systems when performing with Sonic Pi.</oldsource>
@@ -182,17 +182,17 @@ external PA systems when performing with Sonic Pi.</source>
 an einem externen Verstärker gut gebrauchen kann.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="798"/>
+        <location filename="../mainwindow.cpp" line="808"/>
         <source>Invert Stereo</source>
         <translation>Stereokanäle tauschen</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="801"/>
+        <location filename="../mainwindow.cpp" line="811"/>
         <source>Force Mono</source>
         <translation>Mono-Ton erzwingen</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="819"/>
+        <location filename="../mainwindow.cpp" line="829"/>
         <source>Your Raspberry Pi has two forms of audio output.
 Firstly, there is the headphone jack of the Raspberry Pi itself.
 Secondly, some HDMI monitors/TVs support audio through the HDMI port.
@@ -208,53 +208,53 @@ Zweitens: Der digitale HDMI-Monitoranschluss, der den Ton zum Monitor/Fernseher 
 Hier wählst Du aus, über welchen davon die Tonausgabe gehen soll.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="872"/>
-        <location filename="../mainwindow.cpp" line="994"/>
+        <location filename="../mainwindow.cpp" line="882"/>
+        <location filename="../mainwindow.cpp" line="1004"/>
         <source>Updates</source>
         <translation>Updates</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="874"/>
+        <location filename="../mainwindow.cpp" line="884"/>
         <source>Check for updates</source>
         <translation>Auf Updates prüfen</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="978"/>
+        <location filename="../mainwindow.cpp" line="988"/>
         <source>Editor</source>
         <translation>Editor</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="913"/>
+        <location filename="../mainwindow.cpp" line="923"/>
         <source>Show line numbers</source>
         <translation>Zeilennummern anzeigen</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="152"/>
+        <location filename="../mainwindow.cpp" line="153"/>
         <source>Sonic Pi update info</source>
         <translation>Sonic Pi Update-Info</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="624"/>
+        <location filename="../mainwindow.cpp" line="634"/>
         <source>Commenting selection...</source>
         <translation>Auswahl auskommentieren...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="628"/>
+        <location filename="../mainwindow.cpp" line="638"/>
         <source>Commenting line...</source>
         <translation>Zeile auskommentieren...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="707"/>
+        <location filename="../mainwindow.cpp" line="717"/>
         <source>Ruby could not be started, is it installed and in your PATH?</source>
         <translation>Konnte ruby nicht starten, ist es korrekt installiert?</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="796"/>
+        <location filename="../mainwindow.cpp" line="806"/>
         <source>Advanced Audio</source>
         <translation>Erweiterte Audio-Einstellungen</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="806"/>
+        <location filename="../mainwindow.cpp" line="816"/>
         <source>Toggle synth argument checking functions.
 If disabled, certain synth opt values may
 create unexpectedly loud or uncomfortable sounds.</source>
@@ -263,22 +263,22 @@ Ohne diese Prüfung können Synth-Werte auch mal
 unerwartet laute oder unangenehme Sounds erzeugen.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="842"/>
+        <location filename="../mainwindow.cpp" line="852"/>
         <source>Logging</source>
         <translation>Protokollieren</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="845"/>
+        <location filename="../mainwindow.cpp" line="855"/>
         <source>Log synths</source>
         <translation>Synths protokollieren</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="851"/>
+        <location filename="../mainwindow.cpp" line="861"/>
         <source>Log cues</source>
         <translation>Einsatz protokollieren</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="852"/>
+        <location filename="../mainwindow.cpp" line="862"/>
         <source>Enable or disable logging of cues.
 If disabled, cues will still trigger.
 However, they will not be visible in the logs.</source>
@@ -287,503 +287,503 @@ Falls deaktiviert, wird der Einsatz weiterhin ausgelöst.
 Dennoch sind sie im Protokoll nicht mehr sichtbar.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="861"/>
+        <location filename="../mainwindow.cpp" line="871"/>
         <source>Transparency</source>
         <translation>Transparenz</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="876"/>
+        <location filename="../mainwindow.cpp" line="886"/>
         <source>Toggle automatic update checking.
 This check involves sending anonymous information about your platform and version.</source>
         <translation>Automatisches Suchen nach Updates aktivieren.
 Diese Suche versendet anonyme Informationen über Deine Plattform und Version.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="877"/>
+        <location filename="../mainwindow.cpp" line="887"/>
         <source>Check now</source>
         <translation>Jetzt prüfen</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="878"/>
+        <location filename="../mainwindow.cpp" line="888"/>
         <source>Force a check for updates now.
 This check involves sending anonymous information about your platform and version.</source>
         <translation>Jetzt nach Updates suchen.
 Diese Suche versendet anonyme Informationen über Deine Plattform und Version.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="879"/>
+        <location filename="../mainwindow.cpp" line="889"/>
         <source>Get update</source>
         <translation>Update herunterladen</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="880"/>
+        <location filename="../mainwindow.cpp" line="890"/>
         <source>Visit http://sonic-pi.net to download new version</source>
         <translation>Besuche http://sonic-pi.net, um die neue Version herunterzuladen</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="885"/>
+        <location filename="../mainwindow.cpp" line="895"/>
         <source>Update Info</source>
         <translation>Update-Info</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="904"/>
+        <location filename="../mainwindow.cpp" line="914"/>
         <source>Show and Hide</source>
         <translation>Ein-/Ausblenden</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="905"/>
+        <location filename="../mainwindow.cpp" line="915"/>
         <source>Configure editor display options.</source>
         <translation>Ansichtsoptionen für das Editorfenster konfigurieren.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="906"/>
+        <location filename="../mainwindow.cpp" line="916"/>
         <source>Look and Feel</source>
         <translation>Darstellung</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="907"/>
+        <location filename="../mainwindow.cpp" line="917"/>
         <source>Configure editor look and feel.</source>
         <translation>Darstellung für das Editorfenster konfigurieren.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="908"/>
+        <location filename="../mainwindow.cpp" line="918"/>
         <source>Automation</source>
         <translation>Automatismen</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="909"/>
+        <location filename="../mainwindow.cpp" line="919"/>
         <source>Configure automation features.</source>
         <translation>Konfigurieren von praktischen automatischen Vorgängen</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="910"/>
+        <location filename="../mainwindow.cpp" line="920"/>
         <source>Auto-align</source>
         <translation>Auto-Ausrichtung</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="911"/>
+        <location filename="../mainwindow.cpp" line="921"/>
         <source>Automatically align code on Run</source>
         <translation>Lasse den Code beim Start automatisch ausrichten.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="915"/>
+        <location filename="../mainwindow.cpp" line="925"/>
         <source>Show log</source>
         <translation>Protokollfenster anzeigen</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="916"/>
+        <location filename="../mainwindow.cpp" line="926"/>
         <source>Toggle visibility of the log.</source>
         <translation>Protokollfenster anzeigen.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="918"/>
+        <location filename="../mainwindow.cpp" line="928"/>
         <source>Show buttons</source>
         <translation>Menüleiste anzeigen</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="919"/>
+        <location filename="../mainwindow.cpp" line="929"/>
         <source>Toggle visibility of the control buttons.</source>
         <translation>Menüleiste anzeigen.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="921"/>
+        <location filename="../mainwindow.cpp" line="931"/>
         <source>Show tabs</source>
         <translation>Tabs anzeigen</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="923"/>
+        <location filename="../mainwindow.cpp" line="933"/>
         <source>Toggle visibility of the buffer selection tabs.</source>
         <translation>Buffer-Auswahl anzeigen.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="924"/>
+        <location filename="../mainwindow.cpp" line="934"/>
         <source>Full screen</source>
         <translation>Vollbild</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="925"/>
+        <location filename="../mainwindow.cpp" line="935"/>
         <source>Toggle full screen mode.</source>
         <translation>In den Vollbildmodus umschalten.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="927"/>
+        <location filename="../mainwindow.cpp" line="937"/>
         <source>Toggle dark mode.</source>
         <translation>Zu dunkler Oberfläche umschalten.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="927"/>
+        <location filename="../mainwindow.cpp" line="937"/>
         <source>
 Dark mode is perfect for live coding in night clubs.</source>
         <translation>
 Die dunkle Oberfläche eignet sich hervorragend zum Live-Coden in Nachtklubs.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="966"/>
+        <location filename="../mainwindow.cpp" line="976"/>
         <source>Audio</source>
         <translation>Audio</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="979"/>
+        <location filename="../mainwindow.cpp" line="989"/>
         <source>Studio</source>
         <translation>Studio</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2434"/>
+        <location filename="../mainwindow.cpp" line="2448"/>
         <source>Welcome back. Now get your live code on...</source>
         <translation>Willkommen zurück. Legen wir los mit dem Live-Code...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1171"/>
+        <location filename="../mainwindow.cpp" line="1181"/>
         <source>Save Current Buffer</source>
         <translation>Aktuellen Buffer speichern</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1281"/>
+        <location filename="../mainwindow.cpp" line="1291"/>
         <source>Zooming In...</source>
         <translation>Text vergrößern...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1288"/>
+        <location filename="../mainwindow.cpp" line="1298"/>
         <source>Zooming Out...</source>
         <translation>Text verkleinern...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1322"/>
+        <location filename="../mainwindow.cpp" line="1332"/>
         <source>Checking for updates...</source>
         <translation>Auf Updates prüfen...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1330"/>
+        <location filename="../mainwindow.cpp" line="1340"/>
         <source>Enabling update checking...</source>
         <translation>Update-Prüfung aktiv...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1338"/>
+        <location filename="../mainwindow.cpp" line="1348"/>
         <source>Disabling update checking...</source>
         <translation>Update-Prüfung inaktiv...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1363"/>
+        <location filename="../mainwindow.cpp" line="1373"/>
         <source>Enabling Mixer LPF...</source>
         <oldsource>Enabling Mixer LPF....</oldsource>
         <translation>Mixer-Tiefpassfilter aktiv...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1372"/>
+        <location filename="../mainwindow.cpp" line="1382"/>
         <source>Disabling Mixer LPF...</source>
         <oldsource>Disabling Mixer LPF....</oldsource>
         <translation>Mixer-Tiefpassfilter inaktiv...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1380"/>
+        <location filename="../mainwindow.cpp" line="1390"/>
         <source>Enabling Inverted Stereo...</source>
         <oldsource>Enabling Inverted Stereo....</oldsource>
         <translation>Stereo-Kanaltausch aktiv...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1388"/>
+        <location filename="../mainwindow.cpp" line="1398"/>
         <source>Enabling Standard Stereo...</source>
         <oldsource>Enabling Standard Stereo....</oldsource>
         <translation>Stereo-Kanaltausch inaktiv...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1396"/>
+        <location filename="../mainwindow.cpp" line="1406"/>
         <source>Mono Mode...</source>
         <oldsource>Mono Mode....</oldsource>
         <translation>Mono-Ton aktiv...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1404"/>
+        <location filename="../mainwindow.cpp" line="1414"/>
         <source>Stereo Mode...</source>
         <oldsource>Stereo Mode....</oldsource>
         <translation>Stereo-Ton aktiv...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1413"/>
+        <location filename="../mainwindow.cpp" line="1423"/>
         <source>Stopping...</source>
         <translation>Stopp...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1497"/>
+        <location filename="../mainwindow.cpp" line="1507"/>
         <source>Updating System Volume...</source>
         <translation>Setze System-Lautstärke...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1715"/>
+        <location filename="../mainwindow.cpp" line="1729"/>
         <source>Switching To Headphone Audio Output...</source>
         <translation>Umschalten auf Kopfhörerbuchse...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1731"/>
+        <location filename="../mainwindow.cpp" line="1745"/>
         <source>Switching To HDMI Audio Output...</source>
         <translation>Umschalten auf HDMI-Anschluss...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1746"/>
+        <location filename="../mainwindow.cpp" line="1760"/>
         <source>Switching To Default Audio Output...</source>
         <translation>Umschalten auf Standard-Tonausgabe...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1898"/>
+        <location filename="../mainwindow.cpp" line="1912"/>
         <source>Save current buffer as an external file</source>
         <translation>Aktuellen Buffer als externe Datei speichern</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1916"/>
+        <location filename="../mainwindow.cpp" line="1930"/>
         <source>Start recording to WAV audio file</source>
         <translation>Tonausgabe in WAV-Datei aufnehmen</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1921"/>
+        <location filename="../mainwindow.cpp" line="1935"/>
         <source>Improve readability of code</source>
         <translation>Lesbarkeit des Codes verbessern</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2062"/>
+        <location filename="../mainwindow.cpp" line="2076"/>
         <source>Ready...</source>
         <translation>Bereit...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2149"/>
+        <location filename="../mainwindow.cpp" line="2163"/>
         <source>File loaded...</source>
         <translation>Datei geladen...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2174"/>
+        <location filename="../mainwindow.cpp" line="2188"/>
         <source>File saved...</source>
         <translation>Datei gespeichert...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2399"/>
+        <location filename="../mainwindow.cpp" line="2413"/>
         <source>Last checked %1</source>
         <translation>Zuletzt überprüft am %1</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2401"/>
+        <location filename="../mainwindow.cpp" line="2415"/>
         <source>Sonic Pi checks for updates
 every two weeks.</source>
         <translation>Sonic Pi sucht alle zwei Wochen nach Aktualisierungen.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2403"/>
+        <location filename="../mainwindow.cpp" line="2417"/>
         <source>This is Sonic Pi %1</source>
         <translation>Dies ist Sonic Pi %1</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2404"/>
+        <location filename="../mainwindow.cpp" line="2418"/>
         <source>Version %2 is now available!</source>
         <translation>Version %2 ist jetzt verfügbar!</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2408"/>
+        <location filename="../mainwindow.cpp" line="2422"/>
         <source>New version available!
 Get Sonic Pi %1</source>
         <translation>Eine neue Version ist verfügbar! Lade Sonic Pi %1 herunter</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1888"/>
+        <location filename="../mainwindow.cpp" line="1902"/>
         <source>Run</source>
         <translation>Ausführen</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1889"/>
+        <location filename="../mainwindow.cpp" line="1903"/>
         <source>Run the code in the current workspace</source>
         <translation>Das Programm im aktuellen Arbeitsbereich ausführen</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1893"/>
+        <location filename="../mainwindow.cpp" line="1907"/>
         <source>Stop</source>
         <translation>Stopp</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1894"/>
+        <location filename="../mainwindow.cpp" line="1908"/>
         <source>Stop all running code</source>
         <translation>Alle laufenden Programme beenden</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1897"/>
+        <location filename="../mainwindow.cpp" line="1911"/>
         <source>Save As...</source>
         <translation>Speichern als...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1901"/>
+        <location filename="../mainwindow.cpp" line="1915"/>
         <source>Info</source>
         <translation>Info</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1902"/>
+        <location filename="../mainwindow.cpp" line="1916"/>
         <source>See information about Sonic Pi</source>
         <translation>Einige Informationen über Sonic Pi</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="404"/>
-        <location filename="../mainwindow.cpp" line="1906"/>
+        <location filename="../mainwindow.cpp" line="414"/>
+        <location filename="../mainwindow.cpp" line="1920"/>
         <source>Help</source>
         <translation>Hilfe</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="981"/>
-        <location filename="../mainwindow.cpp" line="986"/>
+        <location filename="../mainwindow.cpp" line="991"/>
+        <location filename="../mainwindow.cpp" line="996"/>
         <source>Performance</source>
         <translation>Auftritt</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="982"/>
+        <location filename="../mainwindow.cpp" line="992"/>
         <source>Settings useful for performing with Sonic Pi</source>
         <translation>Praktische Einstellungen für die Bühne</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1077"/>
+        <location filename="../mainwindow.cpp" line="1087"/>
         <source>Server boot error...</source>
         <translation>Fehler bei Server-Start...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1077"/>
+        <location filename="../mainwindow.cpp" line="1087"/>
         <source>Apologies, a critical error occurred during startup</source>
         <translation>Entschuldigung, beim Start ging etwas schief</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1077"/>
+        <location filename="../mainwindow.cpp" line="1087"/>
         <source>Please consider reporting a bug at</source>
         <translation>Bitte melde den Fehler doch auf</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1907"/>
+        <location filename="../mainwindow.cpp" line="1921"/>
         <source>Toggle help pane</source>
         <translation>Hilfetexte anzeigen</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1910"/>
+        <location filename="../mainwindow.cpp" line="1924"/>
         <source>Prefs</source>
         <translation>Einstellungen</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1911"/>
+        <location filename="../mainwindow.cpp" line="1925"/>
         <source>Toggle preferences pane</source>
         <translation>Einstellungen anzeigen</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1915"/>
-        <location filename="../mainwindow.cpp" line="2037"/>
-        <location filename="../mainwindow.cpp" line="2038"/>
+        <location filename="../mainwindow.cpp" line="1929"/>
+        <location filename="../mainwindow.cpp" line="2051"/>
+        <location filename="../mainwindow.cpp" line="2052"/>
         <source>Start Recording</source>
         <translation>Aufnahme starten</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1920"/>
+        <location filename="../mainwindow.cpp" line="1934"/>
         <source>Auto-Align Text</source>
         <oldsource>Auto Align Text</oldsource>
         <translation>Text automatisch ausrichten</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1925"/>
-        <location filename="../mainwindow.cpp" line="1926"/>
+        <location filename="../mainwindow.cpp" line="1939"/>
+        <location filename="../mainwindow.cpp" line="1940"/>
         <source>Increase Text Size</source>
         <translation>Text vergrößern</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1930"/>
-        <location filename="../mainwindow.cpp" line="1931"/>
+        <location filename="../mainwindow.cpp" line="1944"/>
+        <location filename="../mainwindow.cpp" line="1945"/>
         <source>Decrease Text Size</source>
         <translation>Text verkleinern</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1936"/>
+        <location filename="../mainwindow.cpp" line="1950"/>
         <source>Tools</source>
         <translation>Werkzeuge</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1983"/>
+        <location filename="../mainwindow.cpp" line="1997"/>
         <source>About</source>
         <translation>Über Sonic Pi</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1984"/>
+        <location filename="../mainwindow.cpp" line="1998"/>
         <source>Core Team</source>
         <translation>Kern-Team</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1985"/>
+        <location filename="../mainwindow.cpp" line="1999"/>
         <source>Contributors</source>
         <translation>Mitwirkende</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1986"/>
+        <location filename="../mainwindow.cpp" line="2000"/>
         <source>Community</source>
         <translation>Gemeinschaft</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1987"/>
+        <location filename="../mainwindow.cpp" line="2001"/>
         <source>License</source>
         <translation>Lizenz</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1988"/>
+        <location filename="../mainwindow.cpp" line="2002"/>
         <source>History</source>
         <translation>Änderungen</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2009"/>
+        <location filename="../mainwindow.cpp" line="2023"/>
         <source>Sonic Pi - Info</source>
         <translation>Über Sonic Pi</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2029"/>
-        <location filename="../mainwindow.cpp" line="2030"/>
+        <location filename="../mainwindow.cpp" line="2043"/>
+        <location filename="../mainwindow.cpp" line="2044"/>
         <source>Stop Recording</source>
         <translation>Aufnahme stoppen</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2043"/>
+        <location filename="../mainwindow.cpp" line="2057"/>
         <source>Save Recording</source>
         <translation>Aufnahme speichern</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2139"/>
+        <location filename="../mainwindow.cpp" line="2153"/>
         <source>Cannot read file %1:
 %2.</source>
         <translation>Kann Datei %1 nicht laden:
 %2.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2157"/>
+        <location filename="../mainwindow.cpp" line="2171"/>
         <source>Cannot write file %1:
 %2.</source>
         <translation>Kann Datei %1 nicht schreiben:
 %2.</translation>
     </message>
     <message>
-        <location filename="../ruby_help.h" line="79"/>
-        <location filename="../ruby_help.h" line="138"/>
-        <location filename="../ruby_help.h" line="149"/>
-        <location filename="../ruby_help.h" line="163"/>
-        <location filename="../ruby_help.h" line="223"/>
-        <location filename="../ruby_help.h" line="283"/>
+        <location filename="../ruby_help.h" line="80"/>
+        <location filename="../ruby_help.h" line="139"/>
+        <location filename="../ruby_help.h" line="199"/>
+        <location filename="../ruby_help.h" line="218"/>
+        <location filename="../ruby_help.h" line="278"/>
+        <location filename="../ruby_help.h" line="338"/>
         <source>Tutorial</source>
         <translation>Tutorial</translation>
     </message>
     <message>
-        <location filename="../ruby_help.h" line="315"/>
+        <location filename="../ruby_help.h" line="370"/>
         <source>Examples</source>
         <translation>Beispiele</translation>
     </message>
     <message>
-        <location filename="../ruby_help.h" line="355"/>
+        <location filename="../ruby_help.h" line="410"/>
         <source>Synths</source>
         <translation>Synths</translation>
     </message>
     <message>
-        <location filename="../ruby_help.h" line="391"/>
+        <location filename="../ruby_help.h" line="446"/>
         <source>Fx</source>
         <translation>Fx</translation>
     </message>
     <message>
-        <location filename="../ruby_help.h" line="408"/>
+        <location filename="../ruby_help.h" line="463"/>
         <source>Samples</source>
         <translation>Samples</translation>
     </message>
     <message>
-        <location filename="../ruby_help.h" line="574"/>
+        <location filename="../ruby_help.h" line="629"/>
         <source>Lang</source>
         <translation>Lang</translation>
     </message>

--- a/app/gui/qt/lang/sonic-pi_fr.ts
+++ b/app/gui/qt/lang/sonic-pi_fr.ts
@@ -1,0 +1,790 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.0" language="fr_FR">
+<defaultcodec>UTF-8</defaultcodec>
+<context>
+    <name>MainWindow</name>
+    <message>
+        <location filename="../mainwindow.cpp" line="152"/>
+        <source>Sonic Pi update info</source>
+        <translation>Info de mise à jour de Sonic Pi</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="295"/>
+        <source>Buffer %1</source>
+        <translation>Buffer %1</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="359"/>
+        <source>Preferences</source>
+        <translation>Préférences</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="372"/>
+        <source>Log</source>
+        <translation>Trace</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="413"/>
+        <location filename="../mainwindow.cpp" line="1919"/>
+        <source>Help</source>
+        <translation>Aide</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="444"/>
+        <location filename="../mainwindow.cpp" line="2151"/>
+        <location filename="../mainwindow.cpp" line="2169"/>
+        <source>Sonic Pi</source>
+        <translation>Sonic Pi</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="458"/>
+        <source>Welcome to Sonic Pi</source>
+        <translation>Bienvenue à Sonic Pi</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="600"/>
+        <source>Indenting selection...</source>
+        <translation>Indentation de la sélection...</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="604"/>
+        <source>Indenting line...</source>
+        <translation>Indentation de la ligne...</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="633"/>
+        <source>Commenting selection...</source>
+        <translation>Commentant la sélection...</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="637"/>
+        <source>Commenting line...</source>
+        <translation>Commentant la ligne...</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="716"/>
+        <source>Ruby could not be started, is it installed and in your PATH?</source>
+        <translation>Ruby ne peut être lancé, est-il installé et dans votre PATH ?</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="802"/>
+        <source>Raspberry Pi System Volume</source>
+        <translation>Volume du son du Raspberry Pi</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="803"/>
+        <source>Use this slider to change the system volume of your Raspberry Pi.</source>
+        <translation>Utilisez ce curseur pour changer le volume du son de votre Raspberry Pi</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="805"/>
+        <source>Advanced Audio</source>
+        <translation>Audio avancé</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="806"/>
+        <source>Advanced audio settings for working with
+external PA systems when performing with Sonic Pi.</source>
+        <translation>Paramètres audio avancés pour l'utilisation
+d'un amplificateur externe avec Sonic Pi</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="807"/>
+        <source>Invert Stereo</source>
+        <translation>Stéréo inversée</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="808"/>
+        <source>Toggle stereo inversion.
+If enabled, audio sent to the left speaker will
+be routed to the right speaker and visa versa.</source>
+        <translation>Bascule en stéréo inversée.
+Si activée, le son destiné au haut-parleur de gauche sera
+dirigé vers le haut-parleur de droite et vice et versa</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="810"/>
+        <source>Force Mono</source>
+        <translation>Mono forcé</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="811"/>
+        <source>Toggle mono mode.
+If enabled both right and left audio is mixed and
+the same signal is sent to both speakers.
+Useful when working with external systems that
+can only handle mono.</source>
+        <translation>Bascule en mode mono.
+Si activée, l'audio de gauche est mélangé avec celui de droite
+et le même signal est dirigé vers les deux haut-parleurs. 
+Utile quand on travaille avec des systèmes externes qui 
+ne supportent que le mono.</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="814"/>
+        <source>Safe mode</source>
+        <translation>Mode sécurisé</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="815"/>
+        <source>Toggle synth argument checking functions.
+If disabled, certain synth opt values may
+create unexpectedly loud or uncomfortable sounds.</source>
+        <translation>Bascule des fonctions de vérification des arguments de synth. 
+Si désactivée, certaines valeurs des options de synth peuvent
+engendrer des sons forts ou inconfortables de manière imprévue.</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="827"/>
+        <source>Raspberry Pi Audio Output</source>
+        <translation>Sortie audio du Raspberry Pi</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="828"/>
+        <source>Your Raspberry Pi has two forms of audio output.
+Firstly, there is the headphone jack of the Raspberry Pi itself.
+Secondly, some HDMI monitors/TVs support audio through the HDMI port.
+Use these buttons to force the output to the one you want.</source>
+        <translation>Votre Raspberry Pi a deux sorties audio.
+Premièrement, il y a la prise jack pour écouteurs du Raspberry PI lui-même.
+Deuxièmement, des moniteurs ou TV supportent l'audio via la prise HDMI.
+Utilisez ces boutons pour forcer la sortie vers ce que vous souhaitez.</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="829"/>
+        <source>&amp;Default</source>
+        <translation>&amp;Défaut</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="830"/>
+        <source>&amp;Headphones</source>
+        <translation>&amp;Écouteurs</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="831"/>
+        <source>&amp;HDMI</source>
+        <translation>&amp;HDMI</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="851"/>
+        <source>Logging</source>
+        <translation>Trace</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="852"/>
+        <source>Configure debug behaviour</source>
+        <translation>Configuration du comportement de débogage</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="854"/>
+        <source>Log synths</source>
+        <translation>Trace les synthés</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="855"/>
+        <source>Toggle log messages.
+If disabled, activity such as synth and sample
+triggering will not be printed to the log by default.</source>
+        <translation>Bascule des messages de trace.
+Si désactivée, l'activité telle que le jeu des synthés et des échantillons 
+ne sera pas affichée dans la trace par défaut.</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="857"/>
+        <source>Clear log on run</source>
+        <translation>Efface la trace avant exécution</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="858"/>
+        <source>Toggle log clearing on run.
+If enabled, the log is cleared each
+time the run button is pressed.</source>
+        <translation>Bascule de l'effacement de la trace avant exécution.
+Si activé, la trace est effacée à chaque appui 
+sur le bouton run.</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="860"/>
+        <source>Log cues</source>
+        <translation>Trace des cues</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="861"/>
+        <source>Enable or disable logging of cues.
+If disabled, cues will still trigger.
+However, they will not be visible in the logs.</source>
+        <translation>Bascule de la trace des cues.
+Si désactivée, les cues continueront à être émis.
+Toutefois, ils ne seront pas visibles dans la trace.</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="870"/>
+        <source>Transparency</source>
+        <translation>Transparence</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="881"/>
+        <location filename="../mainwindow.cpp" line="1003"/>
+        <source>Updates</source>
+        <translation>Mises à jour</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="883"/>
+        <source>Check for updates</source>
+        <translation>Vérification des mises à jour</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="885"/>
+        <source>Toggle automatic update checking.
+This check involves sending anonymous information about your platform and version.</source>
+        <translation>Bascule de la vérification automatique des mises à jour.
+Cette vérification implique l'envoi d'informations anonymes 
+sur votre plateforme et votre version</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="886"/>
+        <source>Check now</source>
+        <translation>Vérification sur le champ</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="887"/>
+        <source>Force a check for updates now.
+This check involves sending anonymous information about your platform and version.</source>
+        <translation>Force une vérification des mises à jour sur le champ.
+Cette vérification implique l'envoi d'informations anonymes 
+sur votre plateforme et votre version</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="888"/>
+        <source>Get update</source>
+        <translation>Obtention d'une mise à jour</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="889"/>
+        <source>Visit http://sonic-pi.net to download new version</source>
+        <translation>Visitez http://sonic-pi.net pour télécharger une nouvelle version</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="894"/>
+        <source>Update Info</source>
+        <translation>Information de mise à jour</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="913"/>
+        <source>Show and Hide</source>
+        <translation>Montre et cache</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="914"/>
+        <source>Configure editor display options.</source>
+        <translation>Configuration des options d'affichage de l'éditeur</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="915"/>
+        <source>Look and Feel</source>
+        <translation>Look and Feel</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="916"/>
+        <source>Configure editor look and feel.</source>
+        <translation>Configuration du look and feel de l'éditeur</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="917"/>
+        <source>Automation</source>
+        <translation>Automatisation</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="918"/>
+        <source>Configure automation features.</source>
+        <translation>Configuration des caractéristiques de l'automatisation</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="919"/>
+        <source>Auto-align</source>
+        <translation>Alignement automatique</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="920"/>
+        <source>Automatically align code on Run</source>
+        <translation>Alignement automatique du code à l'exécution</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="922"/>
+        <source>Show line numbers</source>
+        <translation>Affichage des numéros de ligne</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="923"/>
+        <source>Toggle line number visibility.</source>
+        <translation>Bascule de la visibilité des numéros de ligne</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="924"/>
+        <source>Show log</source>
+        <translation>Affichage de la trace</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="925"/>
+        <source>Toggle visibility of the log.</source>
+        <translation>Bascule de la visibilité de la trace</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="927"/>
+        <source>Show buttons</source>
+        <translation>Affichage des boutons</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="928"/>
+        <source>Toggle visibility of the control buttons.</source>
+        <translation>Bascule de la visibilité des boutons de contrôle</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="930"/>
+        <source>Show tabs</source>
+        <translation>Affichage des onglets</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="932"/>
+        <source>Toggle visibility of the buffer selection tabs.</source>
+        <translation>Bascule de l'affichage des onglets de sélection des buffers</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="933"/>
+        <source>Full screen</source>
+        <translation>Plein écran</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="934"/>
+        <source>Toggle full screen mode.</source>
+        <translation>Bascule du mode plein écran</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="935"/>
+        <source>Dark mode</source>
+        <translation>Mode sombre</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="936"/>
+        <source>Toggle dark mode.</source>
+        <translation>Bascule du mode sombre</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="936"/>
+        <source>Dark mode is perfect for live coding in night clubs.</source>
+        <translation>Le mode sombre est parfait pour le codage en live dans les boîtes de nuit</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="975"/>
+        <source>Audio</source>
+        <translation>Audio</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="987"/>
+        <source>Editor</source>
+        <translation>Éditeur</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="988"/>
+        <source>Studio</source>
+        <translation>Studio</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="990"/>
+        <location filename="../mainwindow.cpp" line="995"/>
+        <source>Performance</source>
+        <translation>Interprétation</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="991"/>
+        <source>Settings useful for performing with Sonic Pi</source>
+        <translation>Paramètres utiles pour l'interprétation avec Sonic Pi</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1086"/>
+        <source>Server boot error...</source>
+        <translation>Erreur du lanceur du serveur...</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1086"/>
+        <source>Apologies, a critical error occurred during startup</source>
+        <translation>Veuillez nous excuser, une erreur critique s'est produite
+pendant le démarrage.</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1086"/>
+        <source>Please consider reporting a bug at</source>
+        <translation>Envisagez SVP la signalisation d'un bogue à</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1180"/>
+        <source>Save Current Buffer</source>
+        <translation>Sauvegarde du buffer courant</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1248"/>
+        <source>Running Code...</source>
+        <translation>Exécution du code...</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1274"/>
+        <source>Workspace %1</source>
+        <translation>Buffer %1</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1290"/>
+        <source>Zooming In...</source>
+        <translation>Zoom arrière...</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1297"/>
+        <source>Zooming Out...</source>
+        <translation>Zoom avant...</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1304"/>
+        <source>Beautifying...</source>
+        <translation>Embellissement...</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1324"/>
+        <source>Reloading...</source>
+        <translation>Rechargement...</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1331"/>
+        <source>Checking for updates...</source>
+        <translation>Vérification des mises à jour...</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1339"/>
+        <source>Enabling update checking...</source>
+        <translation>Activation de la vérification des mises à jour...</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1347"/>
+        <source>Disabling update checking...</source>
+        <translation>Désactivation de la vérification des mises à jour...</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1355"/>
+        <source>Enabling Mixer HPF...</source>
+        <translation>Activation du filtre passe-haut...</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1364"/>
+        <source>Disabling Mixer HPF...</source>
+        <translation>Désactivation du filtre passe-haut...</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1372"/>
+        <source>Enabling Mixer LPF...</source>
+        <translation>Activation du filtre passe-bas...</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1381"/>
+        <source>Disabling Mixer LPF...</source>
+        <translation>Désactivation du filtre passe-bas...</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1389"/>
+        <source>Enabling Inverted Stereo...</source>
+        <translation>Activation de l'inversion stéréo...</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1397"/>
+        <source>Enabling Standard Stereo...</source>
+        <translation>Activation de la stéréo standard...</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1405"/>
+        <source>Mono Mode...</source>
+        <translation>Mode mono...</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1413"/>
+        <source>Stereo Mode...</source>
+        <translation>Mode stéréo...</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1422"/>
+        <source>Stopping...</source>
+        <translation>Arrêt...</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1506"/>
+        <source>Updating System Volume...</source>
+        <translation>Changement du volume du son du système</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1728"/>
+        <source>Switching To Headphone Audio Output...</source>
+        <translation>Aiguillage vers la sortie écouteurs...</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1744"/>
+        <source>Switching To HDMI Audio Output...</source>
+        <translation>Aiguillage vers la sortie HDMI...</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1759"/>
+        <source>Switching To Default Audio Output...</source>
+        <translation>Aiguillage vers la sortie par défaut...</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1901"/>
+        <source>Run</source>
+        <translation>Run</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1902"/>
+        <source>Run the code in the current workspace</source>
+        <translation>Exécute le code dans le buffer courant</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1906"/>
+        <source>Stop</source>
+        <translation>Stop</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1907"/>
+        <source>Stop all running code</source>
+        <translation>Arrête l'exécution de tous les codes</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1910"/>
+        <source>Save As...</source>
+        <translation>Enregistrer sous...</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1911"/>
+        <source>Save current buffer as an external file</source>
+        <translation>Enregistre le buffer courant dans un fichier externe</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1914"/>
+        <source>Info</source>
+        <translation>Info</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1915"/>
+        <source>See information about Sonic Pi</source>
+        <translation>Voir l'information sur Sonic Pi</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1920"/>
+        <source>Toggle help pane</source>
+        <translation>Bascule de l'affichage du panneau d'aide</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1923"/>
+        <source>Prefs</source>
+        <translation>Prefs</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1924"/>
+        <source>Toggle preferences pane</source>
+        <translation>Bascule de l'affichage du panneau des préférences</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1928"/>
+        <location filename="../mainwindow.cpp" line="2050"/>
+        <location filename="../mainwindow.cpp" line="2051"/>
+        <source>Start Recording</source>
+        <translation>Démarrage de l'enregistrement</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1929"/>
+        <source>Start recording to WAV audio file</source>
+        <translation>Démarre l'enregistrement vers un fichier audio WAV</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1933"/>
+        <source>Auto-Align Text</source>
+        <translation>Alignement automatique du texte</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1934"/>
+        <source>Improve readability of code</source>
+        <translation>Amélioration de la lisibilité du code</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1938"/>
+        <location filename="../mainwindow.cpp" line="1939"/>
+        <source>Increase Text Size</source>
+        <translation>Augmente la taille du texte</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1943"/>
+        <location filename="../mainwindow.cpp" line="1944"/>
+        <source>Decrease Text Size</source>
+        <translation>Diminue la taille du texte</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1949"/>
+        <source>Tools</source>
+        <translation>Outils</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1996"/>
+        <source>About</source>
+        <translation>A propos</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1997"/>
+        <source>Core Team</source>
+        <translation>Équipe principale</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1998"/>
+        <source>Contributors</source>
+        <translation>Contributeurs</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1999"/>
+        <source>Community</source>
+        <translation>Communauté</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2000"/>
+        <source>License</source>
+        <translation>License</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2001"/>
+        <source>History</source>
+        <translation>Historique</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2022"/>
+        <source>Sonic Pi - Info</source>
+        <translation>Sonic Pi - Info</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2042"/>
+        <location filename="../mainwindow.cpp" line="2043"/>
+        <source>Stop Recording</source>
+        <translation>Arrête l'enregistrement</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2056"/>
+        <source>Save Recording</source>
+        <translation>Sauvegarde de l'enregistrement</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2075"/>
+        <source>Ready...</source>
+        <translation>Prêt...</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2152"/>
+        <source>Cannot read file %1:
+%2.</source>
+        <translation>Lecture impossible du fichier %1:
+%2.</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2162"/>
+        <source>File loaded...</source>
+        <translation>Fichier chargé...</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2170"/>
+        <source>Cannot write file %1:
+%2.</source>
+        <translation>Écriture impossible du fichier %1:
+%2.</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2187"/>
+        <source>File saved...</source>
+        <translation>Fichier enregistré...</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2412"/>
+        <source>Last checked %1</source>
+        <translation>%1 vérifié en dernier</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2414"/>
+        <source>Sonic Pi checks for updates
+every two weeks.</source>
+        <translation>Sonic Pi vérifie les mises à jour
+toutes les deux semaines.</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2416"/>
+        <source>This is Sonic Pi %1</source>
+        <translation>C'est Sonic Pi %1</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2417"/>
+        <source>Version %2 is now available!</source>
+        <translation>La version %2 est maintenant disponible !</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2421"/>
+        <source>New version available!
+Get Sonic Pi %1</source>
+        <translation>Nouvelle version disponible !
+Obtenez Sonic Pi %1</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2447"/>
+        <source>Welcome back. Now get your live code on...</source>
+        <translation>Retour bienvenu. Obtenez maintenant votre code sur...</translation>
+    </message>
+    <message>
+        <location filename="../ruby_help.h" line="80"/>
+        <location filename="../ruby_help.h" line="139"/>
+        <location filename="../ruby_help.h" line="199"/>
+        <location filename="../ruby_help.h" line="218"/>
+        <location filename="../ruby_help.h" line="278"/>
+        <location filename="../ruby_help.h" line="338"/>
+        <source>Tutorial</source>
+        <translation>Tutoriel</translation>
+    </message>
+    <message>
+        <location filename="../ruby_help.h" line="370"/>
+        <source>Examples</source>
+        <translation>Exemples</translation>
+    </message>
+    <message>
+        <location filename="../ruby_help.h" line="410"/>
+        <source>Synths</source>
+        <translation>Synths</translation>
+    </message>
+    <message>
+        <location filename="../ruby_help.h" line="446"/>
+        <source>Fx</source>
+        <translation>Fx</translation>
+    </message>
+    <message>
+        <location filename="../ruby_help.h" line="463"/>
+        <source>Samples</source>
+        <translation>Échantillons</translation>
+    </message>
+    <message>
+        <location filename="../ruby_help.h" line="629"/>
+        <source>Lang</source>
+        <translation>Langage</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../main.cpp" line="43"/>
+        <source>Sonic Pi</source>
+        <translation>Sonic Pi</translation>
+    </message>
+</context>
+<context>
+    <name>SonicPiUDPServer</name>
+    <message>
+        <location filename="../sonicpiudpserver.cpp" line="24"/>
+        <source>Is Sonic Pi already running?  Can&apos;t open UDP port 4558.</source>
+        <translation>Sonic Pi toujours en cours d'exécution ? Ouverture du port UDP 4558 impossible</translation>
+    </message>
+</context>
+</TS>

--- a/app/gui/qt/lang/sonic-pi_is.ts
+++ b/app/gui/qt/lang/sonic-pi_is.ts
@@ -5,98 +5,108 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../mainwindow.cpp" line="152"/>
+        <location filename="../mainwindow.cpp" line="153"/>
         <source>Sonic Pi update info</source>
         <translation>Upplýsingar um Sonic Pi uppfærslur</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="295"/>
+        <location filename="../mainwindow.cpp" line="296"/>
         <source>Buffer %1</source>
         <translation>Rissblað %1</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="350"/>
+        <location filename="../mainwindow.cpp" line="360"/>
         <source>Preferences</source>
         <translation>Stillingar</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="363"/>
+        <location filename="../mainwindow.cpp" line="373"/>
         <source>Log</source>
         <translation>Atburðaskrá</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="401"/>
-        <location filename="../mainwindow.cpp" line="1841"/>
+        <location filename="../mainwindow.cpp" line="414"/>
+        <location filename="../mainwindow.cpp" line="1920"/>
         <source>Help</source>
         <translation>Hjálp</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="432"/>
-        <location filename="../mainwindow.cpp" line="2073"/>
-        <location filename="../mainwindow.cpp" line="2091"/>
+        <location filename="../mainwindow.cpp" line="445"/>
+        <location filename="../mainwindow.cpp" line="2152"/>
+        <location filename="../mainwindow.cpp" line="2170"/>
         <source>Sonic Pi</source>
         <translation>Sonic Pi</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="446"/>
+        <location filename="../mainwindow.cpp" line="459"/>
         <source>Welcome to Sonic Pi</source>
         <translation>Velkomin(n) í Sonic Pi</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="584"/>
+        <location filename="../mainwindow.cpp" line="601"/>
         <source>Indenting selection...</source>
         <translation>Dreg inn val...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="588"/>
+        <location filename="../mainwindow.cpp" line="605"/>
         <source>Indenting line...</source>
         <translation>Dreg inn línu...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="667"/>
+        <location filename="../mainwindow.cpp" line="634"/>
+        <source>Commenting selection...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="638"/>
+        <source>Commenting line...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="717"/>
         <source>Ruby could not be started, is it installed and in your PATH?</source>
         <translation>Gat ekki ræst Ruby, er það sett upp og í PATH?</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="753"/>
+        <location filename="../mainwindow.cpp" line="803"/>
         <source>Raspberry Pi System Volume</source>
         <translation>Hljóðstyrkur kerfis á Raspberry Pi</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="754"/>
+        <location filename="../mainwindow.cpp" line="804"/>
         <source>Use this slider to change the system volume of your Raspberry Pi.</source>
         <translation>Notaðu þennan sleða til að breyta hljóðstyrk kerfisins á Raspberry Pi.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="756"/>
+        <location filename="../mainwindow.cpp" line="806"/>
         <source>Advanced Audio</source>
         <translation>Flóknari hjóðstillingar</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="757"/>
+        <location filename="../mainwindow.cpp" line="807"/>
         <source>Advanced audio settings for working with
 external PA systems when performing with Sonic Pi.</source>
         <translation>Flóknari hljóðstillingar sem notast með ytri\nhljóðkerfum þegar komið er fram með Sonic Pi.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="758"/>
+        <location filename="../mainwindow.cpp" line="808"/>
         <source>Invert Stereo</source>
         <translation>Viðsnúinn víðómur</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="759"/>
+        <location filename="../mainwindow.cpp" line="809"/>
         <source>Toggle stereo inversion.
 If enabled, audio sent to the left speaker will
 be routed to the right speaker and visa versa.</source>
         <translation>Breyta viðsnúnum víðóm.\nEf virkjað þá er hljóð ætlað í vinstri hátalara\nsent í hægri hátalara og öfugt.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="761"/>
+        <location filename="../mainwindow.cpp" line="811"/>
         <source>Force Mono</source>
         <translation>Þvinga einóm</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="762"/>
+        <location filename="../mainwindow.cpp" line="812"/>
         <source>Toggle mono mode.
 If enabled both right and left audio is mixed and
 the same signal is sent to both speakers.
@@ -105,24 +115,24 @@ can only handle mono.</source>
         <translation>Breyta einóma ham.\nEf virkjað þá er hægri og vinstri hljóðrás blandað og\nsama merki sent í báða hátalara.\nGagnlegt þegar unnið er með ytri hljóðkerfi\nsem höndla bara einóm.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="765"/>
+        <location filename="../mainwindow.cpp" line="815"/>
         <source>Safe mode</source>
         <translation>Öruggur hamur</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="766"/>
+        <location filename="../mainwindow.cpp" line="816"/>
         <source>Toggle synth argument checking functions.
 If disabled, certain synth opt values may
 create unexpectedly loud or uncomfortable sounds.</source>
         <translation>Breyta yfirferð viðfanga á hljóðgervla.\nEf ekki virkjað þá gæti sum viðföng á hljóðgervla valdið hávaða eða\nóþægilegum hljóðum þegar ekki er búist við þeim.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="778"/>
+        <location filename="../mainwindow.cpp" line="828"/>
         <source>Raspberry Pi Audio Output</source>
         <translation>Hljóðúttak á Raspberry Pi</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="779"/>
+        <location filename="../mainwindow.cpp" line="829"/>
         <source>Your Raspberry Pi has two forms of audio output.
 Firstly, there is the headphone jack of the Raspberry Pi itself.
 Secondly, some HDMI monitors/TVs support audio through the HDMI port.
@@ -130,586 +140,607 @@ Use these buttons to force the output to the one you want.</source>
         <translation>Raspberry Pi tölvan þín hefur tvennskonar úttak fyrir hljóð.\nAnnarsvegar er tengi fyrir heyrnartól á sjálfri Raspberry Pi tölvunni. Hinsvegar styðja sumir HDMI skjáir/sjónvörp hljóð í gegnum HDMI tengið.\nNotaðu þessa takka til að þvinga hljóðiðí það úttak sem þú vilt.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="780"/>
+        <location filename="../mainwindow.cpp" line="830"/>
         <source>&amp;Default</source>
         <translation>&amp;Sjálfgefið</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="781"/>
+        <location filename="../mainwindow.cpp" line="831"/>
         <source>&amp;Headphones</source>
         <translation>&amp;Heyrnartól</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="782"/>
+        <location filename="../mainwindow.cpp" line="832"/>
         <source>&amp;HDMI</source>
         <translation>&amp;HDMI</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="802"/>
+        <location filename="../mainwindow.cpp" line="852"/>
         <source>Logging</source>
         <translation>Skráning atburða</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="803"/>
+        <location filename="../mainwindow.cpp" line="853"/>
         <source>Configure debug behaviour</source>
         <translation>Stilla hegðun við aflúsun</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="805"/>
+        <location filename="../mainwindow.cpp" line="855"/>
         <source>Log synths</source>
         <translation>Skrá atburði hljóðgervla</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="806"/>
+        <location filename="../mainwindow.cpp" line="856"/>
         <source>Toggle log messages.
 If disabled, activity such as synth and sample
 triggering will not be printed to the log by default.</source>
+        <translation></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="808"/>
+        <location filename="../mainwindow.cpp" line="858"/>
         <source>Clear log on run</source>
         <translation>Hreinsa atburðaskrá við keyrslu</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="809"/>
+        <location filename="../mainwindow.cpp" line="859"/>
         <source>Toggle log clearing on run.
 If enabled, the log is cleared each
 time the run button is pressed.</source>
         <translation>Breyta hreinsun atburðaskráar við keyrslu.\nEf virkjað þá er atburðaskráin hreinsuð\nhvert sinn sem stutt er á keyra hnappinn.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="811"/>
+        <location filename="../mainwindow.cpp" line="861"/>
         <source>Log cues</source>
         <translation>Skrá atburði um &quot;cues&quot;</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="812"/>
+        <location filename="../mainwindow.cpp" line="862"/>
         <source>Enable or disable logging of cues.
 If disabled, cues will still trigger.
 However, they will not be visible in the logs.</source>
+        <translation></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="823"/>
-        <location filename="../mainwindow.cpp" line="938"/>
+        <location filename="../mainwindow.cpp" line="871"/>
+        <source>Transparency</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="882"/>
+        <location filename="../mainwindow.cpp" line="1004"/>
         <source>Updates</source>
         <translation>Uppfærslur</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="825"/>
+        <location filename="../mainwindow.cpp" line="884"/>
         <source>Check for updates</source>
         <translation>Athuga með uppfærslur</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="827"/>
+        <location filename="../mainwindow.cpp" line="886"/>
         <source>Toggle automatic update checking.
 This check involves sending anonymous information about your platform and version.</source>
         <translation>Breyta sjálfvirkum athugunum á uppfærslum.\nÞetta felur í sér að senda nafnlausar upplýsingar um búnað þinn og útgáfu.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="828"/>
+        <location filename="../mainwindow.cpp" line="887"/>
         <source>Check now</source>
         <translation>Athuga núna</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="829"/>
+        <location filename="../mainwindow.cpp" line="888"/>
         <source>Force a check for updates now.
 This check involves sending anonymous information about your platform and version.</source>
         <translation>Þvinga athugun á uppfærslum núna.\nÞetta felur í sér að senda nafnlausar upplýsingar um búnað þinn og útgáfu.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="830"/>
+        <location filename="../mainwindow.cpp" line="889"/>
         <source>Get update</source>
         <translation>Sækja uppfærslu</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="831"/>
+        <location filename="../mainwindow.cpp" line="890"/>
         <source>Visit http://sonic-pi.net to download new version</source>
         <translation>Heimsæktu http://sonic-pi.net til að sækja nýjustu útgáfu</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="836"/>
+        <location filename="../mainwindow.cpp" line="895"/>
         <source>Update Info</source>
         <translation>Uppfærslu upplýsingar</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="855"/>
+        <location filename="../mainwindow.cpp" line="914"/>
         <source>Show and Hide</source>
         <translation>Sýna og fela</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="856"/>
+        <location filename="../mainwindow.cpp" line="915"/>
         <source>Configure editor display options.</source>
         <translation>Stilla framsetningu ritils.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="857"/>
+        <location filename="../mainwindow.cpp" line="916"/>
         <source>Look and Feel</source>
         <translation>Útlit og hegðun</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="858"/>
+        <location filename="../mainwindow.cpp" line="917"/>
         <source>Configure editor look and feel.</source>
         <translation>Stilla útlit og hegðun ritils.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="859"/>
+        <location filename="../mainwindow.cpp" line="918"/>
         <source>Automation</source>
         <translation>Sjálfvirkni</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="860"/>
+        <location filename="../mainwindow.cpp" line="919"/>
         <source>Configure automation features.</source>
         <translation>Stilla sjálfvirkni.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="861"/>
+        <location filename="../mainwindow.cpp" line="920"/>
         <source>Auto-align</source>
         <translation>Jafna sjálfvirkt</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="862"/>
+        <location filename="../mainwindow.cpp" line="921"/>
         <source>Automatically align code on Run</source>
         <translation>Jafna kóða sjálfvirkt við keyrslu</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="864"/>
+        <location filename="../mainwindow.cpp" line="923"/>
         <source>Show line numbers</source>
         <translation>Sýna línunúmer</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="865"/>
+        <location filename="../mainwindow.cpp" line="924"/>
         <source>Toggle line number visibility.</source>
         <translation>Breyta sýnileika línunúmera.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="866"/>
+        <location filename="../mainwindow.cpp" line="925"/>
         <source>Show log</source>
         <translation>Sýna atburðaskrá</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="867"/>
+        <location filename="../mainwindow.cpp" line="926"/>
         <source>Toggle visibility of the log.</source>
         <translation>Breyta sýnileika atburðaskrár.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="869"/>
+        <location filename="../mainwindow.cpp" line="928"/>
         <source>Show buttons</source>
         <translation>Sýna hnappa</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="870"/>
+        <location filename="../mainwindow.cpp" line="929"/>
         <source>Toggle visibility of the control buttons.</source>
         <translation>Breyta sýnileika stýrihnappa.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="872"/>
+        <location filename="../mainwindow.cpp" line="931"/>
         <source>Show tabs</source>
         <translation>Sýna flipa</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="874"/>
+        <location filename="../mainwindow.cpp" line="933"/>
         <source>Toggle visibility of the buffer selection tabs.</source>
         <translation>Breyta sýnileika flipa fyrir rissblöð.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="875"/>
+        <location filename="../mainwindow.cpp" line="934"/>
         <source>Full screen</source>
         <translation>Fylla skjá</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="876"/>
+        <location filename="../mainwindow.cpp" line="935"/>
         <source>Toggle full screen mode.</source>
         <translation>Breyta í/frá fullum skjá.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="877"/>
+        <location filename="../mainwindow.cpp" line="936"/>
         <source>Dark mode</source>
         <translation>Dökkur hamur</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="878"/>
+        <location filename="../mainwindow.cpp" line="937"/>
         <source>Toggle dark mode.</source>
         <translation>Breyta í/úr dökkum ham.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="878"/>
+        <location filename="../mainwindow.cpp" line="937"/>
         <source>
 Dark mode is perfect for live coding in night clubs.</source>
         <translation>Dökki hamurinn hentar sérlega vel þegar komið er fram í næturklúbbum.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="917"/>
+        <location filename="../mainwindow.cpp" line="976"/>
         <source>Audio</source>
         <translation>Hljóð</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="929"/>
+        <location filename="../mainwindow.cpp" line="988"/>
         <source>Editor</source>
         <translation>Ritill</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="930"/>
+        <location filename="../mainwindow.cpp" line="989"/>
         <source>Studio</source>
         <translation>Hljóðver</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1019"/>
+        <location filename="../mainwindow.cpp" line="991"/>
+        <location filename="../mainwindow.cpp" line="996"/>
+        <source>Performance</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="992"/>
+        <source>Settings useful for performing with Sonic Pi</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1087"/>
         <source>Server boot error...</source>
         <translation>Villa við gangsetningu þjóns...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1019"/>
+        <location filename="../mainwindow.cpp" line="1087"/>
         <source>Apologies, a critical error occurred during startup</source>
         <translation>Afsakið, krítísk villa varð við ræsingu</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1019"/>
+        <location filename="../mainwindow.cpp" line="1087"/>
         <source>Please consider reporting a bug at</source>
         <translation>Kæmi til greina að tilkynna villu á</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1113"/>
+        <location filename="../mainwindow.cpp" line="1181"/>
         <source>Save Current Buffer</source>
         <translation>Vista virka rissblað</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1181"/>
+        <location filename="../mainwindow.cpp" line="1249"/>
         <source>Running Code...</source>
         <translation>Keyri kóða...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1207"/>
+        <location filename="../mainwindow.cpp" line="1275"/>
         <source>Workspace %1</source>
         <translation>Vinnusvæði %1</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1223"/>
+        <location filename="../mainwindow.cpp" line="1291"/>
         <source>Zooming In...</source>
         <translation>Þysja inn...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1230"/>
+        <location filename="../mainwindow.cpp" line="1298"/>
         <source>Zooming Out...</source>
         <translation>Þysja út...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1237"/>
+        <location filename="../mainwindow.cpp" line="1305"/>
         <source>Beautifying...</source>
         <translation>Fegra...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1257"/>
+        <location filename="../mainwindow.cpp" line="1325"/>
         <source>Reloading...</source>
         <translation>Endurhleð...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1264"/>
+        <location filename="../mainwindow.cpp" line="1332"/>
         <source>Checking for updates...</source>
         <translation>Athuga með uppfærslur...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1272"/>
+        <location filename="../mainwindow.cpp" line="1340"/>
         <source>Enabling update checking...</source>
         <translation>Virkja uppfærsluathugun...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1280"/>
+        <location filename="../mainwindow.cpp" line="1348"/>
         <source>Disabling update checking...</source>
         <translation>Afvirka uppfærsluathugun...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1288"/>
+        <location filename="../mainwindow.cpp" line="1356"/>
         <source>Enabling Mixer HPF...</source>
         <translation>Virkja mixer HPF...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1297"/>
+        <location filename="../mainwindow.cpp" line="1365"/>
         <source>Disabling Mixer HPF...</source>
         <translation>Afvirkja Mixer HPF...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1305"/>
+        <location filename="../mainwindow.cpp" line="1373"/>
         <source>Enabling Mixer LPF...</source>
         <translation>Virkja Mixer LPF...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1314"/>
+        <location filename="../mainwindow.cpp" line="1382"/>
         <source>Disabling Mixer LPF...</source>
         <translation>Afvirkja Mixer LPF...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1322"/>
+        <location filename="../mainwindow.cpp" line="1390"/>
         <source>Enabling Inverted Stereo...</source>
         <translation>Virkja speglaðan víðóm...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1330"/>
+        <location filename="../mainwindow.cpp" line="1398"/>
         <source>Enabling Standard Stereo...</source>
         <translation>Virkja venjulegan víðóm...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1338"/>
+        <location filename="../mainwindow.cpp" line="1406"/>
         <source>Mono Mode...</source>
         <translation>Einóma hamur...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1346"/>
+        <location filename="../mainwindow.cpp" line="1414"/>
         <source>Stereo Mode...</source>
         <translation>Víðóma hamur...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1355"/>
+        <location filename="../mainwindow.cpp" line="1423"/>
         <source>Stopping...</source>
         <translation>Stöðva...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1432"/>
+        <location filename="../mainwindow.cpp" line="1507"/>
         <source>Updating System Volume...</source>
         <translation>Uppfæri hljóðstyrk kerfis...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1650"/>
+        <location filename="../mainwindow.cpp" line="1729"/>
         <source>Switching To Headphone Audio Output...</source>
         <translation>Skipti í hljóðúttak fyrir heyrnartól...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1666"/>
+        <location filename="../mainwindow.cpp" line="1745"/>
         <source>Switching To HDMI Audio Output...</source>
         <translation>Skipti í HDMI hljóðúttak...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1681"/>
+        <location filename="../mainwindow.cpp" line="1760"/>
         <source>Switching To Default Audio Output...</source>
         <translation>Skipti í sjálfgefna hljóðúttakið...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1823"/>
+        <location filename="../mainwindow.cpp" line="1902"/>
         <source>Run</source>
         <translation>Keyra</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1824"/>
+        <location filename="../mainwindow.cpp" line="1903"/>
         <source>Run the code in the current workspace</source>
         <translation>Keyra kóðann í núverandi vinnusvæði</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1828"/>
+        <location filename="../mainwindow.cpp" line="1907"/>
         <source>Stop</source>
         <translation>Stöðva</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1829"/>
+        <location filename="../mainwindow.cpp" line="1908"/>
         <source>Stop all running code</source>
         <translation>Stöðva allan keyrandi kóða</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1832"/>
+        <location filename="../mainwindow.cpp" line="1911"/>
         <source>Save As...</source>
         <translation>Vista sem...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1833"/>
+        <location filename="../mainwindow.cpp" line="1912"/>
         <source>Save current buffer as an external file</source>
         <translation>Vista virkt rissblað sem ytri skrá</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1836"/>
+        <location filename="../mainwindow.cpp" line="1915"/>
         <source>Info</source>
         <translation>Upplýsingar</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1837"/>
+        <location filename="../mainwindow.cpp" line="1916"/>
         <source>See information about Sonic Pi</source>
         <translation>Sjá upplýsingar um Sonic Pi</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1842"/>
+        <location filename="../mainwindow.cpp" line="1921"/>
         <source>Toggle help pane</source>
         <translation>Breyta hjálpar flöt</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1845"/>
+        <location filename="../mainwindow.cpp" line="1924"/>
         <source>Prefs</source>
         <translation>Kostir</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1846"/>
+        <location filename="../mainwindow.cpp" line="1925"/>
         <source>Toggle preferences pane</source>
         <translation>Breyta flöt fyrir kosti</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1850"/>
-        <location filename="../mainwindow.cpp" line="1972"/>
-        <location filename="../mainwindow.cpp" line="1973"/>
+        <location filename="../mainwindow.cpp" line="1929"/>
+        <location filename="../mainwindow.cpp" line="2051"/>
+        <location filename="../mainwindow.cpp" line="2052"/>
         <source>Start Recording</source>
         <translation>Hefja upptöku</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1851"/>
+        <location filename="../mainwindow.cpp" line="1930"/>
         <source>Start recording to WAV audio file</source>
         <translation>Hefja upptöku í WAV hljóðskrá</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1855"/>
+        <location filename="../mainwindow.cpp" line="1934"/>
         <source>Auto-Align Text</source>
         <translation>Jafna texta sjálfvirkt</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1856"/>
+        <location filename="../mainwindow.cpp" line="1935"/>
         <source>Improve readability of code</source>
         <translation>Bæta læsileika kóða</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1860"/>
-        <location filename="../mainwindow.cpp" line="1861"/>
+        <location filename="../mainwindow.cpp" line="1939"/>
+        <location filename="../mainwindow.cpp" line="1940"/>
         <source>Increase Text Size</source>
         <translation>Stækka texta</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1865"/>
-        <location filename="../mainwindow.cpp" line="1866"/>
+        <location filename="../mainwindow.cpp" line="1944"/>
+        <location filename="../mainwindow.cpp" line="1945"/>
         <source>Decrease Text Size</source>
         <translation>Minnka texta</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1871"/>
+        <location filename="../mainwindow.cpp" line="1950"/>
         <source>Tools</source>
         <translation>Tól</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1918"/>
+        <location filename="../mainwindow.cpp" line="1997"/>
         <source>About</source>
         <translation>Um</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1919"/>
+        <location filename="../mainwindow.cpp" line="1998"/>
         <source>Core Team</source>
         <translation>Kjarnateymi</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1920"/>
+        <location filename="../mainwindow.cpp" line="1999"/>
         <source>Contributors</source>
         <translation>Þáttakendur</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1921"/>
+        <location filename="../mainwindow.cpp" line="2000"/>
         <source>Community</source>
         <translation>Samfélag</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1922"/>
+        <location filename="../mainwindow.cpp" line="2001"/>
         <source>License</source>
         <translation>Leyfi</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1923"/>
+        <location filename="../mainwindow.cpp" line="2002"/>
         <source>History</source>
         <translation>Saga</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1944"/>
+        <location filename="../mainwindow.cpp" line="2023"/>
         <source>Sonic Pi - Info</source>
         <translation>Sonic Pi - Upplýsingar</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1964"/>
-        <location filename="../mainwindow.cpp" line="1965"/>
+        <location filename="../mainwindow.cpp" line="2043"/>
+        <location filename="../mainwindow.cpp" line="2044"/>
         <source>Stop Recording</source>
         <translation>Stöðva upptöku</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1978"/>
+        <location filename="../mainwindow.cpp" line="2057"/>
         <source>Save Recording</source>
         <translation>Vista upptöku</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1997"/>
+        <location filename="../mainwindow.cpp" line="2076"/>
         <source>Ready...</source>
         <translation>Tilbúin...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2074"/>
+        <location filename="../mainwindow.cpp" line="2153"/>
         <source>Cannot read file %1:
 %2.</source>
         <translation>Get ekki lesið skrá %1: %2.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2084"/>
+        <location filename="../mainwindow.cpp" line="2163"/>
         <source>File loaded...</source>
         <translation>Skrá hlaðið...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2092"/>
+        <location filename="../mainwindow.cpp" line="2171"/>
         <source>Cannot write file %1:
 %2.</source>
         <translation>Get ekki skrifað skrá %1: %2.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2109"/>
+        <location filename="../mainwindow.cpp" line="2188"/>
         <source>File saved...</source>
         <translation>Skrá vistuð...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2334"/>
+        <location filename="../mainwindow.cpp" line="2413"/>
         <source>Last checked %1</source>
         <translation>Síðast athugað %1</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2336"/>
+        <location filename="../mainwindow.cpp" line="2415"/>
         <source>Sonic Pi checks for updates
 every two weeks.</source>
         <translation>Sonic Pi athugar með uppfærslur\naðra hverja viku.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2338"/>
+        <location filename="../mainwindow.cpp" line="2417"/>
         <source>This is Sonic Pi %1</source>
         <translation>Þetta er Sonic Pi %1</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2339"/>
+        <location filename="../mainwindow.cpp" line="2418"/>
         <source>Version %2 is now available!</source>
         <translation>Útgáfa %2 er nú tilbúin!</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2343"/>
+        <location filename="../mainwindow.cpp" line="2422"/>
         <source>New version available!
 Get Sonic Pi %1</source>
         <translation>Ný útgáfa tilbúin!\nSækja Sonic Pi %1</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2369"/>
+        <location filename="../mainwindow.cpp" line="2448"/>
         <source>Welcome back. Now get your live code on...</source>
         <translation>Velkominn aftur. Byrjaðu að kóða í beinni...</translation>
     </message>
     <message>
-        <location filename="../ruby_help.h" line="31"/>
-        <location filename="../ruby_help.h" line="90"/>
-        <location filename="../ruby_help.h" line="150"/>
+        <location filename="../ruby_help.h" line="80"/>
+        <location filename="../ruby_help.h" line="139"/>
+        <location filename="../ruby_help.h" line="199"/>
+        <location filename="../ruby_help.h" line="218"/>
+        <location filename="../ruby_help.h" line="278"/>
+        <location filename="../ruby_help.h" line="338"/>
         <source>Tutorial</source>
         <translation>Kennsla</translation>
     </message>
     <message>
-        <location filename="../ruby_help.h" line="183"/>
+        <location filename="../ruby_help.h" line="370"/>
         <source>Examples</source>
         <translation>Dæmi</translation>
     </message>
     <message>
-        <location filename="../ruby_help.h" line="223"/>
+        <location filename="../ruby_help.h" line="410"/>
         <source>Synths</source>
         <translation>Hljóðgervlar</translation>
     </message>
     <message>
-        <location filename="../ruby_help.h" line="258"/>
+        <location filename="../ruby_help.h" line="446"/>
         <source>Fx</source>
         <translation>Fx</translation>
     </message>
     <message>
-        <location filename="../ruby_help.h" line="275"/>
+        <location filename="../ruby_help.h" line="463"/>
         <source>Samples</source>
         <translation>Sömpl</translation>
     </message>
     <message>
-        <location filename="../ruby_help.h" line="437"/>
+        <location filename="../ruby_help.h" line="629"/>
         <source>Lang</source>
         <translation>Mál</translation>
     </message>

--- a/app/gui/qt/lang/sonic-pi_ja.ts
+++ b/app/gui/qt/lang/sonic-pi_ja.ts
@@ -1,147 +1,216 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1" language="ja_JP">
+<TS version="2.0" language="ja_JP">
+<defaultcodec>UTF-8</defaultcodec>
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../mainwindow.cpp" line="292"/>
+        <location filename="../mainwindow.cpp" line="360"/>
         <source>Preferences</source>
         <translation>環境設定</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="302"/>
+        <location filename="../mainwindow.cpp" line="373"/>
         <source>Log</source>
         <translation>ログ</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="370"/>
-        <location filename="../mainwindow.cpp" line="1577"/>
-        <location filename="../mainwindow.cpp" line="1595"/>
+        <location filename="../mainwindow.cpp" line="445"/>
+        <location filename="../mainwindow.cpp" line="2152"/>
+        <location filename="../mainwindow.cpp" line="2170"/>
         <source>Sonic Pi</source>
         <translation>Sonic Pi</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="506"/>
         <source>ruby could not be started, is it installed and in your PATH?</source>
-        <translation>rubyを起動することができませんでした。インストール、またパスはを確認してください。</translation>
+        <translation type="obsolete">rubyを起動することができませんでした。インストール、またパスはを確認してください。</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="525"/>
         <source>Failed to start server, please check %1.</source>
         <oldsource>Failed to start server, please check </oldsource>
-        <translation>%1.サーバーの起動に失敗しました。確認してください。</translation>
+        <translation type="obsolete">%1.サーバーの起動に失敗しました。確認してください。</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="585"/>
+        <location filename="../mainwindow.cpp" line="803"/>
         <source>Raspberry Pi System Volume</source>
         <translation>Raspberry Pi システム ボリューム</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="588"/>
         <source>Studio Settings</source>
-        <translation>スタジオ設定</translation>
+        <translation type="obsolete">スタジオ設定</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="605"/>
+        <location filename="../mainwindow.cpp" line="828"/>
         <source>Raspberry Pi Audio Output</source>
         <translation>Raspberry Pi オーディオアウト</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="607"/>
+        <location filename="../mainwindow.cpp" line="830"/>
         <source>&amp;Default</source>
         <translation>&amp;デフォルト</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="608"/>
+        <location filename="../mainwindow.cpp" line="831"/>
         <source>&amp;Headphones</source>
         <translation>&amp;ヘッドフォン</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="609"/>
+        <location filename="../mainwindow.cpp" line="832"/>
         <source>&amp;HDMI</source>
         <translation>&amp;HDMI</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="842"/>
         <source>Save Current Workspace</source>
-        <translation>現在のワークスペースを保存</translation>
+        <translation type="obsolete">現在のワークスペースを保存</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="910"/>
+        <location filename="../mainwindow.cpp" line="1249"/>
         <source>Running Code...</source>
         <oldsource>Running Code....</oldsource>
         <translation>コードの実行...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="953"/>
+        <location filename="../mainwindow.cpp" line="1291"/>
+        <source>Zooming In...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1298"/>
+        <source>Zooming Out...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1305"/>
         <source>Beautifying...</source>
         <oldsource>Beautifying....</oldsource>
         <translation>整形します...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="972"/>
+        <location filename="../mainwindow.cpp" line="1325"/>
         <source>Reloading...</source>
         <oldsource>Reloading....</oldsource>
         <translation>リロード...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="993"/>
+        <location filename="../mainwindow.cpp" line="1332"/>
+        <source>Checking for updates...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1356"/>
         <source>Enabling Mixer HPF...</source>
         <oldsource>Enabling Mixer HPF....</oldsource>
         <translation>ミキサーHPFを有効にしています...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1001"/>
+        <location filename="../mainwindow.cpp" line="1365"/>
         <source>Disabling Mixer HPF...</source>
         <oldsource>Disabling Mixer HPF....</oldsource>
         <translation>ミキサーHPFを無効にしています...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="237"/>
-        <location filename="../mainwindow.cpp" line="932"/>
+        <location filename="../mainwindow.cpp" line="1275"/>
         <source>Workspace %1</source>
         <translation>Workspace %1</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="387"/>
+        <location filename="../mainwindow.cpp" line="153"/>
+        <source>Sonic Pi update info</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="296"/>
+        <source>Buffer %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="459"/>
         <source>Welcome to Sonic Pi</source>
         <translation>Sonic Piへようこそ</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="415"/>
+        <location filename="../mainwindow.cpp" line="601"/>
         <source>Indenting selection...</source>
         <translation>選択範囲をインデント...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="419"/>
+        <location filename="../mainwindow.cpp" line="605"/>
         <source>Indenting line...</source>
         <translation>行をインデント...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="586"/>
+        <location filename="../mainwindow.cpp" line="634"/>
+        <source>Commenting selection...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="638"/>
+        <source>Commenting line...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="717"/>
+        <source>Ruby could not be started, is it installed and in your PATH?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="804"/>
         <source>Use this slider to change the system volume of your Raspberry Pi.</source>
         <oldsource>Use this slider to change the system volume of your Raspberry Pi</oldsource>
         <translation>あなたのラズベリーパイのシステムボリュームを変更するには、このスライダを使用します。</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="589"/>
+        <location filename="../mainwindow.cpp" line="806"/>
+        <source>Advanced Audio</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="807"/>
         <source>Advanced audio settings for working with
 external PA systems when performing with Sonic Pi.</source>
         <oldsource>Advanced audio settings for working with external PA systems when performing with Sonic Pi.</oldsource>
         <translation>外部PAシステムの高度なオーディオ設定を行います。</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="590"/>
+        <location filename="../mainwindow.cpp" line="808"/>
         <source>Invert Stereo</source>
         <translation>ステレオ反転</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="592"/>
+        <location filename="../mainwindow.cpp" line="809"/>
+        <source>Toggle stereo inversion.
+If enabled, audio sent to the left speaker will
+be routed to the right speaker and visa versa.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="811"/>
         <source>Force Mono</source>
         <translation>モノラル設定</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="606"/>
+        <location filename="../mainwindow.cpp" line="812"/>
+        <source>Toggle mono mode.
+If enabled both right and left audio is mixed and
+the same signal is sent to both speakers.
+Useful when working with external systems that
+can only handle mono.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="815"/>
+        <source>Safe mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="816"/>
+        <source>Toggle synth argument checking functions.
+If disabled, certain synth opt values may
+create unexpectedly loud or uncomfortable sounds.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="829"/>
         <source>Your Raspberry Pi has two forms of audio output.
 Firstly, there is the headphone jack of the Raspberry Pi itself.
 Secondly, some HDMI monitors/TVs support audio through the HDMI port.
@@ -157,161 +226,418 @@ For example, if you have headphones connected to your Raspberry Pi, choose &apos
 これらのボタンを使用し、あなたが望む出力に設定します。</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="629"/>
+        <location filename="../mainwindow.cpp" line="852"/>
+        <source>Logging</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="853"/>
+        <source>Configure debug behaviour</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="855"/>
+        <source>Log synths</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="856"/>
+        <source>Toggle log messages.
+If disabled, activity such as synth and sample
+triggering will not be printed to the log by default.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="858"/>
+        <source>Clear log on run</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="859"/>
+        <source>Toggle log clearing on run.
+If enabled, the log is cleared each
+time the run button is pressed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="861"/>
+        <source>Log cues</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="862"/>
+        <source>Enable or disable logging of cues.
+If disabled, cues will still trigger.
+However, they will not be visible in the logs.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="871"/>
+        <source>Transparency</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="886"/>
+        <source>Toggle automatic update checking.
+This check involves sending anonymous information about your platform and version.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="887"/>
+        <source>Check now</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="888"/>
+        <source>Force a check for updates now.
+This check involves sending anonymous information about your platform and version.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="889"/>
+        <source>Get update</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="890"/>
+        <source>Visit http://sonic-pi.net to download new version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="895"/>
+        <source>Update Info</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="914"/>
+        <source>Show and Hide</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="915"/>
+        <source>Configure editor display options.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="916"/>
+        <source>Look and Feel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="917"/>
+        <source>Configure editor look and feel.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="918"/>
+        <source>Automation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="919"/>
+        <source>Configure automation features.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="920"/>
+        <source>Auto-align</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="921"/>
+        <source>Automatically align code on Run</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="924"/>
+        <source>Toggle line number visibility.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="925"/>
+        <source>Show log</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="926"/>
+        <source>Toggle visibility of the log.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="928"/>
+        <source>Show buttons</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="929"/>
+        <source>Toggle visibility of the control buttons.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="931"/>
+        <source>Show tabs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="933"/>
+        <source>Toggle visibility of the buffer selection tabs.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="934"/>
+        <source>Full screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="935"/>
+        <source>Toggle full screen mode.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="936"/>
+        <source>Dark mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="937"/>
+        <source>Toggle dark mode.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="937"/>
+        <source>
+Dark mode is perfect for live coding in night clubs.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="976"/>
+        <source>Audio</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="989"/>
+        <source>Studio</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="991"/>
+        <location filename="../mainwindow.cpp" line="996"/>
+        <source>Performance</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="992"/>
+        <source>Settings useful for performing with Sonic Pi</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1087"/>
+        <source>Server boot error...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1087"/>
+        <source>Apologies, a critical error occurred during startup</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1087"/>
+        <source>Please consider reporting a bug at</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1181"/>
+        <source>Save Current Buffer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2413"/>
+        <source>Last checked %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2415"/>
+        <source>Sonic Pi checks for updates
+every two weeks.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2417"/>
+        <source>This is Sonic Pi %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2418"/>
+        <source>Version %2 is now available!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2422"/>
+        <source>New version available!
+Get Sonic Pi %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2448"/>
+        <source>Welcome back. Now get your live code on...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Debug Options</source>
-        <translation>デバッグオプション</translation>
+        <translation type="obsolete">デバッグオプション</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="630"/>
         <source>Print output</source>
-        <translation>プリント出力</translation>
+        <translation type="obsolete">プリント出力</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="631"/>
         <source>Check synth args</source>
-        <translation>シンセの引数を確認</translation>
+        <translation type="obsolete">シンセの引数を確認</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="632"/>
         <source>Clear output on run</source>
-        <translation>実行時の出力をクリア</translation>
+        <translation type="obsolete">実行時の出力をクリア</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="642"/>
+        <location filename="../mainwindow.cpp" line="882"/>
+        <location filename="../mainwindow.cpp" line="1004"/>
         <source>Updates</source>
         <translation>アップデート</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="643"/>
+        <location filename="../mainwindow.cpp" line="884"/>
         <source>Check for updates</source>
         <translation>アップデートをチェック</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="646"/>
         <source>Configure whether Sonic Pi may check for new updates on launch.
 Please note, the checking process includes sending
 anonymous information to the Sonic Pi server.</source>
-        <translation>Sonic Piが起動時に新しい更新をチェックするかを設定します。
+        <translation type="obsolete">Sonic Piが起動時に新しい更新をチェックするかを設定します。
 チェック処理は、Sonic Piサーバーへ匿名情報を
 送信することを含むことに注意してください。</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="653"/>
+        <location filename="../mainwindow.cpp" line="988"/>
         <source>Editor</source>
         <translation>エディタ</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="654"/>
+        <location filename="../mainwindow.cpp" line="923"/>
         <source>Show line numbers</source>
         <translation>行番号を表示</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="657"/>
         <source>Editor Preferences</source>
-        <translation>エディタ設定</translation>
+        <translation type="obsolete">エディタ設定</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="745"/>
         <source>We&apos;re sorry, but Sonic Jam Pi was unable to start...</source>
-        <translation>Sonic Jam Piは開始できませんでした...</translation>
+        <translation type="obsolete">Sonic Jam Piは開始できませんでした...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="979"/>
+        <location filename="../mainwindow.cpp" line="1340"/>
         <source>Enabling update checking...</source>
         <translation>更新チェックを有効にしています...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="986"/>
+        <location filename="../mainwindow.cpp" line="1348"/>
         <source>Disabling update checking...</source>
         <translation>更新チェックを無効にしています...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1008"/>
+        <location filename="../mainwindow.cpp" line="1373"/>
         <source>Enabling Mixer LPF...</source>
         <oldsource>Enabling Mixer LPF....</oldsource>
         <translation>ミキサーLPFを有効にしています...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1016"/>
+        <location filename="../mainwindow.cpp" line="1382"/>
         <source>Disabling Mixer LPF...</source>
         <oldsource>Disabling Mixer LPF....</oldsource>
         <translation>ミキサーLPFを無効にしています...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1023"/>
+        <location filename="../mainwindow.cpp" line="1390"/>
         <source>Enabling Inverted Stereo...</source>
         <oldsource>Enabling Inverted Stereo....</oldsource>
         <translation>ステレオ反転を有効にしています...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1030"/>
+        <location filename="../mainwindow.cpp" line="1398"/>
         <source>Enabling Standard Stereo...</source>
         <oldsource>Enabling Standard Stereo....</oldsource>
         <translation>標準ステレオを有効にしています...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1037"/>
+        <location filename="../mainwindow.cpp" line="1406"/>
         <source>Mono Mode...</source>
         <oldsource>Mono Mode....</oldsource>
         <translation>モノラルモード...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1044"/>
+        <location filename="../mainwindow.cpp" line="1414"/>
         <source>Stereo Mode...</source>
         <oldsource>Stereo Mode....</oldsource>
         <translation>ステレオモード...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1052"/>
+        <location filename="../mainwindow.cpp" line="1423"/>
         <source>Stopping...</source>
         <translation>停止しています...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1116"/>
-        <location filename="../mainwindow.cpp" line="1132"/>
+        <location filename="../mainwindow.cpp" line="1507"/>
         <source>Updating System Volume...</source>
         <translation>システムボリュームを更新しています...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1155"/>
-        <location filename="../mainwindow.cpp" line="1161"/>
+        <location filename="../mainwindow.cpp" line="1729"/>
         <source>Switching To Headphone Audio Output...</source>
         <translation>ヘッドフォンオーディオ出力に切り替えます...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1174"/>
-        <location filename="../mainwindow.cpp" line="1180"/>
+        <location filename="../mainwindow.cpp" line="1745"/>
         <source>Switching To HDMI Audio Output...</source>
         <translation>HDMIオーディオ出力に切り替えます...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1193"/>
-        <location filename="../mainwindow.cpp" line="1199"/>
+        <location filename="../mainwindow.cpp" line="1760"/>
         <source>Switching To Default Audio Output...</source>
         <translation>オーディオ出力をデフォルトに切り替えます...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1377"/>
+        <location filename="../mainwindow.cpp" line="1912"/>
+        <source>Save current buffer as an external file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1916"/>
+        <source>See information about Sonic Pi</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1930"/>
         <source>Start recording to WAV audio file</source>
         <translation>WAVオーディオファイルへ記録を開始</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1382"/>
+        <location filename="../mainwindow.cpp" line="1935"/>
         <source>Improve readability of code</source>
         <translation>コードの可読性を向上</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1509"/>
+        <location filename="../mainwindow.cpp" line="2076"/>
         <source>Ready...</source>
         <translation>Ready...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1588"/>
+        <location filename="../mainwindow.cpp" line="2163"/>
         <source>File loaded...</source>
         <translation>ファイルをロードされました...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1613"/>
+        <location filename="../mainwindow.cpp" line="2188"/>
         <source>File saved...</source>
         <translation>ファイルが保存されました...</translation>
     </message>
@@ -336,48 +662,46 @@ anonymous information to the Sonic Pi server.</source>
         <translation type="obsolete">オーディオ出力をデフォルトに切り替えます。</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1349"/>
+        <location filename="../mainwindow.cpp" line="1902"/>
         <source>Run</source>
         <translation>実行</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1350"/>
+        <location filename="../mainwindow.cpp" line="1903"/>
         <source>Run the code in the current workspace</source>
         <translation>現在のワークスペースを実行</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1354"/>
+        <location filename="../mainwindow.cpp" line="1907"/>
         <source>Stop</source>
         <translation>停止</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1355"/>
+        <location filename="../mainwindow.cpp" line="1908"/>
         <source>Stop all running code</source>
         <translation>実行中のコードを全て停止</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1358"/>
+        <location filename="../mainwindow.cpp" line="1911"/>
         <source>Save As...</source>
         <translation>名前を付けて保存</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1359"/>
         <source>Save current workspace as an external file</source>
-        <translation>現在のワークスペースを外部ファイルに保存</translation>
+        <translation type="obsolete">現在のワークスペースを外部ファイルに保存</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1362"/>
+        <location filename="../mainwindow.cpp" line="1915"/>
         <source>Info</source>
         <translation>インフォメーション</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1363"/>
         <source>See information about Sonic Jam Pi</source>
-        <translation>Sonic Jam Piについての情報を参照</translation>
+        <translation type="obsolete">Sonic Jam Piについての情報を参照</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="339"/>
-        <location filename="../mainwindow.cpp" line="1367"/>
+        <location filename="../mainwindow.cpp" line="414"/>
+        <location filename="../mainwindow.cpp" line="1920"/>
         <source>Help</source>
         <translation>ヘルプ</translation>
     </message>
@@ -390,29 +714,29 @@ anonymous information to the Sonic Pi server.</source>
         <translation type="obsolete">更新チェックを無効にします....</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1368"/>
+        <location filename="../mainwindow.cpp" line="1921"/>
         <source>Toggle help pane</source>
         <translation>ヘルプ画面の表示</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1371"/>
+        <location filename="../mainwindow.cpp" line="1924"/>
         <source>Prefs</source>
         <translation>環境設定</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1372"/>
+        <location filename="../mainwindow.cpp" line="1925"/>
         <source>Toggle preferences pane</source>
         <translation>設定画面を表示</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1376"/>
-        <location filename="../mainwindow.cpp" line="1489"/>
-        <location filename="../mainwindow.cpp" line="1490"/>
+        <location filename="../mainwindow.cpp" line="1929"/>
+        <location filename="../mainwindow.cpp" line="2051"/>
+        <location filename="../mainwindow.cpp" line="2052"/>
         <source>Start Recording</source>
         <translation>録音開始</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1381"/>
+        <location filename="../mainwindow.cpp" line="1934"/>
         <source>Auto-Align Text</source>
         <oldsource>Auto Align Text</oldsource>
         <translation>テキスト自動整列</translation>
@@ -422,73 +746,73 @@ anonymous information to the Sonic Pi server.</source>
         <translation type="obsolete">テキスト自動整列</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1386"/>
+        <location filename="../mainwindow.cpp" line="1939"/>
+        <location filename="../mainwindow.cpp" line="1940"/>
         <source>Increase Text Size</source>
         <translation>文字を大きく</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1387"/>
         <source>Make text bigger</source>
-        <translation>テキストを大きく</translation>
+        <translation type="obsolete">テキストを大きく</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1392"/>
+        <location filename="../mainwindow.cpp" line="1944"/>
+        <location filename="../mainwindow.cpp" line="1945"/>
         <source>Decrease Text Size</source>
         <translation>文字を小さく</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1393"/>
         <source>Make text smaller</source>
-        <translation>テキストを小さく</translation>
+        <translation type="obsolete">テキストを小さく</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1399"/>
+        <location filename="../mainwindow.cpp" line="1950"/>
         <source>Tools</source>
         <translation>ツール</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1440"/>
+        <location filename="../mainwindow.cpp" line="1997"/>
         <source>About</source>
         <translation>概要</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1440"/>
+        <location filename="../mainwindow.cpp" line="1998"/>
         <source>Core Team</source>
         <translation>コアチーム</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1440"/>
+        <location filename="../mainwindow.cpp" line="1999"/>
         <source>Contributors</source>
         <translation>協力者</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1441"/>
+        <location filename="../mainwindow.cpp" line="2000"/>
         <source>Community</source>
         <translation>コミュニティ</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1441"/>
+        <location filename="../mainwindow.cpp" line="2001"/>
         <source>License</source>
         <translation>ライセンス</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1441"/>
+        <location filename="../mainwindow.cpp" line="2002"/>
         <source>History</source>
         <translation>ヒストリー</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1462"/>
+        <location filename="../mainwindow.cpp" line="2023"/>
         <source>Sonic Pi - Info</source>
         <translation>Sonic Pi - Info</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1482"/>
-        <location filename="../mainwindow.cpp" line="1483"/>
+        <location filename="../mainwindow.cpp" line="2043"/>
+        <location filename="../mainwindow.cpp" line="2044"/>
         <source>Stop Recording</source>
         <translation>録音停止</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1494"/>
+        <location filename="../mainwindow.cpp" line="2057"/>
         <source>Save Recording</source>
         <translation>録音を保存</translation>
     </message>
@@ -497,7 +821,7 @@ anonymous information to the Sonic Pi server.</source>
         <translation type="obsolete">Ready</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1578"/>
+        <location filename="../mainwindow.cpp" line="2153"/>
         <source>Cannot read file %1:
 %2.</source>
         <translation>%1:ファイルを読み取ることができません。
@@ -508,7 +832,7 @@ anonymous information to the Sonic Pi server.</source>
         <translation type="obsolete">Datei geladen</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1596"/>
+        <location filename="../mainwindow.cpp" line="2171"/>
         <source>Cannot write file %1:
 %2.</source>
         <translation>%1:ファイルを書き込むことができません。
@@ -519,33 +843,37 @@ anonymous information to the Sonic Pi server.</source>
         <translation type="obsolete">ファイルが保存されました。</translation>
     </message>
     <message>
-        <location filename="../ruby_help.h" line="79"/>
-        <location filename="../ruby_help.h" line="138"/>
+        <location filename="../ruby_help.h" line="80"/>
+        <location filename="../ruby_help.h" line="139"/>
+        <location filename="../ruby_help.h" line="199"/>
+        <location filename="../ruby_help.h" line="218"/>
+        <location filename="../ruby_help.h" line="278"/>
+        <location filename="../ruby_help.h" line="338"/>
         <source>Tutorial</source>
         <translation>チュートリアル</translation>
     </message>
     <message>
-        <location filename="../ruby_help.h" line="172"/>
+        <location filename="../ruby_help.h" line="370"/>
         <source>Examples</source>
         <translation>例</translation>
     </message>
     <message>
-        <location filename="../ruby_help.h" line="209"/>
+        <location filename="../ruby_help.h" line="410"/>
         <source>Synths</source>
         <translation>シンセ</translation>
     </message>
     <message>
-        <location filename="../ruby_help.h" line="243"/>
+        <location filename="../ruby_help.h" line="446"/>
         <source>Fx</source>
         <translation>効果</translation>
     </message>
     <message>
-        <location filename="../ruby_help.h" line="260"/>
+        <location filename="../ruby_help.h" line="463"/>
         <source>Samples</source>
         <translation>サンプル</translation>
     </message>
     <message>
-        <location filename="../ruby_help.h" line="397"/>
+        <location filename="../ruby_help.h" line="629"/>
         <source>Lang</source>
         <translation>命令</translation>
     </message>
@@ -553,7 +881,7 @@ anonymous information to the Sonic Pi server.</source>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../main.cpp" line="41"/>
+        <location filename="../main.cpp" line="43"/>
         <source>Sonic Pi</source>
         <translation>Sonic Pi</translation>
     </message>

--- a/app/gui/qt/lang/sonic-pi_pl.ts
+++ b/app/gui/qt/lang/sonic-pi_pl.ts
@@ -5,96 +5,96 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../mainwindow.cpp" line="152"/>
+        <location filename="../mainwindow.cpp" line="153"/>
         <source>Sonic Pi update info</source>
         <translation>Sonic PI informacje o aktualizacjach</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="295"/>
+        <location filename="../mainwindow.cpp" line="296"/>
         <source>Buffer %1</source>
         <translation>Bufor %1</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="356"/>
+        <location filename="../mainwindow.cpp" line="360"/>
         <source>Preferences</source>
         <translation>Ustawienia</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="369"/>
+        <location filename="../mainwindow.cpp" line="373"/>
         <source>Log</source>
         <translation>Log</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="410"/>
-        <location filename="../mainwindow.cpp" line="1912"/>
+        <location filename="../mainwindow.cpp" line="414"/>
+        <location filename="../mainwindow.cpp" line="1920"/>
         <source>Help</source>
         <translation>Pomoc</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="441"/>
-        <location filename="../mainwindow.cpp" line="2144"/>
-        <location filename="../mainwindow.cpp" line="2162"/>
+        <location filename="../mainwindow.cpp" line="445"/>
+        <location filename="../mainwindow.cpp" line="2152"/>
+        <location filename="../mainwindow.cpp" line="2170"/>
         <source>Sonic Pi</source>
         <translation>Sonic Pi</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="455"/>
+        <location filename="../mainwindow.cpp" line="459"/>
         <source>Welcome to Sonic Pi</source>
         <translation>Witaj w Sonic Pi</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="597"/>
+        <location filename="../mainwindow.cpp" line="601"/>
         <source>Indenting selection...</source>
         <translation>Formatowanie zaznaczenia...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="601"/>
+        <location filename="../mainwindow.cpp" line="605"/>
         <source>Indenting line...</source>
         <translation>Formatowanie linii...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="630"/>
+        <location filename="../mainwindow.cpp" line="634"/>
         <source>Commenting selection...</source>
         <translation>Komentowanie zaznaczenia...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="634"/>
+        <location filename="../mainwindow.cpp" line="638"/>
         <source>Commenting line...</source>
         <translation>Komentowanie linii...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="713"/>
+        <location filename="../mainwindow.cpp" line="717"/>
         <source>Ruby could not be started, is it installed and in your PATH?</source>
         <translation>Ruby nie mógł zostać uruchomiony, czy został on dodany do twojej ścieżki PATH?</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="799"/>
+        <location filename="../mainwindow.cpp" line="803"/>
         <source>Raspberry Pi System Volume</source>
         <translation>Raspberry Pi Głośność Systemu</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="800"/>
+        <location filename="../mainwindow.cpp" line="804"/>
         <source>Use this slider to change the system volume of your Raspberry Pi.</source>
         <translation>Użyj tego suwaka aby zmienić poziom głośności w twoim Raspberry Pi.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="802"/>
+        <location filename="../mainwindow.cpp" line="806"/>
         <source>Advanced Audio</source>
         <translation>Zaawansowane Ustawienia Dźwięku</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="803"/>
+        <location filename="../mainwindow.cpp" line="807"/>
         <source>Advanced audio settings for working with
 external PA systems when performing with Sonic Pi.</source>
         <translation>Zaawansowane ustawienia audio pozwalające na pracę z zewnętrznymi profesjonalnymi sytemami audio używanymi podczas występów na scenie z Sonic Pi. </translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="804"/>
+        <location filename="../mainwindow.cpp" line="808"/>
         <source>Invert Stereo</source>
         <translation>Odwrócone Stereo</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="805"/>
+        <location filename="../mainwindow.cpp" line="809"/>
         <source>Toggle stereo inversion.
 If enabled, audio sent to the left speaker will
 be routed to the right speaker and visa versa.</source>
@@ -103,12 +103,12 @@ Jeśli jest włączone, dźwięĸ wysyłany do lewego głośnika
 zostanie wysłany do prawego i vice versa.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="807"/>
+        <location filename="../mainwindow.cpp" line="811"/>
         <source>Force Mono</source>
         <translation>Wymuś Mono</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="808"/>
+        <location filename="../mainwindow.cpp" line="812"/>
         <source>Toggle mono mode.
 If enabled both right and left audio is mixed and
 the same signal is sent to both speakers.
@@ -121,12 +121,12 @@ Bardzo przydatne podczas pracy z zewnętrznymi systemami
 audio, które potrafią obsługiwać tylko dźwięk mono.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="811"/>
+        <location filename="../mainwindow.cpp" line="815"/>
         <source>Safe mode</source>
         <translation>Tryb bezpieczny</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="812"/>
+        <location filename="../mainwindow.cpp" line="816"/>
         <source>Toggle synth argument checking functions.
 If disabled, certain synth opt values may
 create unexpectedly loud or uncomfortable sounds.</source>
@@ -135,12 +135,12 @@ Jeśłi nie jest włączona, pewne opcje syntezatorów mogą
 spowodować dźwięki o nieoczekiwanej głośności lub nieprzyjemnym brzmieniu. </translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="824"/>
+        <location filename="../mainwindow.cpp" line="828"/>
         <source>Raspberry Pi Audio Output</source>
         <translation>Raspberry Pi Wyjście Audio</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="825"/>
+        <location filename="../mainwindow.cpp" line="829"/>
         <source>Your Raspberry Pi has two forms of audio output.
 Firstly, there is the headphone jack of the Raspberry Pi itself.
 Secondly, some HDMI monitors/TVs support audio through the HDMI port.
@@ -152,37 +152,37 @@ dźwięĸu przez port HDMI.
 Użyj tych przycisków aby wymusić wyjście na takie urządzenie, które chesz.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="826"/>
+        <location filename="../mainwindow.cpp" line="830"/>
         <source>&amp;Default</source>
         <translation>&amp;Domyślnie</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="827"/>
+        <location filename="../mainwindow.cpp" line="831"/>
         <source>&amp;Headphones</source>
         <translation>&amp;Słuchawki</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="828"/>
+        <location filename="../mainwindow.cpp" line="832"/>
         <source>&amp;HDMI</source>
         <translation>&amp;HDMI</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="848"/>
+        <location filename="../mainwindow.cpp" line="852"/>
         <source>Logging</source>
         <translation>Logowanie</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="849"/>
+        <location filename="../mainwindow.cpp" line="853"/>
         <source>Configure debug behaviour</source>
         <translation>Konfiguracja zachowania debugowanych informacji</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="851"/>
+        <location filename="../mainwindow.cpp" line="855"/>
         <source>Log synths</source>
         <translation>Logowanie syntezatorów</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="852"/>
+        <location filename="../mainwindow.cpp" line="856"/>
         <source>Toggle log messages.
 If disabled, activity such as synth and sample
 triggering will not be printed to the log by default.</source>
@@ -192,12 +192,12 @@ i samplerów nie będą domyślnie powodowały prezentowania informacji
 w oknie logowania.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="854"/>
+        <location filename="../mainwindow.cpp" line="858"/>
         <source>Clear log on run</source>
         <translation>Wyczyść okno logowania przy uruchomieniu</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="855"/>
+        <location filename="../mainwindow.cpp" line="859"/>
         <source>Toggle log clearing on run.
 If enabled, the log is cleared each
 time the run button is pressed.</source>
@@ -208,12 +208,12 @@ jest czyszczone przy każdym naciśnięciu
 przycisku Run.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="857"/>
+        <location filename="../mainwindow.cpp" line="861"/>
         <source>Log cues</source>
         <translation>Loguj punkty cue</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="858"/>
+        <location filename="../mainwindow.cpp" line="862"/>
         <source>Enable or disable logging of cues.
 If disabled, cues will still trigger.
 However, they will not be visible in the logs.</source>
@@ -222,23 +222,23 @@ Jeśłi jest wyłączone, punkty cue wciąż będą uruchamiane.
 Jednakżę, nie będą one widoczne panelu logowania.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="867"/>
+        <location filename="../mainwindow.cpp" line="871"/>
         <source>Transparency</source>
         <translation>Przezroczystość</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="878"/>
-        <location filename="../mainwindow.cpp" line="1000"/>
+        <location filename="../mainwindow.cpp" line="882"/>
+        <location filename="../mainwindow.cpp" line="1004"/>
         <source>Updates</source>
         <translation>Aktualizacje</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="880"/>
+        <location filename="../mainwindow.cpp" line="884"/>
         <source>Check for updates</source>
         <translation>Sprawdź dostępność aktualizacji</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="882"/>
+        <location filename="../mainwindow.cpp" line="886"/>
         <source>Toggle automatic update checking.
 This check involves sending anonymous information about your platform and version.</source>
         <translation>Włącza lub wyłącza automatyczne sprawdzanie aktualizacji.
@@ -246,528 +246,528 @@ Włączenie spowoduje wysyłanie anonimowych informacji o plaftormie
 i wersji z której korzystasz.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="883"/>
+        <location filename="../mainwindow.cpp" line="887"/>
         <source>Check now</source>
         <translation>Sprawdź teraz</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="884"/>
+        <location filename="../mainwindow.cpp" line="888"/>
         <source>Force a check for updates now.
 This check involves sending anonymous information about your platform and version.</source>
         <translation>Wymusza sprawdzenie aktualizacji w tej chwili.
 Zaznaczenie powoduje wysłanie anonimowych informacji o twojej platformie i wersji.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="885"/>
+        <location filename="../mainwindow.cpp" line="889"/>
         <source>Get update</source>
         <translation>Pobierz aktualizację</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="886"/>
+        <location filename="../mainwindow.cpp" line="890"/>
         <source>Visit http://sonic-pi.net to download new version</source>
         <translation>Wejdź na stronę http://sonic-pi.net aby pobrać nową wersję</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="891"/>
+        <location filename="../mainwindow.cpp" line="895"/>
         <source>Update Info</source>
         <translation>Informacje dot. Aktualizacji</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="910"/>
+        <location filename="../mainwindow.cpp" line="914"/>
         <source>Show and Hide</source>
         <translation>Pokaż i Ukryj</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="911"/>
+        <location filename="../mainwindow.cpp" line="915"/>
         <source>Configure editor display options.</source>
         <translation>Skonfiguruj opcje dot. wyświetlania edytora.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="912"/>
+        <location filename="../mainwindow.cpp" line="916"/>
         <source>Look and Feel</source>
         <translation>Wygląd i Wrażenia</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="913"/>
+        <location filename="../mainwindow.cpp" line="917"/>
         <source>Configure editor look and feel.</source>
         <translation>Konfiguracja wyglądu i wrażeń dot. edytora.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="914"/>
+        <location filename="../mainwindow.cpp" line="918"/>
         <source>Automation</source>
         <translation>Automatyzacja</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="915"/>
+        <location filename="../mainwindow.cpp" line="919"/>
         <source>Configure automation features.</source>
         <translation>Konfiguracja opcji dot. automatyzacji.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="916"/>
+        <location filename="../mainwindow.cpp" line="920"/>
         <source>Auto-align</source>
         <translation>Auto wyrównanie</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="917"/>
+        <location filename="../mainwindow.cpp" line="921"/>
         <source>Automatically align code on Run</source>
         <translation>Automatycznie wyrównanie (formatowanie) przy uruchomieniu kodu (Run)</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="919"/>
+        <location filename="../mainwindow.cpp" line="923"/>
         <source>Show line numbers</source>
         <translation>Pokaż numery linii</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="920"/>
+        <location filename="../mainwindow.cpp" line="924"/>
         <source>Toggle line number visibility.</source>
         <translation>Włącza i wyłącza widoczność numerów linii.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="921"/>
+        <location filename="../mainwindow.cpp" line="925"/>
         <source>Show log</source>
         <translation>Pokaż log</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="922"/>
+        <location filename="../mainwindow.cpp" line="926"/>
         <source>Toggle visibility of the log.</source>
         <translation>Włącza i wyłącza widoczność panelu logowania (log).</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="924"/>
+        <location filename="../mainwindow.cpp" line="928"/>
         <source>Show buttons</source>
         <translation>Pokaż przyciski</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="925"/>
+        <location filename="../mainwindow.cpp" line="929"/>
         <source>Toggle visibility of the control buttons.</source>
         <translation>Włącza i wyłącza widoczność przycisków.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="927"/>
+        <location filename="../mainwindow.cpp" line="931"/>
         <source>Show tabs</source>
         <translation>Pokazuj zakładki</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="929"/>
+        <location filename="../mainwindow.cpp" line="933"/>
         <source>Toggle visibility of the buffer selection tabs.</source>
         <translation>Włącza i wyłącza widoczność zakładek prezentujących bufory.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="930"/>
+        <location filename="../mainwindow.cpp" line="934"/>
         <source>Full screen</source>
         <translation>Pełny ekran</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="931"/>
+        <location filename="../mainwindow.cpp" line="935"/>
         <source>Toggle full screen mode.</source>
         <translation>Włącza i wyłącza tryb pełnoekranowy.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="932"/>
+        <location filename="../mainwindow.cpp" line="936"/>
         <source>Dark mode</source>
         <translation>Tryb nocny</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="933"/>
+        <location filename="../mainwindow.cpp" line="937"/>
         <source>Toggle dark mode.</source>
         <translation>Włącza i wyłącza tryb nocny.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="933"/>
+        <location filename="../mainwindow.cpp" line="937"/>
         <source>
 Dark mode is perfect for live coding in night clubs.</source>
         <translation>
 Tryb nocny jest idealny do kodowania na żywo w klubach.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="972"/>
+        <location filename="../mainwindow.cpp" line="976"/>
         <source>Audio</source>
         <translation>Audio</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="984"/>
+        <location filename="../mainwindow.cpp" line="988"/>
         <source>Editor</source>
         <translation>Edytor</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="985"/>
+        <location filename="../mainwindow.cpp" line="989"/>
         <source>Studio</source>
         <translation>Studio</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="987"/>
-        <location filename="../mainwindow.cpp" line="992"/>
+        <location filename="../mainwindow.cpp" line="991"/>
+        <location filename="../mainwindow.cpp" line="996"/>
         <source>Performance</source>
         <translation>Koncert</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="988"/>
+        <location filename="../mainwindow.cpp" line="992"/>
         <source>Settings useful for performing with Sonic Pi</source>
         <translation>Ustawienia przydatne gdy korzystasz z Sonic Pi na koncertach/podczas występów</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1083"/>
+        <location filename="../mainwindow.cpp" line="1087"/>
         <source>Server boot error...</source>
         <translation>Błąd przy uruchamianiu serwera...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1083"/>
+        <location filename="../mainwindow.cpp" line="1087"/>
         <source>Apologies, a critical error occurred during startup</source>
         <translation>Przepraszamy, wystąpił krytyczny błąd podczas uruchamiania</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1083"/>
+        <location filename="../mainwindow.cpp" line="1087"/>
         <source>Please consider reporting a bug at</source>
         <translation>Proszę, spróbuj zgłosić ten błąd na stronie</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1177"/>
+        <location filename="../mainwindow.cpp" line="1181"/>
         <source>Save Current Buffer</source>
         <translation>Zapisz Aktualny Bufor</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1245"/>
+        <location filename="../mainwindow.cpp" line="1249"/>
         <source>Running Code...</source>
         <translation>Uruchamianie Kodu...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1271"/>
+        <location filename="../mainwindow.cpp" line="1275"/>
         <source>Workspace %1</source>
         <translation>Bufor %1</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1287"/>
+        <location filename="../mainwindow.cpp" line="1291"/>
         <source>Zooming In...</source>
         <translation>Powiększanie...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1294"/>
+        <location filename="../mainwindow.cpp" line="1298"/>
         <source>Zooming Out...</source>
         <translation>Zmniejszanie...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1301"/>
+        <location filename="../mainwindow.cpp" line="1305"/>
         <source>Beautifying...</source>
         <translation>Upiększanie...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1321"/>
+        <location filename="../mainwindow.cpp" line="1325"/>
         <source>Reloading...</source>
         <translation>Trwa Przeładowanie...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1328"/>
+        <location filename="../mainwindow.cpp" line="1332"/>
         <source>Checking for updates...</source>
         <translation>Sprawdzam aktualizacje...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1336"/>
+        <location filename="../mainwindow.cpp" line="1340"/>
         <source>Enabling update checking...</source>
         <translation>Włączam sprawdzanie aktualizacji...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1344"/>
+        <location filename="../mainwindow.cpp" line="1348"/>
         <source>Disabling update checking...</source>
         <translation>Wyłączam sprawdzanie aktualizacji...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1352"/>
+        <location filename="../mainwindow.cpp" line="1356"/>
         <source>Enabling Mixer HPF...</source>
         <translatorcomment>HPF - High Pass Filter (Filtr górnoprzepustowy)</translatorcomment>
         <translation>Włączanie Miksera HPF...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1361"/>
+        <location filename="../mainwindow.cpp" line="1365"/>
         <source>Disabling Mixer HPF...</source>
         <translation>Wyłączam Mikser HPF...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1369"/>
+        <location filename="../mainwindow.cpp" line="1373"/>
         <source>Enabling Mixer LPF...</source>
         <translation>Włączam Mikser LPF...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1378"/>
+        <location filename="../mainwindow.cpp" line="1382"/>
         <source>Disabling Mixer LPF...</source>
         <translation>Wyłączam Mikser LPF...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1386"/>
+        <location filename="../mainwindow.cpp" line="1390"/>
         <source>Enabling Inverted Stereo...</source>
         <translation>Włączam Odwrócone Stereo...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1394"/>
+        <location filename="../mainwindow.cpp" line="1398"/>
         <source>Enabling Standard Stereo...</source>
         <translation>Włączam Standardowe Stereo...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1402"/>
+        <location filename="../mainwindow.cpp" line="1406"/>
         <source>Mono Mode...</source>
         <translation>Tryb Mono...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1410"/>
+        <location filename="../mainwindow.cpp" line="1414"/>
         <source>Stereo Mode...</source>
         <translation>Tryb Stereo...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1419"/>
+        <location filename="../mainwindow.cpp" line="1423"/>
         <source>Stopping...</source>
         <translation>Zatrzymuję...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1503"/>
+        <location filename="../mainwindow.cpp" line="1507"/>
         <source>Updating System Volume...</source>
         <translation>Aktualizuję Głośność Systemu...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1721"/>
+        <location filename="../mainwindow.cpp" line="1729"/>
         <source>Switching To Headphone Audio Output...</source>
         <translation>Zmieniam Wyjśćie Na Słuchawkowe...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1737"/>
+        <location filename="../mainwindow.cpp" line="1745"/>
         <source>Switching To HDMI Audio Output...</source>
         <translation>Zmieniam Wyjśćie na HDMI...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1752"/>
+        <location filename="../mainwindow.cpp" line="1760"/>
         <source>Switching To Default Audio Output...</source>
         <translation>Zmieniam Wyjście Na Domyślne Wyjście Audio...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1894"/>
+        <location filename="../mainwindow.cpp" line="1902"/>
         <source>Run</source>
         <translation>Run (Uruchom)</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1895"/>
+        <location filename="../mainwindow.cpp" line="1903"/>
         <source>Run the code in the current workspace</source>
         <translation>Uruchom kod znajdujący się aktualnym buforze</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1899"/>
+        <location filename="../mainwindow.cpp" line="1907"/>
         <source>Stop</source>
         <translation>Stop</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1900"/>
+        <location filename="../mainwindow.cpp" line="1908"/>
         <source>Stop all running code</source>
         <translation>Zatrzymuje jakikolwiek kod, który jest aktualnie uruchomiony</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1903"/>
+        <location filename="../mainwindow.cpp" line="1911"/>
         <source>Save As...</source>
         <translation>Zapisz jako...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1904"/>
+        <location filename="../mainwindow.cpp" line="1912"/>
         <source>Save current buffer as an external file</source>
         <translation>Zapisz aktualny bufor jako zewnętrzny plik</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1907"/>
+        <location filename="../mainwindow.cpp" line="1915"/>
         <source>Info</source>
         <translation>Info</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1908"/>
+        <location filename="../mainwindow.cpp" line="1916"/>
         <source>See information about Sonic Pi</source>
         <translation>Zobacz informacje o Sonic Pi</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1913"/>
+        <location filename="../mainwindow.cpp" line="1921"/>
         <source>Toggle help pane</source>
         <translation>Włącza i wyłącza panel pomocy</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1916"/>
+        <location filename="../mainwindow.cpp" line="1924"/>
         <source>Prefs</source>
         <translation>Ustawienia</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1917"/>
+        <location filename="../mainwindow.cpp" line="1925"/>
         <source>Toggle preferences pane</source>
         <translation>Włącza i wyłącza panel ustawień</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1921"/>
-        <location filename="../mainwindow.cpp" line="2043"/>
-        <location filename="../mainwindow.cpp" line="2044"/>
+        <location filename="../mainwindow.cpp" line="1929"/>
+        <location filename="../mainwindow.cpp" line="2051"/>
+        <location filename="../mainwindow.cpp" line="2052"/>
         <source>Start Recording</source>
         <translation>Uruchom Nagrywanie</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1922"/>
+        <location filename="../mainwindow.cpp" line="1930"/>
         <source>Start recording to WAV audio file</source>
         <translation>Uruchamiana nagrywanie dźwięku do pliku WAV</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1926"/>
+        <location filename="../mainwindow.cpp" line="1934"/>
         <source>Auto-Align Text</source>
         <translation>Automatyczne Wyrównanie Tekstu</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1927"/>
+        <location filename="../mainwindow.cpp" line="1935"/>
         <source>Improve readability of code</source>
         <translation>Poprawia czytelność kodu</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1931"/>
-        <location filename="../mainwindow.cpp" line="1932"/>
+        <location filename="../mainwindow.cpp" line="1939"/>
+        <location filename="../mainwindow.cpp" line="1940"/>
         <source>Increase Text Size</source>
         <translation>Zwiększa Wielkość Tekstu</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1936"/>
-        <location filename="../mainwindow.cpp" line="1937"/>
+        <location filename="../mainwindow.cpp" line="1944"/>
+        <location filename="../mainwindow.cpp" line="1945"/>
         <source>Decrease Text Size</source>
         <translation>Zmniejsza Wielkość Tekstu</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1942"/>
+        <location filename="../mainwindow.cpp" line="1950"/>
         <source>Tools</source>
         <translation>Narzędzia</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1989"/>
+        <location filename="../mainwindow.cpp" line="1997"/>
         <source>About</source>
         <translation>Informacje</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1990"/>
+        <location filename="../mainwindow.cpp" line="1998"/>
         <source>Core Team</source>
         <translation>Zespół Podstawowy</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1991"/>
+        <location filename="../mainwindow.cpp" line="1999"/>
         <source>Contributors</source>
         <translation>Osoby, które wniosły wkład</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1992"/>
+        <location filename="../mainwindow.cpp" line="2000"/>
         <source>Community</source>
         <translation>Społeczność</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1993"/>
+        <location filename="../mainwindow.cpp" line="2001"/>
         <source>License</source>
         <translation>Licencja</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1994"/>
+        <location filename="../mainwindow.cpp" line="2002"/>
         <source>History</source>
         <translation>HIstoria</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2015"/>
+        <location filename="../mainwindow.cpp" line="2023"/>
         <source>Sonic Pi - Info</source>
         <translation>Sonic Pi - Info</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2035"/>
-        <location filename="../mainwindow.cpp" line="2036"/>
+        <location filename="../mainwindow.cpp" line="2043"/>
+        <location filename="../mainwindow.cpp" line="2044"/>
         <source>Stop Recording</source>
         <translation>Zakończ Nagrywanie</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2049"/>
+        <location filename="../mainwindow.cpp" line="2057"/>
         <source>Save Recording</source>
         <translation>Zapisz Nagranie</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2068"/>
+        <location filename="../mainwindow.cpp" line="2076"/>
         <source>Ready...</source>
         <translation>Gotowy....</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2145"/>
+        <location filename="../mainwindow.cpp" line="2153"/>
         <source>Cannot read file %1:
 %2.</source>
         <translation>NIe można odczytać pliku %1: %2.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2155"/>
+        <location filename="../mainwindow.cpp" line="2163"/>
         <source>File loaded...</source>
         <translation>Plik wczytany....</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2163"/>
+        <location filename="../mainwindow.cpp" line="2171"/>
         <source>Cannot write file %1:
 %2.</source>
         <translation>Nie można zapisać pliku %1: %2.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2180"/>
+        <location filename="../mainwindow.cpp" line="2188"/>
         <source>File saved...</source>
         <translation>Plik zapisany....</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2405"/>
+        <location filename="../mainwindow.cpp" line="2413"/>
         <source>Last checked %1</source>
         <translation>Ostatnio sprawdzono %1</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2407"/>
+        <location filename="../mainwindow.cpp" line="2415"/>
         <source>Sonic Pi checks for updates
 every two weeks.</source>
         <translation>Sonic Pi sprawdza aktualizacje
 co dwa tygodnie.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2409"/>
+        <location filename="../mainwindow.cpp" line="2417"/>
         <source>This is Sonic Pi %1</source>
         <translation>To jest Sonic Pi %1</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2410"/>
+        <location filename="../mainwindow.cpp" line="2418"/>
         <source>Version %2 is now available!</source>
         <translation>Wersja %2 jest dostępna!</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2414"/>
+        <location filename="../mainwindow.cpp" line="2422"/>
         <source>New version available!
 Get Sonic Pi %1</source>
         <translation>Nowa wersja jest już dostępna! Pobierz Sonic Pi %1</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2440"/>
+        <location filename="../mainwindow.cpp" line="2448"/>
         <source>Welcome back. Now get your live code on...</source>
         <translation>Witaj ponownie. A teraz spraw aby twój kod ożył...</translation>
     </message>
     <message>
         <location filename="../ruby_help.h" line="80"/>
-        <location filename="../ruby_help.h" line="140"/>
-        <location filename="../ruby_help.h" line="151"/>
-        <location filename="../ruby_help.h" line="210"/>
-        <location filename="../ruby_help.h" line="229"/>
-        <location filename="../ruby_help.h" line="289"/>
+        <location filename="../ruby_help.h" line="139"/>
+        <location filename="../ruby_help.h" line="199"/>
+        <location filename="../ruby_help.h" line="218"/>
+        <location filename="../ruby_help.h" line="278"/>
+        <location filename="../ruby_help.h" line="338"/>
         <source>Tutorial</source>
         <translation>Samouczek</translation>
     </message>
     <message>
-        <location filename="../ruby_help.h" line="321"/>
+        <location filename="../ruby_help.h" line="370"/>
         <source>Examples</source>
         <translation>Przykłady</translation>
     </message>
     <message>
-        <location filename="../ruby_help.h" line="361"/>
+        <location filename="../ruby_help.h" line="410"/>
         <source>Synths</source>
         <translation>Syntezatory</translation>
     </message>
     <message>
-        <location filename="../ruby_help.h" line="397"/>
+        <location filename="../ruby_help.h" line="446"/>
         <source>Fx</source>
         <translation>Efekty</translation>
     </message>
     <message>
-        <location filename="../ruby_help.h" line="414"/>
+        <location filename="../ruby_help.h" line="463"/>
         <source>Samples</source>
         <translation>Sample</translation>
     </message>
     <message>
-        <location filename="../ruby_help.h" line="580"/>
+        <location filename="../ruby_help.h" line="629"/>
         <source>Lang</source>
         <translation>Język</translation>
     </message>

--- a/etc/doc/tutorial/fr/01-Welcome-to-Sonic-Pi.md
+++ b/etc/doc/tutorial/fr/01-Welcome-to-Sonic-Pi.md
@@ -8,13 +8,13 @@ faire des sons délirants comme je le suis pour vous le montrer. Ça va
 musique, de la synthèse, de la programmation, de l'interprètation et
 plus encore.
 
-Mais attendez, c'est dur pour moi ! Je me présente. Je suis
+Mais attendez, comme je suis impoli ! Je me présente. Je suis
 [Sam Aaron](http://twitter.com/samaaron) - le gars qui a créé Sonic Pi.
 Vous pouvez me joindre à [@samaaron](http://twitter.com/samaaron) sur
 Twitter et je serai plus qu'heureux de vous saluer. Vous pourriez aussi
 être intéressé par mon orchestre "Live Coding" [Meta-eX](http://meta-ex.com)
 où j'interprête de la musique avec du code devant un public. Vous pouvez
-trouver une de mes pistes [Meta-eX](http://meta-ex.com) dans les exemples.
+trouver un de mes morceaux [Meta-eX](http://meta-ex.com) dans les exemples.
 
 Si vous avez des observations ou des idées pour améliorer Sonic Pi - Faîtes
 m'en part s'il vous plait - les retours sont tellement utiles. Vous ne le

--- a/etc/doc/tutorial/fr/01.1-Live-Coding.md
+++ b/etc/doc/tutorial/fr/01.1-Live-Coding.md
@@ -17,7 +17,7 @@ sur votre siège et de profiter...
 
 ## Une boucle en "live"
 
-Démarrons, copiez le code suivant dans un "workspace" (espace de travail) 
+Démarrons, copiez le code suivant dans un "buffer" 
 libre :
 
 ```

--- a/etc/doc/tutorial/fr/01.2-Exploring-the-Interface.md
+++ b/etc/doc/tutorial/fr/01.2-Exploring-the-Interface.md
@@ -12,7 +12,7 @@ un peu de temps à l'explorer.
 * *C* - Info, Help et Prefs
 * *D* - Éditeur de code
 * *E* - Paneau des préférences
-* *F* - Visualisateur du journal ("log")
+* *F* - Visualisateur de la trace
 * *G* - Système d'aide
 
 
@@ -57,15 +57,15 @@ Sonic Pi supporte quelques préférences ajustables qui peuvent être
 accédées en pressant le bouton *Prefs* à droite des boutons Info et Help.
 Cela activera l'affichage du panneau des préférences qui inclut un
 nombre d'options modifiables. Par exemple pour forcer le mode mono,
-inverser la stéréo, activer le mode verbeux du journal et aussi règler
+inverser la stéréo, activer le mode verbeux de la trace et aussi règler
 un curseur de volume et le sélecteur audio du Raspberry Pi (par défaut,
 il est sur "auto". Si vous n'entendez plus le son de votre Pi en étant 
 branchés sur la prise jack, modifiez ce paramètre).
 
-## F. Visualisateur du journal ("log")
+## F. Visualisateur de la trace
 
 Quand vous exécutez votre code, l'information sur ce que le programme est
-en train de faire est affichée dans le visualisateur du "log". Par défaut,
+en train de faire est affichée dans le visualisateur de la trace. Par défaut,
 vous verrez un message pour chaque son que vous céer avec l'heure éxacte à
 laquelle le son a été déclenché. C'est très utile pour déboguer votre code
 et comprendre ce qu'il fait.

--- a/etc/doc/tutorial/fr/03.1-Triggering-Samples.md
+++ b/etc/doc/tutorial/fr/03.1-Triggering-Samples.md
@@ -46,7 +46,7 @@ de ces sons avec des enveloppes.
 
 Il y a deux manière de découvrir l'étendue des échantillons fournis 
 par Sonic Pi. En premier lieu, on peut utiliser le système d'aide. 
-Cliquez sur "Samples" dans le menu horizontal du bas, choisissez votre 
+Cliquez sur "Échantillons" dans le menu horizontal du bas, choisissez votre 
 catégorie et vous verrez une liste des sons disponibles.
 
 Alternativement, vous pouvez utiliser le *système d'auto-complétion*. 

--- a/etc/doc/tutorial/fr/05.4-Threads.md
+++ b/etc/doc/tutorial/fr/05.4-Threads.md
@@ -196,8 +196,8 @@ in_thread(name: :drums) do
 end
 ```
 
-Regardez le panneau "log" quand vous exécutez ce code. Regardez comment 
-le "log" rapporte le nom du thread avec le message.
+Regardez le panneau "trace" quand vous exécutez ce code. Regardez comment 
+le "trace" rapporte le nom du thread avec le message.
 
 ```
 [Run 36, Time 4.0, Thread :bass]
@@ -219,7 +219,7 @@ in_thread do
 end
 ```
 
-Allez de l'avant et collez cela dans un espace de travail et pressez le 
+Allez de l'avant et collez cela dans un buffer et pressez le 
 bouton "run". Pressez-le encore quelquefois. Ecoutez la cacaphonie des 
 échantillons amen bouclant de façon désynchronisée. Ok, vous pouvez 
 maintenant presser "stop".
@@ -242,7 +242,7 @@ end
 
 Essayez de presser le bouton "run" plusieurs fois avec ce code. Vous 
 entendrez seulement une boucle de l'échantillon amen. Vous allez aussi 
-voir ceci dans le "log" :
+voir ceci dans la trace :
 
 ```
 ==> Skipping thread creation: thread with name :amen already exists.

--- a/etc/doc/tutorial/fr/05.5-Functions.md
+++ b/etc/doc/tutorial/fr/05.5-Functions.md
@@ -61,11 +61,11 @@ significatifs à utiliser dans nos compositions.
 
 Pour le moment, chaque fois que nous avons pressé le bouton Run, Sonic 
 Pi a démarré d'un état complètement vierge. Il ne savait rien à part ce 
-qui était dans l'espace de travail. Vous ne pouviez pas référencer du 
-code d'un autre espace de travail ou d'un autre thread. Toutefois, les 
+qui était dans le buffer. Vous ne pouviez pas référencer du 
+code d'un autre buffer ou d'un autre thread. Toutefois, les 
 fonctions changent cela. Quand vous définissez une fonction, Sonic Pi 
-s'en *rappelle*. Essayons-le. Effacez tout le code dans votre espace de 
-travail et remplacez-le par :
+s'en *rappelle*. Essayons-le. Effacez tout le code dans votre buffer et 
+remplacez-le par :
 
 ```
 foo
@@ -74,7 +74,7 @@ foo
 Pressez le bouton Run et écoutez votre fonction qui est jouée. Où le 
 code est-il allé ? Comment Sonic Pi sait-il quoi jouer ? Sonic Pi s'est 
 simplement souvenu de votre fonction - ainsi, même après l'avoir 
-effacée de votre espace de travail, il se rappelle de ce que vous avez 
+effacée de votre buffer, il se rappelle de ce que vous avez 
 tapé. Ce comportement fonctionne uniquement avec les fonctions créées 
 en utilisant `define` (et `defonce`).
 

--- a/etc/doc/tutorial/fr/08.1-Lists.md
+++ b/etc/doc/tutorial/fr/08.1-Lists.md
@@ -84,7 +84,7 @@ la sorte auparavant. Faites-moi confiance toutefois, ce n'est pas trop
 dur. Il y a trois parties dans la ligne ci-dessus : le mot `puts`, 
 notre liste `52, 55, 59` et notre index `[1]`. En premier, nous disons 
 `puts` parce que nous voulons que Sonic Pi nous affiche la réponse dans 
-le panneau "log". Ensuite, nous lui donnons notre liste, et enfin notre 
+le panneau "trace". Ensuite, nous lui donnons notre liste, et enfin notre 
 index qui demande le second élément. Nous devons encadrer notre index 
 avec des crochets et parce que le compte commence à 0, l'index pour le 
 second élément est `1`. Regardez :
@@ -95,7 +95,7 @@ second élément est `1`. Regardez :
 ```
 
 Essayez d'exécuter le code `puts [52, 55, 59][1]` et vous verrez `55` 
-apparaître dans le panneau "log". Changer l'index `1` par d'autres 
+apparaître dans le panneau "trace". Changer l'index `1` par d'autres 
 valeurs, essayez des listes plus longues et pensez à la façon dont 
 vous pourriez utiliser une liste dans votre prochaine improvisation 
 avec du code. Par exemple, quelles structures musicales pourraient être 

--- a/etc/doc/tutorial/fr/09-Live-Coding.md
+++ b/etc/doc/tutorial/fr/09-Live-Coding.md
@@ -12,6 +12,6 @@ avantage est que vous pouvez amener Sonic Pi sur scène et donner un
 concert avec.
 
 Dans cette section, nous allons couvrir les fondamentaux du changement 
-de vos compositions avec du code statique en interprétations dynamiques.
+de vos compositions en interprétations dynamiques avec du code statique.
 
 Tenez-vous bien...

--- a/etc/doc/tutorial/fr/09.1-Live-Coding-Fundamentals.md
+++ b/etc/doc/tutorial/fr/09.1-Live-Coding-Fundamentals.md
@@ -2,7 +2,7 @@
 
 # Codage en "live"
 
-Maintenant nous avons suffisamment appris pour commencer réellement 
+Maintenant nous en avons suffisamment appris pour commencer réellement 
 à prendre du plaisir. Dans cette section, nous allons mettre en 
 pratique toutes les sections précédentes et vous montrer comment 
 commencer à faire vos compositions musicales en "live" et les 

--- a/etc/doc/tutorial/fr/09.2-Live-Loops.md
+++ b/etc/doc/tutorial/fr/09.2-Live-Loops.md
@@ -11,7 +11,7 @@ tant à écrire.
 Si vous n'avez pas lu la section précédente, `live_loop` est la 
 meilleure façon d'improviser avec Sonic Pi.
 
-Jouons. Ecrivez le code suivant dans un espace de travail :
+Jouons. Ecrivez le code suivant dans un buffer :
 
 ```
 live_loop :foo do

--- a/etc/doc/tutorial/fr/10.2-Shortcut-Cheatsheet.md
+++ b/etc/doc/tutorial/fr/10.2-Shortcut-Cheatsheet.md
@@ -80,7 +80,7 @@ est la touche *Alt* pour Windows/Linux et *Cmd* sur Mac) :
 * `C-g`   - Sort
 * `S-M-f` - Bascule en mode plein écran
 * `S-M-b` - Affiche/cache les boutons
-* `S-M-l` - Affiche/cache le panneau "log"
+* `S-M-l` - Affiche/cache le panneau "trace"
 * `S-M-m` - Bascule entre l'affichage clair et sombre
 
 

--- a/etc/doc/tutorial/fr/11.1-Basic-API.md
+++ b/etc/doc/tutorial/fr/11.1-Basic-API.md
@@ -21,7 +21,7 @@ Pi. Assurez-vous d'abord que vous avez Minecraft Pi et Sonic Pi
 actifs en même temps et assurez-vous aussi que vous êtes entré dans 
 un monde de Minecraft et que vous pouvez vous y déplacer.
 
-Dans un espace de travail vierge de Sonic Pi, entrez le code suivant :
+Dans un buffer vierge de Sonic Pi, entrez le code suivant :
 
 ```
 mc_message "Hello from Sonic Pi"
@@ -82,7 +82,7 @@ puts mc_location
 ```
 
 Quand vous pressez le bouton *Run*, vous voyez les coordonnées de votre 
-position courante affichées dans le panneau "log". Prenez en note, puis 
+position courante affichées dans le panneau "trace". Prenez en note, puis 
 déplacez-vous dans le monde et essayez à nouveau. Notez comme les 
 coordonnées ont changé ! Maintenant, je vous recommande de passer 
 quelque temps à refaire exactement cela - vous déplacer un peu dans le 


### PR DESCRIPTION
Double quotes issue in tutorial fixed, french translation error fixed in the first section, french gui translation and alignment between french terms used in both translations.