### PR TITLE
wavefile gem: use little-endian pack codes

### DIFF
--- a/app/server/vendor/wavefile-0.6.0/lib/wavefile.rb
+++ b/app/server/vendor/wavefile-0.6.0/lib/wavefile.rb
@@ -25,7 +25,7 @@ module WaveFile
                :sample       => "smpl",
                :instrument   => "inst" }    # :nodoc:
 
-  PACK_CODES = {:pcm => {8 => "C*", 16 => "s*", 24 => "C*", 32 => "l*"},
+  PACK_CODES = {:pcm => {8 => "C*", 16 => "s<*", 24 => "C*", 32 => "l<*"},
                 :float => { 32 => "e*", 64 => "E*"}}    # :nodoc:
 
   UNSIGNED_INT_16 = "v"    # :nodoc:

--- a/app/server/vendor/wavefile-0.6.0/lib/wavefile/writer.rb
+++ b/app/server/vendor/wavefile-0.6.0/lib/wavefile/writer.rb
@@ -76,7 +76,7 @@ module WaveFile
 
       if @format.bits_per_sample == 24 && @format.sample_format == :pcm
         samples.flatten.each do |sample|
-          @file.syswrite([sample].pack("lX"))
+          @file.syswrite([sample].pack("l<X"))
         end
       else
         @file.syswrite(samples.flatten.pack(@pack_code))


### PR DESCRIPTION
The wavefile gem uses "native endian" pack codes where "little endian" pack codes are required.

This is a copy of a [pull request to the upstream gem source](https://github.com/jstrait/wavefile/pull/18).

This and the [sse flags fix for sc3 plugins](https://github.com/supercollider/sc3-plugins/pull/73) should make it possible to use Sonic Pi on big-endian hardware (e.g. MIPS).