### PR TITLE
Fix tb303 and mono_player :cutoff_decay docs

### DIFF
--- a/app/server/sonicpi/lib/sonicpi/lang/sound.rb
+++ b/app/server/sonicpi/lib/sonicpi/lang/sound.rb
@@ -2462,7 +2462,7 @@ Check out the `use_sample_pack` and `use_sample_pack_as` fns for details on maki
                           :cutoff_decay_level   => "The level of cutoff after the decay phase as a MIDI note. Default value is `:cutoff_attack_level`.",
                           :cutoff_sustain_level => "The sustain cutoff (value of cutoff at sustain time) as a MIDI note. Default value is `:cutoff_decay_level`.",
                           :cutoff_attack        => "Attack time for cutoff filter. Amount of time (in beats) for sound to reach full cutoff value. Default value is set to match amp envelope's attack value.",
-                          :cutoff_decay         => "Decay time for cutoff filter. Amount of time (in beats) for sound to reach full cutoff value. Default value is set to match amp envelope's decay value.",
+                          :cutoff_decay         => "Decay time for cutoff filter. Amount of time (in beats) for sound to move from full cutoff value (cutoff attack level) to the cutoff sustain level. Default value is set to match amp envelope's decay value.",
                           :cutoff_sustain       =>  "Amount of time for cutoff value to remain at sustain level in beats. When -1 (the default) will auto-stretch.",
                           :cutoff_release       => "Amount of time (in beats) for sound to move from cutoff sustain value to cutoff min value. Default value is set to match amp envelope's release value.",
                           :cutoff_env_curve     => "Select the shape of the curve between levels in the cutoff envelope. 1=linear, 2=exponential, 3=sine, 4=welch, 6=squared, 7=cubed",

--- a/app/server/sonicpi/lib/sonicpi/synths/synthinfo.rb
+++ b/app/server/sonicpi/lib/sonicpi/synths/synthinfo.rb
@@ -1522,7 +1522,7 @@ module SonicPi
 
           :cutoff_decay =>
           {
-            :doc => "Decay time for cutoff filter. Amount of time (in beats) for sound to reach full cutoff value. Default value is set to match amp envelope's decay value.",
+            :doc => "Decay time for cutoff filter. Amount of time (in beats) for sound to move from full cutoff value (cutoff attack level) to the cutoff sustain level. Default value is set to match amp envelope's decay value.",
             :validations => [v_positive(:cutoff_decay)],
             :modulatable => false,
             :default => "decay",
@@ -2872,7 +2872,7 @@ module SonicPi
 
           :cutoff_decay =>
           {
-            :doc => "Decay time for cutoff filter. Amount of time (in beats) for sound to reach full cutoff value. Default value is set to match amp envelope's decay value.",
+            :doc => "Decay time for cutoff filter. Amount of time (in beats) for sound to move from full cutoff value (cutoff attack level) to the cutoff sustain level. Default value is set to match amp envelope's decay value.",
             :validations => [v_positive(:cutoff_decay)],
             :modulatable => false,
             :default => "decay"


### PR DESCRIPTION
Previously, both the :cutoff_decay and :cutoff_attack docstrings for these
synths said they referred to the Amount of time (in beats) for sound to reach
full cutoff value. This change corrects this by changing :cutoff_decay to refer
to the amount of time for sound to move from full cutoff value (cutoff attack
level) to the cutoff sustain level.

(I'm happy to close this PR if the docs change isn't quite right still, but hopefully the new descriptions are ok)