### PR TITLE
Remove string length hack during packing

### DIFF
--- a/app/server/sonicpi/lib/sonicpi/osc/oscencode.rb
+++ b/app/server/sonicpi/lib/sonicpi/osc/oscencode.rb
@@ -116,10 +116,10 @@ module SonicPi
         if cached = @string_cache[s]
           return cached
         else
-          # Forgive me father, for I have sinned...
           # This makes a null padded string rounded up to the nearest
           # multiple of four
-          res = [s].pack("Z#{4*((s.bytesize.to_f+0.01)/4).ceil}")
+          size = s.bytesize
+          res = [s].pack("Z#{size + 4 - (size % 4)}")
           if @num_cached_strings < @cache_size
             # only cache the first @cache_size strings to avoid a memory
             # memory leak.


### PR DESCRIPTION
Floating point operation is unnecessarily slow and is hacky in this
context. This version produces the same output for each size while
being faster.

Approach with caution. Although it should behave the same, I tested
only by `rake test`.

As for the speed of the calculation:
```ruby
sizes = (0...1000).map {|el| rand}
10000000.times { sizes << rand(10000) }

Benchmark.bm do |x|
  x.report("Bit manipulation") do
    sizes.each do |size|
      size + 4 - (size % 4)
    end
  end

  x.report("Floating point  ") do
    sizes.each do |size|
      4*((size.to_f+0.01)/4).ceil
    end
  end
end

#        user     system      total        real
# Bit manipulation  0.770000   0.000000   0.770000 (  0.779492)
# Floating point    1.750000   0.000000   1.750000 (  1.761073)
```