### PR TITLE
Adding support to include flac within sample packs

### DIFF
--- a/app/server/sonicpi/lib/sonicpi/sample_loader.rb
+++ b/app/server/sonicpi/lib/sonicpi/sample_loader.rb
@@ -83,7 +83,7 @@ module SonicPi
     def consume_filt_or_source!(filt_or_source, idx, filters, dirs, candidates)
       case filt_or_source
       when Symbol
-        filters << /#{filt_or_source}\.(wav|aif|wave|aiff)/
+        filters << /#{filt_or_source}\.(wav|aif|wave|aiff|flac)/
       when Integer
         idx = filt_or_source
       when String

--- a/app/server/sonicpi/lib/sonicpi/sample_loader.rb
+++ b/app/server/sonicpi/lib/sonicpi/sample_loader.rb
@@ -76,7 +76,7 @@ module SonicPi
     end
 
     def ls_samples(path)
-      Dir.glob(path + "/*.{wav,aif,wave,aiff}")
+      Dir.glob(path + "/*.{wav,aif,wave,aiff,flac}")
     end
 
     private


### PR DESCRIPTION
This change enables FLAC filetype usage for use_sample_pack, use_sample_pack_as, with_sample_pack, and with_sample_pack_as .

FLAC based samples work fine when loaded directly -- for me, on Ubuntu, at least.  This might be platform dependent, but I strongly suspect it will work equally cross platform.