### PR TITLE
make sure to call the system ruby, not a locally installed by the user

### DIFF
--- a/app/gui/qt/mainwindow.cpp
+++ b/app/gui/qt/mainwindow.cpp
@@ -685,7 +685,7 @@ void MainWindow::startServer(){
     QFile file(prg_path);
     if(!file.exists()) {
       // use system ruby if bundled ruby doesn't exist
-      prg_path = "ruby";
+      prg_path = "/usr/bin/ruby";
     }
 
     QString prg_arg = root + "/app/server/bin/sonic-pi-server.rb";


### PR DESCRIPTION
It can happen that a user has compiled an own ruby binary in the home directory.
This avoids calling the user's local version.