### PR TITLE
added iostream include to prevent clang compiler error

### DIFF
--- a/app/gui/qt/udp.hh
+++ b/app/gui/qt/udp.hh
@@ -54,6 +54,7 @@
 #include <cassert>
 #include <string>
 #include <vector>
+#include <iostream>
 
 namespace oscpkt {
 


### PR DESCRIPTION
Should fix issue #1076. The clang++ compiler errors went away after adding `#include <iostream>`. 