### PR TITLE
Small adjustment and typo in chp. 4

### DIFF
--- a/etc/doc/tutorial/de/04-Randomisation.md
+++ b/etc/doc/tutorial/de/04-Randomisation.md
@@ -69,7 +69,7 @@ end
 ## Zufällig abschneiden (random cutoff)
 
 Ein anderes spannendes Beispiel für die Randomisierung ist das 
-zufällige Abschneiden[^12] eines Synth-Klangs. Der `:tb303`-Emulator ist 
+zufällige Abschneiden hoher Töne[^12] eines Synth-Klangs. Der `:tb303`-Emulator ist 
 ein guter Synth, um das auszuprobieren:
 
 ```
@@ -224,8 +224,8 @@ Jetzt los, bring Deinen Code mit ein paar Zufälligkeiten durcheinander!
     innerhalb der Schleife steht, wird so oft wie angegeben oder
     unendlich oft wiederholt. 
 
-[^12]: In Sonic Pi wird das das Abschneiden oder Verkürzen mit dem
-    Ausdruck `cutoff` bezeichnet.
+[^12]: In Sonic Pi wird das Abschneiden oder Verkürzen hoher Töne
+    (Filtern) mit dem Ausdruck `cutoff` bezeichnet.
 
 [^13]: Das englische Wort *Seed* bedeutet im Deutschen *Keim* oder
     *Samen*; hier wird es als *Startpunkt* übersetzt. 


### PR DESCRIPTION
While working through the tutorial I misunderstood the term "zufälliges Abschneiden" and thought it will change the duration of a sample or note. However, the cutoff will, of course, cut off high frequency content. Because the tutorial is aimed at people getting started with electronic music (like me), I suggest adding "hoher Töne" to make it more obvious. The addition of "Filtern" in the footnote finally provides a keyword which will give a usable result in a (German) Wikipedia search.

And there were too many "das" in the footnote.