### PR TITLE
Added removal of english translation file for windows

### DIFF
--- a/app/gui/qt/win-build-app.bat
+++ b/app/gui/qt/win-build-app.bat
@@ -18,6 +18,10 @@ nmake
 nmake install
 cd release
 windeployqt Sonic-Pi.exe -printsupport
+
+@echo Removing faulty english translation file
+if exist translations\qt_en.qm del translations\qt_en.qm
+
 cd ..
 
 @goto :done


### PR DESCRIPTION
This solves #923. The problem appears to be that Qt's windeployqt.exe creates a faulty `qt_en.qm` file. They solved the same problem [here](https://github.com/Wohlhabend-Networks/PGE-Project/issues/82).

Removing this file ensures that the default (English) entries are displayed, so I added the removal to the windows build script.