### PR TITLE
Don't print rest notes if synth logging is off

### DIFF
--- a/app/server/sonicpi/lib/sonicpi/lang/sound.rb
+++ b/app/server/sonicpi/lib/sonicpi/lang/sound.rb
@@ -1236,7 +1236,9 @@ set_mixer_control! lpf: 30, lpf_slide: 16 # slide the global lpf to 30 over 16 b
         return nil unless should_trigger?(args_h)
 
         if rest? args_h
-          __delayed_message "synth #{synth_name.to_sym.inspect}, {note: :rest}"
+          unless Thread.current.thread_variable_get(:sonic_pi_mod_sound_synth_silent)
+            __delayed_message "synth #{synth_name.to_sym.inspect}, {note: :rest}"
+          end
           return nil
         end
 


### PR DESCRIPTION
Recently it was noticed that even if synth logging was turned off via the GUI's preferences, rest notes were still being printed to the log. This was most likely due to changes made in 4323434. A check has now been re-introduced to make sure rest notes are once again only printed to the log if the relevant TL variable is set to false.