### PR TITLE
jack_wait: look for 'not running' specifically

### DIFF
--- a/app/server/sonicpi/lib/sonicpi/scsynthexternal.rb
+++ b/app/server/sonicpi/lib/sonicpi/scsynthexternal.rb
@@ -350,7 +350,7 @@ module SonicPi
       sys("jackd -R -p 32 -d alsa -d hw:#{audio_card} -n 3 -p 2048 -r 44100& ")
 
       # Wait for Jackd to start
-      while `jack_wait -c`.match /not.*/
+      while `jack_wait -c`.match /^not running$/
         sleep 0.25
       end
 
@@ -370,7 +370,7 @@ module SonicPi
       log_boot_msg
       log "Booting on Linux"
       #Start Jack if not already running
-      if `jack_wait -c`.match /not.*/
+      if `jack_wait -c`.match /^not running$/
         #Jack not running - start a new instance
         log "Jackd not running on system. Starting..."
         sys("jackd -R -T -p 32 -d alsa -n 3 -p 2048 -r 44100& ")


### PR DESCRIPTION
Looking for 'not' is not enough, as those three letters can appear in
jack_wait -c output for other reasons as well, for example:

Cannot lock down 82274202 byte memory area (Cannot allocate memory)
Jack: JackClient::SetupDriverSync driver sem in flush mode
...
Jack: jack_client_close res = 0
running

Has 'not' on the first line, in "Cannot".