### PR TITLE
Add LF for empty log msg in Sonic::SCSynthExternal.log_boot_msg

### DIFF
--- a/app/server/sonicpi/lib/sonicpi/util.rb
+++ b/app/server/sonicpi/lib/sonicpi/util.rb
@@ -301,6 +301,7 @@ module SonicPi
     def log(message)
       if debug_mode
         res = ""
+        res << "\n" if message.empty?
         first = true
         while !(message.empty?)
           if first
@@ -311,7 +312,6 @@ module SonicPi
             res << "                                        "
             res << message.slice!(0..133)
             res << "\n"
-
           end
         end
         log_raw res


### PR DESCRIPTION
Hi,

Empty log messages (log "") in log_boot_msg are not terminated by a newline.

Assuming debug_mode is true, ~/.sonic-pi/log/debug.log contains:
```
[2016-03-08 14:09:43] [2016-03-08 14:09:43] [2016-03-08 14:09:43] Booting Sonic Pi
[2016-03-08 14:09:43] ----------------
[2016-03-08 14:09:43] [2016-03-08 14:09:43] Boot - Booting on OS X
```
I've therefore add a newline when message is empty in SonicPi::Util.log 
