### PR TITLE
Add breakbeat to loop sample list

### DIFF
--- a/app/server/sonicpi/lib/sonicpi/synths/synthinfo.rb
+++ b/app/server/sonicpi/lib/sonicpi/synths/synthinfo.rb
@@ -5793,7 +5793,8 @@ Use FX `:band_eq` with a negative db for the opposite effect - to attenuate a gi
             :loop_amen,
             :loop_amen_full,
             :loop_garzul,
-            :loop_mika]}}
+            :loop_mika,
+            :loop_breakbeat]}}
 
       @@all_samples = (@@grouped_samples.values.reduce([]) {|s, el| s << el[:samples]}).flatten
 


### PR DESCRIPTION
I was looking at the help documentation just now, specifically the 'sounds for
looping' section of the samples tab. When I started typing in the editor to
reference one of the loop samples, I noticed that the sample :loop_breakbeat
was in the auto-complete list but not in the documentation.
I realised also that this meant that the breakbeat loop sample was not being
shown as part of the output of the 'sample_names' and 'all_sample_names' fns.

This update adds the breakbeat sample to the list of sample metadata, in order
to make it visible in the documentation and the sample name fns.