### PR TITLE
Server - fixed an error when synths have :note_slide_shape option

### DIFF
--- a/app/server/sonicpi/lib/sonicpi/synths/synthinfo.rb
+++ b/app/server/sonicpi/lib/sonicpi/synths/synthinfo.rb
@@ -276,7 +276,7 @@ module SonicPi
           :note_slide_shape =>
           {
             :doc => "Shape of curve for note slide  0: step, 1: linear, 2: exponential, 3: sine, 4: welch, 5: custom (use *_curve opt), 6: squared, 7: cubed, 8: hold",
-            :validations => [v_one_of(:env_curve, [0, 1, 2, 3, 4, 6, 7, 8])],
+            :validations => [v_one_of(:note_slide_shape, [0, 1, 2, 3, 4, 6, 7, 8])],
             :modulatable => false
           },
 


### PR DESCRIPTION
When I run a code contains :note_slide_shape option (for example - https://github.com/kn1kn1/ccss2015/blob/master/SonicPi/chp.rb), I got the following error.

Runtime Error: [Workspace 8, line 104]
Thread death!
 Value of opt :note_slide_shape must be one of the following values: [0, 1, 2, 3, 4, 6, 7, 8], got 7.
/Applications/Sonic Pi2.8.app/app/server/sonicpi/lib/sonicpi/synths/synthinfo.rb:115:in `block (2 levels) in validate!'
/Applications/Sonic Pi2.8.app/app/server/sonicpi/lib/sonicpi/synths/synthinfo.rb:114:in `each'
/Applications/Sonic Pi2.8.app/app/server/sonicpi/lib/sonicpi/synths/synthinfo.rb:114:in `block in validate!'
/Applications/Sonic Pi2.8.app/app/server/sonicpi/lib/sonicpi/synths/synthinfo.rb:110:in `each'
/Applications/Sonic Pi2.8.app/app/server/sonicpi/lib/sonicpi/synths/synthinfo.rb:110:in `validate!'
/Applications/Sonic Pi2.8.app/app/server/sonicpi/lib/sonicpi/lang/sound.rb:3794:in `validate_if_necessary!'
/Applications/Sonic Pi2.8.app/app/server/sonicpi/lib/sonicpi/lang/sound.rb:3509:in `trigger_synth_with_resolved_args'
/Applications/Sonic Pi2.8.app/app/server/sonicpi/lib/sonicpi/lang/sound.rb:3503:in `trigger_synth'
/Applications/Sonic Pi2.8.app/app/server/sonicpi/lib/sonicpi/lang/sound.rb:3457:in `trigger_inst'
/Applications/Sonic Pi2.8.app/app/server/sonicpi/lib/sonicpi/lang/sound.rb:1053:in `play'
Workspace 8:104:in `block (2 levels) in __spider_eval'
Workspace 8:71:in `block (5 levels) in __spider_eval'
/Applications/Sonic Pi2.8.app/app/server/sonicpi/lib/sonicpi/lang/sound.rb:1626:in `call'
/Applications/Sonic Pi2.8.app/app/server/sonicpi/lib/sonicpi/lang/sound.rb:1626:in `block (2 levels) in with_fx'
/Applications/Sonic Pi2.8.app/app/server/sonicpi/lib/sonicpi/lang/sound.rb:1625:in `times'
/Applications/Sonic Pi2.8.app/app/server/sonicpi/lib/sonicpi/lang/sound.rb:1625:in `block in with_fx'
/Applications/Sonic Pi2.8.app/app/server/sonicpi/lib/sonicpi/lang/core.rb:2528:in `call'
/Applications/Sonic Pi2.8.app/app/server/sonicpi/lib/sonicpi/lang/core.rb:2528:in `block in in_thread'
