### PR TITLE
Added instructions for already exisiting newer qt versions on ubuntu

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -66,6 +66,15 @@ In addition, under Ubuntu 14.04 based distributions try these:
 * `libqt4-dev`
 * `libffi-dev`
 
+If you are using a newer version of QT, you need the according version of scintilla. For QT5 they are: 
+
+* `libqt5scintilla2-dev` instead of `libqscintilla2-dev`
+* `libqt5scintilla2-l10n` instead of `libqscintilla2-l10n`
+
+In addition, you need to tell sonic-pi to use these. In order to do so, navigate to `app/gui/qt/`
+and open `SonicPi.pro`with your text editor of choice.
+Replace `lqscintilla2`with `lqt5scintilla2` everywhere it is written.
+
 Fedora package dependency names:
 
 * `supercollider` (via [Planet CCRMA](http://ccrma.stanford.edu/planetccrma/software/installplanettwenty.html))


### PR DESCRIPTION
If one already has a newer version of QT (usually from other coding projects or work or ...), you need different libraries and need to make some changes to the SonicPi.pro file in order to install. I added instructions for that.