### PR TITLE
Fix several fx class references

### DIFF
--- a/app/server/sonicpi/lib/sonicpi/synths/synthinfo.rb
+++ b/app/server/sonicpi/lib/sonicpi/synths/synthinfo.rb
@@ -5087,7 +5087,7 @@ Use FX `:band_eq` with a negative db for the opposite effect - to attenuate a gi
       end
     end
 
-    class FXNormRHPF < FXRLPF
+    class FXNormRHPF < FXRHPF
       def name
         "Normalised Resonant High Pass Filter"
       end
@@ -5309,7 +5309,7 @@ Use FX `:band_eq` with a negative db for the opposite effect - to attenuate a gi
       end
     end
 
-    class FXNormHPF < FXRLPF
+    class FXNormHPF < FXHPF
       def name
         "Normalised High Pass Filter"
       end


### PR DESCRIPTION
When several of the filter fx were added, they were set up to inherit from incorrect base classes. This update changes this so that they inherit from the correct classes.

(Also, are FXRLPF and FXRHPF meant to inherit from FXInfo? or inherit from FXLPF and FXHPF? I wasn't sure)