### PR TITLE
Add basic tests for `sleep`

### DIFF
--- a/app/server/sonicpi/test/lang/core/test_sleep.rb
+++ b/app/server/sonicpi/test/lang/core/test_sleep.rb
@@ -1,0 +1,57 @@
+#--
+# This file is part of Sonic Pi: http://sonic-pi.net
+# Full project source: https://github.com/samaaron/sonic-pi
+# License: https://github.com/samaaron/sonic-pi/blob/master/LICENSE.md
+#
+# Copyright 2013, 2014, 2015 by Sam Aaron (http://sam.aaron.name).
+# All rights reserved.
+#
+# Permission is granted for use, copying, modification, and
+# distribution of modified versions of this work as long as this
+# notice is included.
+#++
+
+require_relative "../../setup_test"
+require_relative "../../../lib/sonicpi/lang/core"
+require_relative "../../../lib/sonicpi/runtime"
+require 'mocha/setup'
+
+module SonicPi
+
+  class SleepTester < Minitest::Test
+    include SonicPi::Lang::Core
+    include SonicPi::RuntimeMethods
+
+    def setup
+      Kernel.stubs(:sleep)
+
+      @mod_sound_studio = mock()
+      @mod_sound_studio.expects(:sched_ahead_time).at_least_once.returns(0.5)
+
+      @start_time = Time.now
+      Thread.current.thread_variable_set(:sonic_pi_spider_time, @start_time)
+      Thread.current.thread_variable_set(:sonic_pi_spider_start_time, @start_time)
+
+      SleepTester.any_instance.stubs(:__schedule_delayed_blocks_and_messages!).returns(true)
+
+      use_bpm 60
+    end
+
+    def test_basic_sleep
+      sleep 2
+      assert_equal(__current_local_run_time, 2.0)
+      sleep 1
+      assert_equal(__current_local_run_time, 3.0)
+    end
+
+    def test_bpm_scaled_sleep
+      use_bpm 120
+
+      sleep 2
+      assert_equal(__current_local_run_time, 1.0)
+      sleep 1
+      assert_equal(__current_local_run_time, 1.5)
+    end
+
+  end
+end


### PR DESCRIPTION
These were a result of trying to add features to sleep to do swing
rhythms. Whilst that feature didn't make it yet, the tests are useful to
have in case anyone else wants to extend the functionality of sleep in
future.