### PR TITLE
[i18n][ja] GUI - translated messages on balloon help, status bar and etc.

### DIFF
--- a/app/gui/qt/lang/sonic-pi_ja.ts
+++ b/app/gui/qt/lang/sonic-pi_ja.ts
@@ -94,7 +94,7 @@ time the run button is pressed.</source>
     <message>
         <location filename="../mainwindow.cpp" line="924"/>
         <source>Toggle line number visibility.</source>
-        <translation type="unfinished"></translation>
+        <translation>行番号の表示を切り替えます。</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="936"/>

--- a/app/gui/qt/lang/sonic-pi_ja.ts
+++ b/app/gui/qt/lang/sonic-pi_ja.ts
@@ -293,7 +293,9 @@ However, they will not be visible in the logs.</source>
         <location filename="../mainwindow.cpp" line="886"/>
         <source>Toggle automatic update checking.
 This check involves sending anonymous information about your platform and version.</source>
-        <translation type="unfinished"></translation>
+        <translation>Sonic Piが起動時に新しい更新をチェックするかを設定します。
+チェック処理は、Sonic Piサーバーへ匿名情報を
+送信することを含むことに注意してください。</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="887"/>
@@ -311,12 +313,12 @@ This check involves sending anonymous information about your platform and versio
     <message>
         <location filename="../mainwindow.cpp" line="889"/>
         <source>Get update</source>
-        <translation type="unfinished"></translation>
+        <translation>アップデートを取得</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="890"/>
         <source>Visit http://sonic-pi.net to download new version</source>
-        <translation>http://sonic-pi.net で新しいバージョンをダウンロードしてください</translation>
+        <translation>新しいバージョンの取得のため、http://sonic-pi.net を表示します</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="895"/>
@@ -433,22 +435,22 @@ Dark mode is perfect for live coding in night clubs.</source>
     <message>
         <location filename="../mainwindow.cpp" line="1181"/>
         <source>Save Current Buffer</source>
-        <translation type="unfinished"></translation>
+        <translation>現在のbufferを保存</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="1291"/>
         <source>Zooming In...</source>
-        <translation type="unfinished"></translation>
+        <translation>ズームイン...</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="1298"/>
         <source>Zooming Out...</source>
-        <translation type="unfinished"></translation>
+        <translation>ズームアウト...</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="1332"/>
         <source>Checking for updates...</source>
-        <translation type="unfinished"></translation>
+        <translation>アップデートを確認しています...</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="1340"/>
@@ -635,17 +637,17 @@ Sonic Pi %1 を取得</translation>
     <message>
         <location filename="../mainwindow.cpp" line="1087"/>
         <source>Server boot error...</source>
-        <translation type="unfinished"></translation>
+        <translation>サーバー起動エラー...</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="1087"/>
         <source>Apologies, a critical error occurred during startup</source>
-        <translation type="unfinished"></translation>
+        <translation>申し訳ありません。起動中に重大なエラーが発生しました。</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="1087"/>
         <source>Please consider reporting a bug at</source>
-        <translation type="unfinished"></translation>
+        <translation>バグの報告をご検討ください。報告先: </translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="1921"/>

--- a/app/gui/qt/lang/sonic-pi_ja.ts
+++ b/app/gui/qt/lang/sonic-pi_ja.ts
@@ -371,7 +371,7 @@ This check involves sending anonymous information about your platform and versio
     <message>
         <location filename="../mainwindow.cpp" line="926"/>
         <source>Toggle visibility of the log.</source>
-        <translation>ログの表示を切り替えます</translation>
+        <translation>ログの表示を切り替えます。</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="928"/>
@@ -381,7 +381,7 @@ This check involves sending anonymous information about your platform and versio
     <message>
         <location filename="../mainwindow.cpp" line="929"/>
         <source>Toggle visibility of the control buttons.</source>
-        <translation>コントロールボタンの表示を切り替えます</translation>
+        <translation>コントロールボタンの表示を切り替えます。</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="931"/>
@@ -571,7 +571,7 @@ every two weeks.</source>
     <message>
         <location filename="../mainwindow.cpp" line="2418"/>
         <source>Version %2 is now available!</source>
-        <translation>バージョン %2 が利用可能です</translation>
+        <translation>バージョン %2 が利用可能です!</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="2422"/>
@@ -603,7 +603,7 @@ Sonic Pi %1 を取得</translation>
     <message>
         <location filename="../mainwindow.cpp" line="1911"/>
         <source>Save As...</source>
-        <translation>名前を付けて保存</translation>
+        <translation>名前を付けて保存...</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="1915"/>

--- a/app/gui/qt/lang/sonic-pi_ja.ts
+++ b/app/gui/qt/lang/sonic-pi_ja.ts
@@ -413,7 +413,8 @@ This check involves sending anonymous information about your platform and versio
         <location filename="../mainwindow.cpp" line="937"/>
         <source>
 Dark mode is perfect for live coding in night clubs.</source>
-        <translation>ダークモードは、クラブでのライブコーディングに最適です。</translation>
+        <translation>
+ダークモードは、クラブでのライブコーディングに最適です。</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="976"/>

--- a/app/gui/qt/lang/sonic-pi_ja.ts
+++ b/app/gui/qt/lang/sonic-pi_ja.ts
@@ -31,7 +31,9 @@
         <source>Toggle stereo inversion.
 If enabled, audio sent to the left speaker will
 be routed to the right speaker and visa versa.</source>
-        <translation type="unfinished"></translation>
+        <translation>ステレオ反転を切り替えます。
+有効にすると、左スピーカーに送った音が
+右のスピーカーに送られ、逆もまた同様です。</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="812"/>
@@ -40,7 +42,11 @@ If enabled both right and left audio is mixed and
 the same signal is sent to both speakers.
 Useful when working with external systems that
 can only handle mono.</source>
-        <translation type="unfinished"></translation>
+        <translation>モノラルモードを切り替えます。
+有効にすると、左右の音がミックスされ
+左右同じ音が両方のスピーカーに送られます。
+外部システムがモノラルしか扱えない場合に
+有用です。</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="828"/>
@@ -65,14 +71,16 @@ can only handle mono.</source>
     <message>
         <location filename="../mainwindow.cpp" line="853"/>
         <source>Configure debug behaviour</source>
-        <translation type="unfinished"></translation>
+        <translation>デバッグ時の振る舞いを設定します</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="856"/>
         <source>Toggle log messages.
 If disabled, activity such as synth and sample
 triggering will not be printed to the log by default.</source>
-        <translation type="unfinished"></translation>
+        <translation>ログメッセージを切り替えます。
+無効にすると、シンセやサンプルの実行のログが
+デフォルトで出力されなくなります。</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="815"/>
@@ -89,7 +97,9 @@ triggering will not be printed to the log by default.</source>
         <source>Toggle log clearing on run.
 If enabled, the log is cleared each
 time the run button is pressed.</source>
-        <translation type="unfinished"></translation>
+        <translation>実行時のログクリアを切り替えます。
+有効にすると、実行ボタンを押下する度に
+ログがクリアされます。</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="924"/>
@@ -246,7 +256,10 @@ For example, if you have headphones connected to your Raspberry Pi, choose &apos
         <source>Toggle synth argument checking functions.
 If disabled, certain synth opt values may
 create unexpectedly loud or uncomfortable sounds.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">シンセの引数をチェックする機能を切り替えます。
+無効にした場合、特定のシンセのオプションの値により
+予期せず大きな音が出たり、不快な音が出たりするかもしれません。
+</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="852"/>
@@ -268,7 +281,9 @@ create unexpectedly loud or uncomfortable sounds.</source>
         <source>Enable or disable logging of cues.
 If disabled, cues will still trigger.
 However, they will not be visible in the logs.</source>
-        <translation type="unfinished"></translation>
+        <translation>cueのログを有効／無効にします。
+無効にした場合にも、cueは実行されますが、
+ログには出力されません。</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="871"/>

--- a/app/gui/qt/lang/sonic-pi_ja.ts
+++ b/app/gui/qt/lang/sonic-pi_ja.ts
@@ -256,7 +256,7 @@ For example, if you have headphones connected to your Raspberry Pi, choose &apos
         <source>Toggle synth argument checking functions.
 If disabled, certain synth opt values may
 create unexpectedly loud or uncomfortable sounds.</source>
-        <translation type="unfinished">シンセの引数をチェックする機能を切り替えます。
+        <translation>シンセの引数をチェックする機能を切り替えます。
 無効にした場合、特定のシンセのオプションの値により
 予期せず大きな音が出たり、不快な音が出たりするかもしれません。</translation>
     </message>
@@ -524,7 +524,7 @@ Dark mode is perfect for live coding in night clubs.</source>
     <message>
         <location filename="../mainwindow.cpp" line="1912"/>
         <source>Save current buffer as an external file</source>
-        <translation type="unfinished">現在のbufferをファイルに保存</translation>
+        <translation>現在のbufferをファイルに保存</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="1930"/>

--- a/app/gui/qt/lang/sonic-pi_ja.ts
+++ b/app/gui/qt/lang/sonic-pi_ja.ts
@@ -219,7 +219,7 @@ For example, if you have headphones connected to your Raspberry Pi, choose &apos
     <message>
         <location filename="../mainwindow.cpp" line="153"/>
         <source>Sonic Pi update info</source>
-        <translation type="unfinished"></translation>
+        <translation>Sonic Pi アップデート情報</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="634"/>
@@ -284,13 +284,15 @@ This check involves sending anonymous information about your platform and versio
     <message>
         <location filename="../mainwindow.cpp" line="887"/>
         <source>Check now</source>
-        <translation type="unfinished"></translation>
+        <translation>今すぐチェック</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="888"/>
         <source>Force a check for updates now.
 This check involves sending anonymous information about your platform and version.</source>
-        <translation type="unfinished"></translation>
+        <translation>強制的にアップデートをチェックします。
+チェック処理は、Sonic Piサーバーへ匿名情報を
+送信することを含むことに注意してください。</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="889"/>
@@ -300,7 +302,7 @@ This check involves sending anonymous information about your platform and versio
     <message>
         <location filename="../mainwindow.cpp" line="890"/>
         <source>Visit http://sonic-pi.net to download new version</source>
-        <translation type="unfinished"></translation>
+        <translation>http://sonic-pi.net で新しいバージョンをダウンロードしてください</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="895"/>
@@ -537,29 +539,31 @@ Dark mode is perfect for live coding in night clubs.</source>
     <message>
         <location filename="../mainwindow.cpp" line="2413"/>
         <source>Last checked %1</source>
-        <translation type="unfinished"></translation>
+        <translation>前回のチェック日時: %1</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="2415"/>
         <source>Sonic Pi checks for updates
 every two weeks.</source>
-        <translation type="unfinished"></translation>
+        <translation>アップデートのチェックは
+2週間毎に行われます。</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="2417"/>
         <source>This is Sonic Pi %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Sonic Pi %1</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="2418"/>
         <source>Version %2 is now available!</source>
-        <translation type="unfinished"></translation>
+        <translation>バージョン %2 が利用可能です</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="2422"/>
         <source>New version available!
 Get Sonic Pi %1</source>
-        <translation type="unfinished"></translation>
+        <translation>新しいバージョンがあります!
+Sonic Pi %1 を取得</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="1902"/>

--- a/app/gui/qt/lang/sonic-pi_ja.ts
+++ b/app/gui/qt/lang/sonic-pi_ja.ts
@@ -258,8 +258,7 @@ If disabled, certain synth opt values may
 create unexpectedly loud or uncomfortable sounds.</source>
         <translation type="unfinished">シンセの引数をチェックする機能を切り替えます。
 無効にした場合、特定のシンセのオプションの値により
-予期せず大きな音が出たり、不快な音が出たりするかもしれません。
-</translation>
+予期せず大きな音が出たり、不快な音が出たりするかもしれません。</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="852"/>

--- a/app/gui/qt/lang/sonic-pi_ja.ts
+++ b/app/gui/qt/lang/sonic-pi_ja.ts
@@ -273,7 +273,7 @@ However, they will not be visible in the logs.</source>
     <message>
         <location filename="../mainwindow.cpp" line="871"/>
         <source>Transparency</source>
-        <translation type="unfinished"></translation>
+        <translation>透過</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="886"/>

--- a/app/gui/qt/lang/sonic-pi_ja.ts
+++ b/app/gui/qt/lang/sonic-pi_ja.ts
@@ -630,7 +630,7 @@ Sonic Pi %1 を取得</translation>
     <message>
         <location filename="../mainwindow.cpp" line="992"/>
         <source>Settings useful for performing with Sonic Pi</source>
-        <translation type="unfinished"></translation>
+        <translation>Sonic Piでパフォーマンスする際に有用な設定です</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="1087"/>

--- a/app/gui/qt/lang/sonic-pi_ja.ts
+++ b/app/gui/qt/lang/sonic-pi_ja.ts
@@ -317,7 +317,7 @@ This check involves sending anonymous information about your platform and versio
     <message>
         <location filename="../mainwindow.cpp" line="915"/>
         <source>Configure editor display options.</source>
-        <translation type="unfinished"></translation>
+        <translation>エディタの表示オプションを設定します。</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="916"/>
@@ -327,7 +327,7 @@ This check involves sending anonymous information about your platform and versio
     <message>
         <location filename="../mainwindow.cpp" line="917"/>
         <source>Configure editor look and feel.</source>
-        <translation type="unfinished"></translation>
+        <translation>エディタのルック・アンド・フィールを設定します。</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="918"/>
@@ -337,7 +337,7 @@ This check involves sending anonymous information about your platform and versio
     <message>
         <location filename="../mainwindow.cpp" line="919"/>
         <source>Configure automation features.</source>
-        <translation type="unfinished"></translation>
+        <translation>自動化機能を設定します。</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="920"/>
@@ -347,7 +347,7 @@ This check involves sending anonymous information about your platform and versio
     <message>
         <location filename="../mainwindow.cpp" line="921"/>
         <source>Automatically align code on Run</source>
-        <translation type="unfinished"></translation>
+        <translation>実行時に自動的にコードを整形します</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="925"/>
@@ -357,7 +357,7 @@ This check involves sending anonymous information about your platform and versio
     <message>
         <location filename="../mainwindow.cpp" line="926"/>
         <source>Toggle visibility of the log.</source>
-        <translation type="unfinished"></translation>
+        <translation>ログの表示を切り替えます</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="928"/>
@@ -367,7 +367,7 @@ This check involves sending anonymous information about your platform and versio
     <message>
         <location filename="../mainwindow.cpp" line="929"/>
         <source>Toggle visibility of the control buttons.</source>
-        <translation type="unfinished"></translation>
+        <translation>コントロールボタンの表示を切り替えます</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="931"/>
@@ -377,7 +377,7 @@ This check involves sending anonymous information about your platform and versio
     <message>
         <location filename="../mainwindow.cpp" line="933"/>
         <source>Toggle visibility of the buffer selection tabs.</source>
-        <translation type="unfinished"></translation>
+        <translation>buffer選択タブの表示を切り替えます。</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="934"/>
@@ -387,18 +387,18 @@ This check involves sending anonymous information about your platform and versio
     <message>
         <location filename="../mainwindow.cpp" line="935"/>
         <source>Toggle full screen mode.</source>
-        <translation type="unfinished"></translation>
+        <translation>フルスクリーンモードを切り替えます。</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="937"/>
         <source>Toggle dark mode.</source>
-        <translation type="unfinished"></translation>
+        <translation>ダークモードを切り替えます。</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="937"/>
         <source>
 Dark mode is perfect for live coding in night clubs.</source>
-        <translation type="unfinished"></translation>
+        <translation>ダークモードは、クラブでのライブコーディングに最適です。</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="976"/>

--- a/app/gui/qt/lang/sonic-pi_ja.ts
+++ b/app/gui/qt/lang/sonic-pi_ja.ts
@@ -756,7 +756,7 @@ Get Sonic Pi %1</source>
     <message>
         <location filename="../ruby_help.h" line="446"/>
         <source>Fx</source>
-        <translation>エフェクト</translation>
+        <translation>効果</translation>
     </message>
     <message>
         <location filename="../ruby_help.h" line="463"/>


### PR DESCRIPTION
GUI Translation into Japanese is almost completed.

Updating '/home/kn1kn1/sonic-pi/app/gui/qt/lang/sonic-pi_ja.qm'...
    Generated 141 translation(s) (141 finished and 0 unfinished)
    Ignored 1 untranslated source text(s)

Please see change log for details.