### PR TITLE
Fix sample duration tests

### DIFF
--- a/app/server/sonicpi/test/lang/sound/test_sample_duration.rb
+++ b/app/server/sonicpi/test/lang/sound/test_sample_duration.rb
@@ -34,7 +34,7 @@ module SonicPi
         60
       end
 
-      def self.sample_path(*args)
+      def self.resolve_sample_path(*args)
         "/foo/bar"
       end
     end


### PR DESCRIPTION
This brings the tests back up to date after a method they relied on was previously renamed.