### PR TITLE
Fix a bunch of typos and outdated docstrings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@
 
 ### New Fns
 
-* `block_duration` - returns the duration of the of the given block in seconds (not scaled with the BPM).
+* `block_duration` - returns the duration of the given block in seconds (not scaled with the BPM).
 * `block_slept?` - returns true if the contents of the block slept or synced.
 * `synth_names` - returns a list of all the available synths
 * `reset_mixer!` - resets the main mixer back to its default values.
@@ -95,7 +95,7 @@
 * Fix number of synth validation errors.
 * Fix sporadically failing boot issues on Windows
 * Add auto-reboot functionality for audio server. This now detects
-  errors in the server such as a killed or zombied process) and
+  errors in the server (such as a killed or zombied process) and
   automatically reboots it to enable Sonic Pi to continue without a full
   restart. Reboots automatically reload all loaded samples and
   synthdefs.

--- a/app/server/sonicpi/lib/sonicpi/studio.rb
+++ b/app/server/sonicpi/lib/sonicpi/studio.rb
@@ -25,7 +25,7 @@ module SonicPi
     attr_reader :synth_group, :fx_group, :mixer_group, :recording_group, :mixer_id, :mixer_bus, :mixer, :max_concurrent_synths, :rand_buf_id, :amp, :rebooting
 
     def initialize(hostname, port, msg_queue, max_concurrent_synths)
-      @hostnane = hostname
+      @hostname = hostname
       @port = port
       @msg_queue = msg_queue
       @max_concurrent_synths = max_concurrent_synths

--- a/app/server/sonicpi/lib/sonicpi/synths/synthinfo.rb
+++ b/app/server/sonicpi/lib/sonicpi/synths/synthinfo.rb
@@ -4925,7 +4925,7 @@ Use FX `:band_eq` with a negative db for the opposite effect - to attenuate a gi
       end
 
       def doc
-        "Like the Band Pass Filter but with a resonance (slight volume boost) around the target frequency. This can produce an interesting whistling effect, especially when used with smaller values for the res opt."
+        "Like the Band Pass Filter but with a resonance (slight volume boost) around the target frequency. This can produce an interesting whistling effect, especially when used with larger values for the res opt."
       end
     end
 
@@ -4963,7 +4963,7 @@ Use FX `:band_eq` with a negative db for the opposite effect - to attenuate a gi
       end
 
       def doc
-        "Like the Band Pass Filter but normalised, with a resonance (slight volume boost) around the target frequency. This can produce an interesting whistling effect, especially when used with smaller values for the res opt.
+        "Like the Band Pass Filter but normalised, with a resonance (slight volume boost) around the target frequency. This can produce an interesting whistling effect, especially when used with larger values for the res opt.
 
   The normaliser is useful here as some volume is lost when filtering the original signal."
       end
@@ -5041,7 +5041,7 @@ Use FX `:band_eq` with a negative db for the opposite effect - to attenuate a gi
       end
 
       def doc
-        "Dampens the parts of the signal that are lower than the cutoff point (typically the bass of the sound) and keeps the higher parts (typically the crunchy fizzy harmonic overtones). The resonant part of the resonant high pass filter emphasises/resonates the frequencies around the cutoff point. The amount of emphasis is controlled by the res param with a lower res resulting in greater resonance. High amounts of resonance (rq ~1) can create a whistling sound around the cutoff frequency.
+        "Dampens the parts of the signal that are lower than the cutoff point (typically the bass of the sound) and keeps the higher parts (typically the crunchy fizzy harmonic overtones). The resonant part of the resonant high pass filter emphasises/resonates the frequencies around the cutoff point. The amount of emphasis is controlled by the res opt with a higher res resulting in greater resonance. High amounts of resonance (rq ~1) can create a whistling sound around the cutoff frequency.
 
   Choose a lower cutoff to keep more of the bass/mid and a higher cutoff to make the sound more light and crispy."
       end

--- a/app/server/sonicpi/lib/sonicpi/synths/synthinfo.rb
+++ b/app/server/sonicpi/lib/sonicpi/synths/synthinfo.rb
@@ -5015,7 +5015,7 @@ Use FX `:band_eq` with a negative db for the opposite effect - to attenuate a gi
       end
 
       def doc
-        "Dampens the parts of the signal that are above than the cutoff point (typically the crunchy fizzy harmonic overtones) and keeps the lower parts (typically the bass/mid of the sound). behaviour, The resonant part of the resonant low pass filter emphasises/resonates the frequencies around the cutoff point. The amount of emphasis is controlled by the res param with a lower res resulting in greater resonance. High amounts of resonance (rq ~1) can create a whistling sound around the cutoff frequency.
+        "Dampens the parts of the signal that are higher than the cutoff point (typically the crunchy fizzy harmonic overtones) and keeps the lower parts (typically the bass/mid of the sound). The resonant part of the resonant low pass filter emphasises/resonates the frequencies around the cutoff point. The amount of emphasis is controlled by the res opt with a higher res resulting in greater resonance. High amounts of resonance (rq ~1) can create a whistling sound around the cutoff frequency.
 
   Choose a higher cutoff to keep more of the high frequences/treble of the sound and a lower cutoff to make the sound more dull and only keep the bass."
       end
@@ -5218,7 +5218,7 @@ Use FX `:band_eq` with a negative db for the opposite effect - to attenuate a gi
 
 
       def doc
-        "Dampens the parts of the signal that are above than the cutoff point (typically the crunchy fizzy harmonic overtones) and keeps the lower parts (typically the bass/mid of the sound). Choose a higher cutoff to keep more of the high frequences/treble of the sound and a lower cutoff to make the sound more dull and only keep the bass."
+        "Dampens the parts of the signal that are higher than the cutoff point (typically the crunchy fizzy harmonic overtones) and keeps the lower parts (typically the bass/mid of the sound). Choose a higher cutoff to keep more of the high frequences/treble of the sound and a lower cutoff to make the sound more dull and only keep the bass."
       end
 
 


### PR DESCRIPTION
This update does what it says - there were several typos in various files that are now corrected, and several docstrings that were not updated fully when the res: opt was inverted, that have also now been brought up to date.