### PR TITLE
detect if installed in /usr/ and change to FHS directory scheme

### DIFF
--- a/app/gui/qt/mainwindow.cpp
+++ b/app/gui/qt/mainwindow.cpp
@@ -102,12 +102,31 @@ MainWindow::MainWindow(QApplication &app, bool i18n, QMainWindow* splash)
 MainWindow::MainWindow(QApplication &app, bool i18n, QSplashScreen* splash)
 #endif
 {
+  if (QCoreApplication::applicationDirPath().startsWith("/usr/bin")) {
+
+    // use FHS directory scheme:
+    // Sonic Pi is not running inside the user's home directory, but is
+    // installed in /usr/bin on Linux from a distribution's package
+    
+    ruby_path = "/usr/bin/ruby";
+    ruby_server_path = "/usr/lib/sonic-pi/server/bin/sonic-pi-server.rb";
+    sample_path = "/usr/share/sonic-pi/samples";
+    
+  } else {
+    
+    // do not use FHS directory scheme:
+    // Sonic Pi is running in user's home dir or installed on
+    // Win, OS-X or in non-FHS /opt directory scheme
+    
+    ruby_path = QDir::toNativeSeparators(rubyPath());
+    QString root_path = QDir::toNativeSeparators(rootPath());
+    ruby_server_path = QDir::toNativeSeparators(root_path + "/app/server/bin/sonic-pi-server.rb");
+    sample_path = QDir::toNativeSeparators(root_path + "/etc/samples");
+  
+  }
+  
   sp_user_path = QDir::toNativeSeparators(QDir::homePath() + "/.sonic-pi");
   log_path = QDir::toNativeSeparators(sp_user_path + "/log");
-  root_path = QDir::toNativeSeparators(rootPath());
-  sample_path = QDir::toNativeSeparators(root_path + "/etc/samples");
-  ruby_path = QDir::toNativeSeparators(rubyPath());
-  ruby_server_path = QDir::toNativeSeparators(root_path + "/app/server/bin/sonic-pi-server.rb");
 
   loaded_workspaces = false;
   is_recording = false;

--- a/app/gui/qt/mainwindow.h
+++ b/app/gui/qt/mainwindow.h
@@ -294,7 +294,7 @@ private:
     std::ofstream stdlog;
 
     SonicPiAPIs *autocomplete;
-    QString sample_path, log_path, sp_user_path, root_path, ruby_server_path, ruby_path;
+    QString sample_path, log_path, sp_user_path, ruby_server_path, ruby_path;
     QString defaultTextBrowserStyle;
 
     QString version;

--- a/app/server/core.rb
+++ b/app/server/core.rb
@@ -52,8 +52,13 @@ require 'wavefile'
 module SonicPi
   module Core
     module SPRand
+      # use FHS directory scheme:
+      # check if Sonic Pi's ruby server is not running inside the
+      # user's home directory, but is installed in /usr/lib/sonic-pi
+      # on Linux from a distribution's package
+      random_numbers_path = File.dirname(__FILE__).start_with?("/usr/lib/sonic-pi") ? "/usr/share/sonic-pi" : "../../../etc"
       # Read in same random numbers as server for random stream sync
-      @@random_numbers = ::WaveFile::Reader.new(File.expand_path("../../../etc/buffers/rand-stream.wav", __FILE__), ::WaveFile::Format.new(:mono, :float, 44100)).read(441000).samples.freeze
+      @@random_numbers = ::WaveFile::Reader.new(File.expand_path("#{random_numbers_path}/buffers/rand-stream.wav", __FILE__), ::WaveFile::Format.new(:mono, :float, 44100)).read(441000).samples.freeze
 
       def self.to_a
         @@random_numbers

--- a/app/server/sonicpi/lib/sonicpi/util.rb
+++ b/app/server/sonicpi/lib/sonicpi/util.rb
@@ -160,6 +160,14 @@ module SonicPi
       FileUtils.mkdir_p(d) unless File.exists?(d)
     end
 
+    def linux_fhs?
+      # use FHS directory scheme:
+      # check if Sonic Pi's ruby server is not running inside the
+      # user's home directory, but is installed in /usr/lib/sonic-pi
+      # on Linux from a distribution's package
+      File.dirname(__FILE__).start_with?("/usr/lib/sonic-pi")
+    end
+    
     def root_path
       File.absolute_path("#{File.dirname(__FILE__)}/../../../../../")
     end
@@ -169,11 +177,15 @@ module SonicPi
     end
 
     def snippets_path
-      File.absolute_path("#{etc_path}/snippets")
+      linux_fhs? ?
+        File.absolute_path("/usr/share/sonic-pi/snippets") :
+        File.absolute_path("#{etc_path}/snippets")
     end
 
     def doc_path
-      File.absolute_path("#{etc_path}/doc")
+      linux_fhs? ?
+        File.absolute_path("/usr/share/doc/sonic-pi") :
+        File.absolute_path("#{etc_path}/doc")
     end
 
     def cheatsheets_path
@@ -185,19 +197,27 @@ module SonicPi
     end
 
     def tmp_path
-      File.absolute_path("#{root_path}/tmp")
+      linux_fhs? ?
+        File.absolute_path("/tmp") :
+        File.absolute_path("#{root_path}/tmp")
     end
 
     def synthdef_path
-      File.absolute_path("#{etc_path}/synthdefs/compiled")
+      linux_fhs? ?
+        File.absolute_path("/usr/share/sonic-pi/synthdefs/compiled") :
+        File.absolute_path("#{etc_path}/synthdefs/compiled")
     end
 
     def samples_path
-      File.absolute_path("#{etc_path}/samples")
+      linux_fhs? ?
+        File.absolute_path("/usr/share/sonic-pi/samples") :
+        File.absolute_path("#{etc_path}/samples")
     end
 
     def buffers_path
-      File.absolute_path("#{etc_path}/buffers")
+      linux_fhs? ?
+        File.absolute_path("/usr/share/sonic-pi/buffers") :
+        File.absolute_path("#{etc_path}/buffers")
     end
 
     def app_path


### PR DESCRIPTION
Sonic Pi uses a directory layout that relies on it being installed in a Sonic Pi main dir. And then:

* `$MAINDIR/app/gui/qt/sonic-pi` the GUI binary
* `$MAINDIR/app/server/bin/sonic-pi-server.rb` the ruby server
* `$MAINDIR/app/server/vendor/` the vendor libs
* `$MAINDIR/etc/buffers/` the random sound file
* `$MAINDIR/etc/samples/` the sample pack
* `$MAINDIR/etc/synthdefs/compiled` the synthdefs for SC
etc.

On Raspberry Pi, the same directory structure is used by using `/opt` as an install target.

However, on Linux, packagers are expected to put things in `/usr` and follow the [FHS](https://wiki.debian.org/FilesystemHierarchyStandard), which leads me to choosing these locations:

* `/usr/bin/sonic-pi` the GUI binary
* `/usr/lib/sonic-pi/server/bin/sonic-pi-server.rb` the ruby server
* `/usr/lib/sonic-pi/server/vendor/` the vendor libs
* `/usr/share/sonic-pi/buffers/` the random sound file
* `/usr/share/sonic-pi/samples/` the sample pack
* `/usr/share/sonic-pi/synthdefs/compiled` the synthdefs for SC
etc.

This patch makes it possible to make Sonic Pi work with both directory schemes. The GUI and the ruby server will detect at runtime if they are installed in `/usr` and then change the expected directory locations of the Sonic Pi assets accordingly. If not running in `/usr`, e.g. during build, the original directory locations are being used.