### PR TITLE
Interpolation over << in bundle encoding

### DIFF
--- a/app/server/sonicpi/lib/sonicpi/osc/oscencode.rb
+++ b/app/server/sonicpi/lib/sonicpi/osc/oscencode.rb
@@ -108,7 +108,7 @@ module SonicPi
       def encode_single_bundle(ts, address, args=[])
         message = encode_single_message(address, args)
         message_encoded = [message.size].pack(@literal_cap_n) << message
-        "" << @bundle_header << time_encoded(ts) << message_encoded
+        "#{@bundle_header}#{time_encoded(ts)}#{message_encoded}"
       end
 
       private


### PR DESCRIPTION
String interpolation is slightly faster than calling << three times.

Here's the benchmark for encode_single_bundle:
```
With <<
Calculating -------------------------------------
          osc-bundle    11.814k i/100ms
-------------------------------------------------
          osc-bundle    147.674k (± 9.2%) i/s -    732.468k

With interpolation
Calculating -------------------------------------
          osc-bundle    12.324k i/100ms
-------------------------------------------------
          osc-bundle    157.125k (± 2.3%) i/s -    788.736k
```

In some runs the difference is a lot closer, so it is in no means a significant improvement.