### PR TITLE
WIP: Transparent backgrounds for Log window and editor

### DIFF
--- a/app/gui/qt/mainwindow.cpp
+++ b/app/gui/qt/mainwindow.cpp
@@ -111,6 +111,11 @@ MainWindow::MainWindow(QApplication &app, bool i18n, QSplashScreen* splash)
   guiID = QUuid::createUuid().toString();
   loaded_workspaces = false;
   this->splash = splash;
+  this->setWindowFlags(Qt::Widget | Qt::FramelessWindowHint);
+  // this->setParent(0); // Create TopLevel-Widget
+  this->setAttribute(Qt::WA_NoSystemBackground, true);
+  this->setAttribute(Qt::WA_TranslucentBackground, true);  
+  // this->setAttribute(Qt::WA_PaintOnScreen); // not needed in Qt 5.2 and up
   protocol = UDP;
 
   if(protocol == TCP){
@@ -191,6 +196,8 @@ MainWindow::MainWindow(QApplication &app, bool i18n, QSplashScreen* splash)
 
   // Window layout
   tabs = new QTabWidget();
+  tabs->setAttribute(Qt::WA_TranslucentBackground);
+  tabs->setStyleSheet("QTabWidget{ background-color: transparent}");
   tabs->setTabsClosable(false);
   tabs->setMovable(false);
   tabs->setTabPosition(QTabWidget::South);

--- a/app/gui/qt/sonicpilog.cpp
+++ b/app/gui/qt/sonicpilog.cpp
@@ -6,6 +6,12 @@
 
 SonicPiLog::SonicPiLog(QWidget *parent) : QPlainTextEdit(parent)
 {
+  this->setWindowFlags(Qt::Widget | Qt::FramelessWindowHint);
+  //setParent(0); // Create TopLevel-Widget
+  this->setAttribute(Qt::WA_NoSystemBackground, true);
+  this->setStyleSheet("background-color: transparent");
+  this->setAttribute(Qt::WA_TranslucentBackground, true);
+  this->setAttribute(Qt::WA_PaintOnScreen); // not needed in Qt 5.2 and up
 }
 
 void SonicPiLog::setTextColor(QColor c)

--- a/app/gui/qt/sonicpiscintilla.cpp
+++ b/app/gui/qt/sonicpiscintilla.cpp
@@ -23,6 +23,7 @@ SonicPiScintilla::SonicPiScintilla(SonicPiLexer *lexer, SonicPiTheme *theme)
   : QsciScintilla()
 {
   this->theme = theme;
+  this->viewport()->setAttribute(Qt::WA_TranslucentBackground);
   standardCommands()->clearKeys();
   standardCommands()->clearAlternateKeys();
   QString skey;

--- a/app/gui/qt/sonicpitheme.cpp
+++ b/app/gui/qt/sonicpitheme.cpp
@@ -47,9 +47,9 @@ QMap<QString, QString> SonicPiTheme::lightTheme(){
     themeSettings["WindowBorder"]= "lightgray";
 
     themeSettings["Foreground"] = "#5e5e5e";
-    themeSettings["Background"] = "white";
+    themeSettings["Background"] = "transparent";
 
-    themeSettings["PaneBackground"] = "white";
+    themeSettings["PaneBackground"] = "transparent";
     themeSettings["DefaultForeground"]               = "#808080";
     themeSettings["CommentForeground"]               = "#5e5e5e";
     themeSettings["PODForeground"]                   = "#004000";
@@ -76,7 +76,7 @@ QMap<QString, QString> SonicPiTheme::lightTheme(){
     themeSettings["PercentStringrForeground"]        = "#000000";
     themeSettings["PercentStringwForeground"]        = "#000000";
 
-    themeSettings["DefaultBackground"]               = "white";
+    themeSettings["DefaultBackground"]               = "transparent";
     themeSettings["CommentBackground"]               = "white";
     themeSettings["ErrorBackground"]                 = "#fff";
     themeSettings["PODBackground"]                   = "#ff0000";
@@ -131,7 +131,7 @@ QMap<QString, QString> SonicPiTheme::darkTheme(){
     themeSettings["PaneBackground"] = "black";
     themeSettings["WindowBorder"]= "#222";
     themeSettings["Foreground"] = "white";
-    themeSettings["Background"] = "black";
+    themeSettings["Background"] = "transparent";
     themeSettings["ErrorBackground"] = "black";
 
     themeSettings["DefaultForeground"]               = "#fff";
@@ -160,7 +160,7 @@ QMap<QString, QString> SonicPiTheme::darkTheme(){
     themeSettings["PercentStringrForeground"]        = "#6e88ff";
     themeSettings["PercentStringwForeground"]        = "#6e88ff";
 
-    themeSettings["DefaultBackground"]               = "#000";
+    themeSettings["DefaultBackground"]               = "transparent";
     themeSettings["CommentBackground"]               = "white";
     themeSettings["ErrorBackground"]                 = "#c0xffc0";
     themeSettings["PODBackground"]                   = "#ff0000";


### PR DESCRIPTION
This is mostly the result of non-scientific Googling and random
copy-n-paste coding. At the moment I've only managed to make the log
window transparent and there are several issues around repainting new
lines. The black on the QScintilla/editor window is probably to do with
the underlying TabWidget. More investigation needed.

Sources as follows:
- http://stackoverflow.com/a/18317002/2618015
- https://forum.qt.io/topic/53911/qtabwidget-background-not-transparent/2
- http://forum.qt.io/topic/1090/solved-how-to-get-an-simple-transparent-window/2
- https://forum.qt.io/topic/17340/transparent-background/2

This is loosely related to @josephWilk's previous work on transparency
here:
https://github.com/josephwilk/sonic-pi/commit/aa4c55042c5ad890329a8114d3dccb52495942f2

Looks a bit like this

![Transparent log](https://cloud.githubusercontent.com/assets/369527/10614538/ca5691ba-7752-11e5-8dd4-fd620e61dd16.png)
