### PR TITLE
Fallback to locally preferred ruby when running from user's home

### DIFF
--- a/app/gui/qt/mainwindow.cpp
+++ b/app/gui/qt/mainwindow.cpp
@@ -128,7 +128,7 @@ MainWindow::MainWindow(QApplication &app, bool i18n, QSplashScreen* splash)
     QString root_path = rootPath();
     
 #if defined(Q_OS_WIN)
-    ruby_path = root_path + "/app/server/native/windows/ruby/bin/ruby.exe";
+    ruby_path = QDir::toNativeSeparators(root_path + "/app/server/native/windows/ruby/bin/ruby.exe");
 #elif defined(Q_OS_MAC)
     ruby_path = root_path + "/server/native/osx/ruby/bin/ruby";
 #else
@@ -141,15 +141,11 @@ MainWindow::MainWindow(QApplication &app, bool i18n, QSplashScreen* splash)
       ruby_path = "ruby";
     }
 
-    ruby_server_path = root_path + "/app/server/bin/sonic-pi-server.rb";
-    sample_path = root_path + "/etc/samples";
+    ruby_server_path = QDir::toNativeSeparators(root_path + "/app/server/bin/sonic-pi-server.rb");
+    sample_path = QDir::toNativeSeparators(root_path + "/etc/samples");
 
   }
   
-  ruby_path = QDir::toNativeSeparators(ruby_path);
-  ruby_server_path = QDir::toNativeSeparators(ruby_server_path);
-  sample_path = QDir::toNativeSeparators(sample_path);
-
   sp_user_path = QDir::toNativeSeparators(QDir::homePath() + "/.sonic-pi");
   log_path = QDir::toNativeSeparators(sp_user_path + "/log");
   server_error_log_path = QDir::toNativeSeparators(log_path + "/server-errors.log");

--- a/app/gui/qt/mainwindow.cpp
+++ b/app/gui/qt/mainwindow.cpp
@@ -133,12 +133,13 @@ MainWindow::MainWindow(QApplication &app, bool i18n, QSplashScreen* splash)
     ruby_path = root_path + "/server/native/osx/ruby/bin/ruby";
 #else
     ruby_path = root_path + "/app/server/native/raspberry/ruby/bin/ruby";
+#endif
+
     QFile file(ruby_path);
     if(!file.exists()) {
       // fallback to user's locally installed ruby
       ruby_path = "ruby";
     }
-#endif
 
     ruby_server_path = root_path + "/app/server/bin/sonic-pi-server.rb";
     sample_path = root_path + "/etc/samples";

--- a/app/gui/qt/mainwindow.cpp
+++ b/app/gui/qt/mainwindow.cpp
@@ -102,28 +102,52 @@ MainWindow::MainWindow(QApplication &app, bool i18n, QMainWindow* splash)
 MainWindow::MainWindow(QApplication &app, bool i18n, QSplashScreen* splash)
 #endif
 {
-  if (QCoreApplication::applicationDirPath().startsWith("/usr/bin")) {
+  if (QCoreApplication::applicationDirPath().startsWith("/usr/bin/")) {
 
     // use FHS directory scheme:
-    // Sonic Pi is not running inside the user's home directory, but is
-    // installed in /usr/bin on Linux from a distribution's package
+    // Sonic Pi is installed in /usr/bin from a Linux distribution's package
 
     ruby_path = "/usr/bin/ruby";
     ruby_server_path = "/usr/lib/sonic-pi/server/bin/sonic-pi-server.rb";
     sample_path = "/usr/share/sonic-pi/samples";
 
+  } else if (QCoreApplication::applicationDirPath().startsWith("/opt/")) {
+    
+    // use /opt directory scheme:
+    // Sonic Pi is installed in /opt from the Raspbian .deb package
+
+    ruby_path = "/usr/bin/ruby";
+    ruby_server_path = "/opt/sonic-pi/server/bin/sonic-pi-server.rb";
+    sample_path = "/opt/sonic-pi/etc/samples";
+  
   } else {
+  
+    // Sonic Pi is installed in the user's home directory
+    // or has been installed on Windows / OSX
+    
+    QString root_path = rootPath();
+    
+#if defined(Q_OS_WIN)
+    ruby_path = root_path + "/app/server/native/windows/ruby/bin/ruby.exe";
+#elif defined(Q_OS_MAC)
+    ruby_path = root_path + "/server/native/osx/ruby/bin/ruby";
+#else
+    ruby_path = root_path + "/app/server/native/raspberry/ruby/bin/ruby";
+    QFile file(ruby_path);
+    if(!file.exists()) {
+      // fallback to user's locally installed ruby
+      ruby_path = "ruby";
+    }
+#endif
 
-    // do not use FHS directory scheme:
-    // Sonic Pi is running in user's home dir or installed on
-    // Win, OS-X or in non-FHS /opt directory scheme
-
-    ruby_path = QDir::toNativeSeparators(rubyPath());
-    QString root_path = QDir::toNativeSeparators(rootPath());
-    ruby_server_path = QDir::toNativeSeparators(root_path + "/app/server/bin/sonic-pi-server.rb");
-    sample_path = QDir::toNativeSeparators(root_path + "/etc/samples");
+    ruby_server_path = root_path + "/app/server/bin/sonic-pi-server.rb";
+    sample_path = root_path + "/etc/samples";
 
   }
+  
+  ruby_path = QDir::toNativeSeparators(ruby_path);
+  ruby_server_path = QDir::toNativeSeparators(ruby_server_path);
+  sample_path = QDir::toNativeSeparators(sample_path);
 
   sp_user_path = QDir::toNativeSeparators(QDir::homePath() + "/.sonic-pi");
   log_path = QDir::toNativeSeparators(sp_user_path + "/log");
@@ -695,24 +719,6 @@ QString MainWindow::rootPath() {
 #else
   return QCoreApplication::applicationDirPath() + "/../../..";
 #endif
-}
-
-QString MainWindow::rubyPath() {
-  QString root_path = rootPath();
-#if defined(Q_OS_WIN)
-  QString prg_path = root_path + "/app/server/native/windows/ruby/bin/ruby.exe";
-#elif defined(Q_OS_MAC)
-  QString prg_path = root_path + "/server/native/osx/ruby/bin/ruby";
-#else
-  //assuming Raspberry Pi
-  QString prg_path = root_path + "/app/server/native/raspberry/ruby/bin/ruby";
-  QFile file(prg_path);
-  if(!file.exists()) {
-    // use system ruby if bundled ruby doesn't exist
-    prg_path = "/usr/bin/ruby";
-  }
-#endif
-  return prg_path;
 }
 
 void MainWindow::startRubyServer(){

--- a/app/gui/qt/mainwindow.h
+++ b/app/gui/qt/mainwindow.h
@@ -210,7 +210,6 @@ private:
     QString tooltipStrMeta(char key, QString str);
     QString readFile(QString name);
     QString rootPath();
-    QString rubyPath();
 
     void addUniversalCopyShortcuts(QTextEdit *te);
 

--- a/app/server/core.rb
+++ b/app/server/core.rb
@@ -31,7 +31,26 @@ os = case RUBY_PLATFORM
      else
        RUBY_PLATFORM
      end
-$:.unshift "#{File.expand_path("../rb-native", __FILE__)}/#{os}/#{ruby_api}/"
+ruby_gem_native_path = "#{File.expand_path("../rb-native", __FILE__)}"
+ruby_gem_api_path = "#{ruby_gem_native_path}/#{os}/#{ruby_api}"
+
+unless File.directory?(ruby_gem_api_path)
+  STDERR.puts "*** COULD NOT FIND RUBY GEMS REQUIRED BY SONIC PI ***"
+  STDERR.puts "Directory '#{ruby_gem_api_path}' not found."
+  STDERR.puts "Your ruby interpreter is '#{RbConfig.ruby}', supporting ruby api #{ruby_api}."
+  Dir.entries("#{ruby_gem_native_path}/#{os}/")
+    .select { |d| (File.directory?("#{ruby_gem_native_path}/#{os}/#{d}") && d != '.' && d != '..') }
+    .each do |installed_ruby_api|
+      STDERR.puts "The Sonic Pi on your computer was installed for ruby api #{installed_ruby_api}."
+    end
+  STDERR.puts "Please refer to the Sonic Pi install instructions."
+  STDERR.puts "For installation, you need to run 'app/server/bin/compile-extensions.rb'."
+  STDERR.puts "If you change or upgrade your ruby interpreter later, you may need to run it again."
+
+  raise "Could not access ruby gem directory"
+end
+
+$:.unshift ruby_gem_api_path
 
 require 'win32/process' if os == :windows
 


### PR DESCRIPTION
ruby, how shall I call thee?
Oh, multifaceted beast of a dozen install locations, what is thy name?

So, #835 seemed like a good idea at the time, but maybe it's better to only use the system's `/usr/bin/ruby` when Sonic Pi is actually installed in `/opt/`(Rasbpian) or in `/usr/bin/`(normal Linux).

Otherwise, the user probably expects to use the preferred ruby in the current path settings.

This should help fix the issues reported by users who had their own rvm ruby installed locally.

The most problematic part of this patch may be that it falls back to "ruby" on all platforms, not just on Raspberry as previously. I *guess* that this would help with users on OS X compiling their own Sonic Pi on their box, but this needs to be discussed prior to merging.