### PR TITLE
Fix broken image in core team in info window

### DIFF
--- a/app/gui/qt/SonicPi.qrc
+++ b/app/gui/qt/SonicPi.qrc
@@ -50,6 +50,7 @@
         <file>images/coreteam/josephwilk.png</file>
         <file>images/coreteam/xavierriley.png</file>
         <file>images/coreteam/jweather.png</file>
+        <file>images/coreteam/hannozulla.png</file>
 
         <file>html/doc.html</file>
         <file>html/info.html</file>


### PR DESCRIPTION
Hanno's image was not displaying. It seems that it was not referenced in the SonicPi.qrc file, which has now been updated.