### PR TITLE
Remove strange chars from ring chain tutorial

### DIFF
--- a/etc/doc/tutorial/en/08.5-Ring-Chains.md
+++ b/etc/doc/tutorial/en/08.5-Ring-Chains.md
@@ -29,6 +29,7 @@ Finally, what if we wanted to shuffle the ring?
 
 ```
 (ring 10, 20, 30, 40, 50).shuffle  #=> (ring 40, 30, 10, 50, 20)
+```
 
 ## Multiple Chains
 


### PR DESCRIPTION
I noticed that in the tutorial section on ring chains, some strange tilde chars
were turning up in one of the examples, as follows:
'Finally, what if we wanted to shuffle the ring?
~~~~ (ring 10, 20, 30, 40, 50).shuffle  #=> (ring 40, 30, 10, 50, 20)'

This was due to the example not having a set of backticks closing it off in the
markdown file, which has been added in this update, removing the strange tilde
chars.