### PR TITLE
Delete obsolete instructions for Qt5 Install

### DIFF
--- a/INSTALL-LINUX.md
+++ b/INSTALL-LINUX.md
@@ -21,10 +21,6 @@ If you are using a newer version of QT, you need the according version of scinti
 * `libqt5scintilla2-dev` instead of `libqscintilla2-dev`
 * `libqt5scintilla2-l10n` instead of `libqscintilla2-l10n`
 
-In addition, you need to tell sonic-pi to use these. In order to do so, navigate to `app/gui/qt/`
-and open `SonicPi.pro`with your text editor of choice.
-Replace `lqscintilla2`with `lqt5scintilla2` everywhere it is written.
-
 Fedora package dependency names:
 
 * `supercollider` (via [Planet CCRMA](http://ccrma.stanford.edu/planetccrma/software/installplanettwenty.html))


### PR DESCRIPTION
The hand edits for Qt5 versions of the QScintilla2 libraries aren't needed since the .pro file already checks the Qt version and links to the correct library.