### PR TITLE
Update mac installation guide with required programs

### DIFF
--- a/INSTALL-MAC.md
+++ b/INSTALL-MAC.md
@@ -28,7 +28,23 @@
  - `ln -s /Applications/SuperCollider/SuperCollider.app/Contents/Resources/scsynth .`
 
 ## Compile Ruby Server extensions
+### Prerequisites
+In order to compile the ruby libraries successfully, make sure you have
+the following programs installed:
 
+* [cmake](https://cmake.org)
+* [pkg-config](https://www.freedesktop.org/wiki/Software/pkg-config/)
+
+If you want to check whether you have them installed already, you can do
+so by typing the following commands in your terminal:
+
+* `cmake` - If installed, it will show the usage of the program
+* `pkg-config` - If installed, it will show a message indicating that a 
+package name should be specified.
+
+Installation of both the programs can be done through Homebrew or MacPorts
+
+### Compiling
 Sonic Pi uses some ruby libraries which have native extensions. We need
 to compile these with the provided script:
 


### PR DESCRIPTION
When compiling the ruby files, you'll have to make sure that both cmake and pkg-config are installed on the system. If they are not, the 'rugged' package will not be installed. The error it throws is directly followed by the other warnings the compile-extensions.rb file throws, making it easy to be overlooked. Therefore an extra section was added with prerequisite programs so others will not run into the same issue.