### PR TITLE
use ruby API version number instead of the runtime/patchlevel

### DIFF
--- a/app/server/bin/compile-extensions.rb
+++ b/app/server/bin/compile-extensions.rb
@@ -14,6 +14,8 @@
 
 require 'fileutils'
 
+require 'rbconfig'
+ruby_api = RbConfig::CONFIG['ruby_version']
 os = case RUBY_PLATFORM
      when /.*arm.*-linux.*/
        :raspberry
@@ -27,7 +29,7 @@ os = case RUBY_PLATFORM
        RUBY_PLATFORM
      end
 
-native_dir = File.dirname(__FILE__) + '/../rb-native/' + os.to_s + '/' + "#{RUBY_VERSION}p#{RUBY_PATCHLEVEL}"
+native_dir = File.dirname(__FILE__) + "/../rb-native/#{os}/#{ruby_api}"
 puts "Clearing #{native_dir}"
 FileUtils.rm_rf native_dir
 puts "Creating #{native_dir}"

--- a/app/server/core.rb
+++ b/app/server/core.rb
@@ -17,6 +17,8 @@ raise "Sonic Pi requires Ruby 1.9.3+ to be installed. You are using version #{RU
 ## This core file sets up the load path and applies any necessary monkeypatches.
 
 ## Ensure native lib dir is available
+require 'rbconfig'
+ruby_api = RbConfig::CONFIG['ruby_version']
 os = case RUBY_PLATFORM
      when /.*arm.*-linux.*/
        :raspberry
@@ -29,7 +31,7 @@ os = case RUBY_PLATFORM
      else
        RUBY_PLATFORM
      end
-$:.unshift "#{File.expand_path("../rb-native", __FILE__)}/#{os}/#{RUBY_VERSION}p#{RUBY_PATCHLEVEL}/"
+$:.unshift "#{File.expand_path("../rb-native", __FILE__)}/#{os}/#{ruby_api}/"
 
 ## Ensure all libs in vendor directory are available
 Dir["#{File.expand_path("../vendor", __FILE__)}/*/lib/"].each do |vendor_lib|

--- a/app/server/vendor/atomic/lib/atomic/ruby.rb
+++ b/app/server/vendor/atomic/lib/atomic/ruby.rb
@@ -12,6 +12,8 @@
 begin
   require 'atomic_reference'
 rescue LoadError
+  require 'rbconfig'
+  ruby_api = RbConfig::CONFIG['ruby_version']
   os = case RUBY_PLATFORM
        when /.*arm.*-linux.*/
          :raspberry
@@ -24,7 +26,7 @@ rescue LoadError
        else
          RUBY_PLATFORM
        end
-  require_relative "../../../../rb-native/#{os}/#{RUBY_VERSION}p#{RUBY_PATCHLEVEL}/atomic_reference"
+  require_relative "../../../../rb-native/#{os}/#{ruby_api}/atomic_reference"
 
 end
 

--- a/app/server/vendor/ruby-prof-0.15.8/lib/ruby-prof.rb
+++ b/app/server/vendor/ruby-prof-0.15.8/lib/ruby-prof.rb
@@ -12,6 +12,8 @@ rescue LoadError
     require "ruby_prof"
   rescue LoadError
     # Modifications made for Sonic Pi multi-platform compatibility:
+    require 'rbconfig'
+    ruby_api = RbConfig::CONFIG['ruby_version']
     os = case RUBY_PLATFORM
          when /.*arm.*-linux.*/
            :raspberry
@@ -24,7 +26,7 @@ rescue LoadError
          else
            RUBY_PLATFORM
          end
-    require_relative "../../../rb-native/#{os}/#{RUBY_VERSION}p#{RUBY_PATCHLEVEL}/ruby_prof"
+    require_relative "../../../rb-native/#{os}/#{ruby_api}/ruby_prof"
   end
   # End modifications
 

--- a/app/server/vendor/rugged/lib/rugged.rb
+++ b/app/server/vendor/rugged/lib/rugged.rb
@@ -10,6 +10,8 @@ rescue LoadError
   rescue LoadError
 
     # Modifications made for Sonic Pi multi-platform compatibility:
+    require 'rbconfig'
+    ruby_api = RbConfig::CONFIG['ruby_version']
     os = case RUBY_PLATFORM
          when /.*arm.*-linux.*/
            :raspberry
@@ -22,7 +24,7 @@ rescue LoadError
          else
            RUBY_PLATFORM
          end
-    require_relative "../../../rb-native/#{os}/#{RUBY_VERSION}p#{RUBY_PATCHLEVEL}/rugged"
+    require_relative "../../../rb-native/#{os}/#{ruby_api}/rugged"
   end
   # End modifications
 end


### PR DESCRIPTION
Currently, Sonic Pi uses the ruby runtime version/patchlevel version numbers to locate the compiled locally installed vendor libraries.

This is problematic when using the system's installed ruby interpreter, as done on Linux _(including Raspberry Pi!)_, because it breaks Sonic Pi when the distributor chooses to update the ruby binary to a more recent patchlevel.

However, the ruby API version number doesn't change within major ruby releases. A dynamic library compiled against ruby API 2.1.0 will work with ruby 2.1.4, 2.1.5 patchlevel 12, 2.1.5 patchlevel 272 and so on. No need to recompile rugged.so.

So this patch helps avoid breaking Sonic Pi just because the system ruby interpreter got a minor update by the distributor.