### PR TITLE
Fix panslicer fx pan_max opt validation

### DIFF
--- a/app/server/sonicpi/lib/sonicpi/synths/synthinfo.rb
+++ b/app/server/sonicpi/lib/sonicpi/synths/synthinfo.rb
@@ -4317,7 +4317,7 @@ module SonicPi
           :pan_max =>
           {
             :doc => "Maximum pan value (+1 is the right speaker only)",
-            :validations => [v_between_inclusive(:pan_min, -1, 1)],
+            :validations => [v_between_inclusive(:pan_max, -1, 1)],
             :modulatable => true
           },
 


### PR DESCRIPTION
Attempting to play with the panslicer just now, I discovered that previously, the validation for the pan_max opt of the panslicer fx had been trying to reference the pan_min opt - causing a runtime error. This update changes the validation to point to the correct symbol. After changing it, the run-time error disappeared.