### PR TITLE
[i18n][pl] too small width for 'Check now' button in PL version

### DIFF
--- a/app/gui/qt/mainwindow.cpp
+++ b/app/gui/qt/mainwindow.cpp
@@ -961,7 +961,7 @@ void MainWindow::initPrefsWindow() {
   visit_sonic_pi_net = new QPushButton(tr("Get update"));
   visit_sonic_pi_net->setToolTip(tr("Visit http://sonic-pi.net to download new version"));
   visit_sonic_pi_net->setVisible(false);
-  check_updates_now->setMaximumWidth(100);
+  check_updates_now->setMaximumWidth(110);
   visit_sonic_pi_net->setMaximumWidth(150);
 
   QGroupBox *update_info_box = new QGroupBox(tr("Update Info"));


### PR DESCRIPTION
Problem found on SPi 2.10b1 on boxes with PL locale (Windows 10 Pro x64, Raspberry Pi 2 Jessie).

Before fix

![image](https://cloud.githubusercontent.com/assets/181356/14192390/b2935452-f79d-11e5-8e47-95bb45543de8.png)

After fix

![image](https://cloud.githubusercontent.com/assets/181356/14192434/eef49302-f79d-11e5-9e38-bb715d5bc002.png)

Would be great if somebody could check it on machines with different locale (en, gb, etc.)

