### PR TITLE
Improve save file dialog

### DIFF
--- a/app/gui/qt/mainwindow.cpp
+++ b/app/gui/qt/mainwindow.cpp
@@ -58,7 +58,6 @@
 #include <QScrollArea>
 #include <QShortcut>
 #include <QToolButton>
-#include <QSettings>
 #include <QScrollBar>
 #include <QSignalMapper>
 #include <QSplitter>

--- a/app/gui/qt/mainwindow.cpp
+++ b/app/gui/qt/mainwindow.cpp
@@ -1240,7 +1240,7 @@ QString MainWindow::currentTabLabel()
 
 bool MainWindow::saveAs()
 {
-  QString fileName = QFileDialog::getSaveFileName(this, tr("Save Current Buffer"), QDir::homePath() + "/Desktop");
+  QString fileName = QFileDialog::getSaveFileName(this, tr("Save Current Buffer"), QDir::homePath() + "/Desktop", tr("Ruby (*.rb)"));
   if(!fileName.isEmpty()){
     if (!fileName.contains(QRegExp("\\.[a-z]+$"))) {
         fileName = fileName + ".txt";
@@ -2144,7 +2144,7 @@ void MainWindow::toggleRecording() {
     Message msg("/stop-recording");
     msg.pushStr(guiID.toStdString());
     sendOSC(msg);
-    QString fileName = QFileDialog::getSaveFileName(this, tr("Save Recording"), QDir::homePath() + "/Desktop/my-recording.wav");
+    QString fileName = QFileDialog::getSaveFileName(this, tr("Save Recording"), QDir::homePath() + "/Desktop", tr("Wavefile (*.wav)"));
     if (!fileName.isEmpty()) {
       Message msg("/save-recording");
       msg.pushStr(guiID.toStdString());


### PR DESCRIPTION
Added filters to the save file dialog when saving code or a recording. Also removed the default my-recording.wav filename for this reason. Set the savetype of code to Ruby files with a .rb extension.

Also a minor remove of a double include QSettings in mainwindow.cpp