### PR TITLE
Revert "Merge pull request #999 from hzulla/qmake"

### DIFF
--- a/app/gui/qt/SonicPi.pro
+++ b/app/gui/qt/SonicPi.pro
@@ -39,7 +39,6 @@ unix:!macx {
     LIBS += -lqt5scintilla2
   }
   QMAKE_CXXFLAGS += -Wall -Werror -Wextra
-  RUBY_PATH = /usr/bin/ruby
 }
 
 # Mac OS X only
@@ -49,7 +48,6 @@ macx {
   QT += macextras
   DEFINES += DONT_USE_OSX_KEYS
   QMAKE_CXXFLAGS += -Wall -Werror -Wextra
-  RUBY_PATH = ../../server/native/osx/ruby/bin/ruby
 }
 
 # Windows only
@@ -57,22 +55,12 @@ win32 {
   LIBS += -lqscintilla2
   QMAKE_CXXFLAGS += /WX
   DEFINES += _CRT_SECURE_NO_WARNINGS _WINSOCK_DEPRECATED_NO_WARNINGS
-  RUBY_PATH = ..\..\server\native\windows\ruby\bin\ruby
 }
 
 CODECFORSRC = UTF-8
 CODECFORTR = UTF-8
 
 TEMPLATE = app
-
-sonicpidocs.name = Generate HTML files and ruby_help.h from markdown files
-sonicpidocs.commands = $${RUBY_PATH} ../../server/bin/qt-doc.rb -o ruby_help.h
-sonicpidocs.target = ruby_help.h
-sonicpidocs.depends = FORCE
-
-PRE_TARGETDEPS      += ruby_help.h
-QMAKE_CLEAN         += ruby_help.h
-QMAKE_EXTRA_TARGETS += sonicpidocs
 
 SOURCES += main.cpp \
            mainwindow.cpp \

--- a/app/gui/qt/mac-build-app
+++ b/app/gui/qt/mac-build-app
@@ -34,6 +34,10 @@ cd $(dirname $0)
 rm -rf build
 mkdir build
 
+# Generate automated docs
+cp -f ruby_help.tmpl ruby_help.h
+../../server/native/osx/ruby/bin/ruby ../../server/bin/qt-doc.rb -o ruby_help.h
+
 # Generate i18n files
 $LREL SonicPi.pro
 

--- a/app/gui/qt/rp-build-app
+++ b/app/gui/qt/rp-build-app
@@ -4,6 +4,8 @@ set -eux
 
 cd $(dirname $0)
 
+cp -f ruby_help.tmpl ruby_help.h
+../../server/bin/qt-doc.rb -o ruby_help.h
 lrelease SonicPi.pro
 qmake -o Makefile SonicPi.pro || qmake-qt4 -o Makefile SonicPi.pro
 set +x

--- a/app/gui/qt/ruby_help.tmpl
+++ b/app/gui/qt/ruby_help.tmpl
@@ -1,0 +1,16 @@
+//--
+// This file is part of Sonic Pi: http://sonic-pi.net
+// Full project source: https://github.com/samaaron/sonic-pi
+// License: https://github.com/samaaron/sonic-pi/blob/master/LICENSE.md
+//
+// Copyright 2013, 2014 by Sam Aaron (http://sam.aaron.name).
+// All rights reserved.
+//
+// Permission is granted for use, copying, modification, distribution,
+// and distribution of modified versions of this work as long as this
+// notice is included.
+//++
+
+// AUTO-GENERATED-DOCS
+// Do not manually add any code below this comment
+// otherwise it may be removed

--- a/app/gui/qt/win-build-app.bat
+++ b/app/gui/qt/win-build-app.bat
@@ -1,5 +1,10 @@
 cd %~dp0
 
+copy /Y ruby_help.tmpl ruby_help.h
+..\..\server\native\windows\ruby\bin\ruby ../../server/bin/qt-doc.rb -o ruby_help.h
+@IF ERRORLEVEL==9009 goto :noruby
+@IF ERRORLEVEL==1 goto :docfail
+
 lrelease SonicPi.pro
 @IF ERRORLEVEL==9009 goto :noqt
 

--- a/app/server/bin/qt-doc.rb
+++ b/app/server/bin/qt-doc.rb
@@ -259,19 +259,18 @@ SonicPi::Synths::SynthInfo.get_all.each do |k, v|
 end
 
 
+# update ruby_help.h
 if options[:output_name] then
    cpp = options[:output_name]
 else
    cpp = "#{qt_gui_path}/ruby_help.h"
 end
 
-new_content = [<<INCLUDEHEADER]
-// AUTO-GENERATED-DOCS
-// Do not manually add any code below this comment
-// otherwise it may be removed
-
-INCLUDEHEADER
-
+content = File.readlines(cpp)
+new_content = content.take_while { |line| !line.start_with?("// AUTO-GENERATED-DOCS")}
+new_content << "// AUTO-GENERATED-DOCS\n"
+new_content << "// Do not manually add any code below this comment\n"
+new_content << "// otherwise it may be removed\n"
 new_content << "\n"
 new_content << "void MainWindow::initDocsWindow() {\n"
 new_content += docs


### PR DESCRIPTION
This didn't work. This qrc files created by qt-doc.rb are needed prior to calling qmake and thus qt-doc cannot be called from within qmake. This breaks the whole concept of #999.

This reverts commit 4e5c80f20bf4c60eb4091bc65c1398b11c76761b, reversing
changes made to 13524cadb4e506d7fe65f2daf47cec3005132753.

Fixing #1000 and #1001.