### PR TITLE
Update core.rb

### DIFF
--- a/app/server/core.rb
+++ b/app/server/core.rb
@@ -343,7 +343,9 @@ module SonicPi
       end
 
       def take(n)
-        return self.reverse.take(-n) if n <= 0
+        return [] if n == 0 and self.is_a? Array
+        return [].ring if n == 0
+        return self.reverse.take(-n) if n < 0
         return super if n <= @size
         self + take(n - @size)
       end


### PR DESCRIPTION
Lets .take return an empty array or an empty ring as appropriate when argument is 0

Tests
```
#Testing behaviour of take function with argument 0
d=[1,2,3]
s=ring(1,2,3)
puts "d = "+d.to_s
puts"s= "+s.to_s
puts "Is d an array: "+(d.is_a? Array).to_s
puts "Is s an array: "+(s.is_a? Array).to_s

puts "d.take(0) gives: "+d.take(0).to_s
puts "Is d.take(0) an array: "+(d.take(0).is_a? Array).to_s
puts "s.take(0) gives: "+s.take(0).to_s
puts "Is s.take(0) an array: "+(s.take(0).is_a? Array).to_s
```
output

 ├─ d = [1, 2, 3]
 ├─ s= (ring 1, 2, 3)
 ├─ Is d an array: true
 ├─ Is s an array: false
 ├─ d.take(0) gives: []
 ├─ Is d.take(0) an array: true
 ├─ s.take(0) gives: (ring)
 └─ Is s.take(0) an array: false
