### PR TITLE
Ensure the messagebox layout is readable

### DIFF
--- a/app/gui/qt/mainwindow.cpp
+++ b/app/gui/qt/mainwindow.cpp
@@ -1127,6 +1127,16 @@ void MainWindow::initPrefsWindow() {
 
 }
 
+void MainWindow::setMessageBoxStyle() {
+  // Set text color to black and background colors to white for the error message display
+  QPalette p = QApplication::palette();
+  p.setColor(QPalette::WindowText,"#000");
+  p.setColor(QPalette::ButtonText,"#000");
+  p.setColor(QPalette::Text,"#000");
+  p.setColor(QPalette::Base,"#FFF");
+  QApplication::setPalette(p);
+}
+
 void MainWindow::invokeStartupError(QString msg) {
   if(startup_error_reported) {
     return;
@@ -1141,6 +1151,8 @@ void MainWindow::invokeStartupError(QString msg) {
 
 void MainWindow::startupError(QString msg) {
   splashClose();
+  
+  setMessageBoxStyle();
 
   QString gui_log = readFile(log_path + QDir::separator() + "gui.log");
   QString server_errors_log = readFile(log_path + QDir::separator() + "server-errors.log");
@@ -2262,10 +2274,12 @@ void MainWindow::loadFile(const QString &fileName, SonicPiScintilla* &text)
 {
   QFile file(fileName);
   if (!file.open(QFile::ReadOnly)) {
+    setMessageBoxStyle();
     QMessageBox::warning(this, tr("Sonic Pi"),
 			 tr("Cannot read file %1:\n%2.")
 			 .arg(fileName)
 			 .arg(file.errorString()));
+    updateDarkMode();
     return;
   }
 
@@ -2280,10 +2294,12 @@ bool MainWindow::saveFile(const QString &fileName, SonicPiScintilla* text)
 {
   QFile file(fileName);
   if (!file.open(QFile::WriteOnly)) {
+    setMessageBoxStyle();
     QMessageBox::warning(this, tr("Sonic Pi"),
 			 tr("Cannot write file %1:\n%2.")
 			 .arg(fileName)
 			 .arg(file.errorString()));
+    updateDarkMode();
     return false;
   }
 

--- a/app/gui/qt/mainwindow.h
+++ b/app/gui/qt/mainwindow.h
@@ -138,6 +138,7 @@ private slots:
     void updateDocPane2(QListWidgetItem *cur, QListWidgetItem *prev);
     void showWindow();
     void splashClose();
+    void setMessageBoxStyle();
     void startupError(QString msg);
     void replaceBuffer(QString id, QString content, int line, int index, int first_line);
     void replaceLines(QString id, QString content, int first_line, int finish_line, int point_line, int point_index);


### PR DESCRIPTION
I noticed that the layout in the QMessageBox is unreadable (white on white) when your default theme is dark. I now included a function that sets the palette so that the message box remains readable.

I tried to implement this using stylesheets so the application palette need not change, but was unable to control the detailed message colors. If necessary, after a messagebox I call updateDarkMode again to ensure the theme remains active.