### PR TITLE
Update core.rb

### DIFF
--- a/app/server/core.rb
+++ b/app/server/core.rb
@@ -343,7 +343,8 @@ module SonicPi
       end
 
       def take(n)
-        return self.reverse.take(-n) if n <= 0
+        raise "error: 0 argument for take" if n == 0
+        return self.reverse.take(-n) if n < 0
         return super if n <= @size
         self + take(n - @size)
       end

--- a/app/server/core.rb
+++ b/app/server/core.rb
@@ -343,7 +343,8 @@ module SonicPi
       end
 
       def take(n)
-        raise "error: 0 argument for take" if n == 0
+        return [] if n == 0 and self.is_a? Array
+        return [].ring if n == 0
         return self.reverse.take(-n) if n < 0
         return super if n <= @size
         self + take(n - @size)


### PR DESCRIPTION
Add error handling for .take with argument=0
prevents ring(1,2,3).take(0) crashing the server

resolves issue #1095