### PR TITLE
Fix runtime error due to incorrect validations

### DIFF
--- a/app/server/sonicpi/lib/sonicpi/synths/synthinfo.rb
+++ b/app/server/sonicpi/lib/sonicpi/synths/synthinfo.rb
@@ -1815,12 +1815,12 @@ module SonicPi
 
           :hard => {
             :doc => "Hardness of keypress. ",
-           :validations => [v_between_inclusive(:vel, 0, 1)],
+           :validations => [v_between_inclusive(:hard, 0, 1)],
             :modulatable => false},
 
           :stereo_width => {
             :doc => "Width of the stereo effect (which makes low notes sound towards the left, high notes towards the right). 0 to 1.",
-            :validations => [v_between_inclusive(:vel, 0, 1)],
+            :validations => [v_between_inclusive(:stereo_width, 0, 1)],
             :modulatable => false},
 
           :attack =>


### PR DESCRIPTION
Previously, it looks like the 'hard' and 'stereo_width' opts of the piano synth
were being validated against the 'vel' opt instead.
This may have been what was causing a run time error as reported here:
https://groups.google.com/forum/#!msg/sonic-pi/X3IuAdR4slE/XUmZLOjkCgAJ
when trying to use the stereo_width opt.
This update changes the validations to refer to the correct symbols. After changing them the runtime error disappears.