### PR TITLE
Update Travis rules, test both ruby and Qt part of Sonic Pi

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,69 @@
 language: ruby
-rvm:
-  - "1.9.3"
-  - "2.1.2"
-# uncomment this line if your project needs to run something other than `rake`:
-script: cd app/server/sonicpi && rake test
+
+os: linux
+sudo: required
+dist: trusty
+compiler: gcc
+cache:
+ - apt
+ - ccache
+
+# in addition to the default settings (above),
+# add test runs using the Travis rvm ruby binaries.
+matrix:
+  include:
+    - rvm: 1.9.3
+      env: USE_RVM=1
+    - rvm: 2.1.2
+      env: USE_RVM=1
+    - rvm: 2.2.3
+      env: USE_RVM=1
+
+before_install:
+ - sudo apt-get update
+ - sudo apt-get --yes install ruby-all-dev rake cmake pkg-config g++ libfftw3-dev libffi-dev libqt5scintilla2-dev qtbase5-dev qttools5-dev qttools5-dev-tools qt5-default
+
+script:
+ - set -e
+# the | starts a multiline YAML entry
+ - |
+   if [[ $USE_RVM ]]
+   then
+     # this compiles the gems and runs the Sonic Pi test suite with the ruby installed through Travis's rvm
+     echo ""
+     echo "***********************************"
+     echo "* Compiling the vendor/ ruby gems *"
+     echo "***********************************"
+     cd $TRAVIS_BUILD_DIR/app/server/bin
+     ruby ./compile-extensions.rb
+     echo ""
+     echo "***********************************"
+     echo "* Running the Sonic Pi test suite *"
+     echo "***********************************"
+     cd $TRAVIS_BUILD_DIR/app/server/sonicpi/test
+     rake test
+   else
+     # this compiles the gems and runs the Sonic Pi test suite for all ruby versions in Ubuntu Trusty (1.9.1 and 2.0.0)
+     echo ""
+     echo "***********************************"
+     echo "* Compiling the vendor/ ruby gems *"
+     echo "***********************************"
+     cd $TRAVIS_BUILD_DIR/app/server/bin
+     /usr/bin/ruby -e 'require "ruby_debian_dev"; include RubyDebianDev; SUPPORTED_RUBY_VERSIONS.each { |v, b| system(b + " ./compile-extensions.rb") or raise ("ruby gem compile failed for " + v) }'
+     echo ""
+     echo "***********************************"
+     echo "* Running the Sonic Pi test suite *"
+     echo "***********************************"
+     cd $TRAVIS_BUILD_DIR/app/server/sonicpi/test
+     /usr/bin/ruby -e 'require "ruby_debian_dev"; include RubyDebianDev; SUPPORTED_RUBY_VERSIONS.each { |v, b| system(b + " /usr/bin/rake test") or raise ("test failed for " + v) }'
+     # the following are the same steps as in ./app/gui/qt/rp-build-app
+     echo ""
+     echo "***********************************"
+     echo "* Compiling Sonic Pi GUI with Qt5 *"
+     echo "***********************************"
+     cd $TRAVIS_BUILD_DIR/app/gui/qt
+     cp -f ruby_help.tmpl ruby_help.h ; /usr/bin/ruby ../../server/bin/qt-doc.rb -o ruby_help.h
+     lrelease SonicPi.pro
+     qmake -o Makefile SonicPi.pro
+     make
+   fi


### PR DESCRIPTION
Wouldn't it be nice if some pull requests were stopped before they can break the build?

This set of travis rules will:

- compile the vendor-gems and then run the ruby test suite with
  - Travis's rvm ruby versions 1.9.3, 2.1.2 and 2.2.3
  - Ubuntu 14.04 / Trusty's ruby versions 1.9.1 and 2.0.0
*and*
- compile the Sonic Pi GUI, using Qt5.

Obviously, this increases the time needed for a Travis test run.

The travis script is more complicated than the previous version and needs to be updated whenever there is a major change to `./app/gui/qt/rp-build-app`.

Hopefully, this will help to avoid issues like #1000 / #1001 in the future.