### PR TITLE
Changed offending double quotes to single quotes

### DIFF
--- a/etc/doc/tutorial/fr/01.1-Live-Coding.md
+++ b/etc/doc/tutorial/fr/01.1-Live-Coding.md
@@ -1,4 +1,4 @@
-1.1 Codage en "live"
+1.1 Codage en 'live'
 
 # Codage en "Live"
 

--- a/etc/doc/tutorial/fr/09-Live-Coding.md
+++ b/etc/doc/tutorial/fr/09-Live-Coding.md
@@ -1,4 +1,4 @@
-9 Codage en "live"
+9 Codage en 'live'
 
 # Codage en "live"
 

--- a/etc/doc/tutorial/fr/09.1-Live-Coding-Fundamentals.md
+++ b/etc/doc/tutorial/fr/09.1-Live-Coding-Fundamentals.md
@@ -1,4 +1,4 @@
-9.1 Fondamentaux du Codage en "live"
+9.1 Fondamentaux du Codage en 'live'
 
 # Codage en "live"
 

--- a/etc/doc/tutorial/fr/09.2-Live-Loops.md
+++ b/etc/doc/tutorial/fr/09.2-Live-Loops.md
@@ -1,4 +1,4 @@
-9.2 Boucles en "live"
+9.2 Boucles en 'live'
 
 # Boucles en "live"
 

--- a/etc/doc/tutorial/fr/09.3-Multiple-Live-Loops.md
+++ b/etc/doc/tutorial/fr/09.3-Multiple-Live-Loops.md
@@ -1,4 +1,4 @@
-9.3 Boucles multiples en "live"
+9.3 Boucles multiples en 'live'
 
 # Boucles multiples en "live"
 


### PR DESCRIPTION
This is a simple, dirty fix which allows sonic-pi to build for the present time.  A full fix allowing double quotes might be reasonable, but as sonic-pi will not currently build for a Linux machine(at least with my system configuration), this seems urgent. 