### PR TITLE
Add install target for non-windows platforms.

### DIFF
--- a/app/gui/qt/SonicPi.pro
+++ b/app/gui/qt/SonicPi.pro
@@ -109,6 +109,15 @@ RC_FILE = SonicPi.rc
 ICON = images/app.icns
 LIBS         += -lqscintilla2
 
+!win32 {
+	QMAKE_COPY = install --preserve-timestamps
+	QMAKE_STRIP = echo # Leave strip decision to package system
+
+	target.files = sonic-pi
+	target.path = /usr/bin
+	INSTALLS += target
+}
+
 win32 {
 	install_qsci.files = $$[QT_INSTALL_LIBS]\qscintilla2.dll
 	install_qsci.path = release


### PR DESCRIPTION
This patch make it easier to make a Debian package of sonic-pi.  I am a bit unsure what other files
need to be installed for the program to work, and would like to get some help there.