### PR TITLE
Recognise rings etc as immutable for cue/sync

### DIFF
--- a/app/server/sonicpi/lib/sonicpi/lang/core.rb
+++ b/app/server/sonicpi/lib/sonicpi/lang/core.rb
@@ -2513,14 +2513,7 @@ Affected by calls to `use_bpm`, `with_bpm`, `use_sample_bpm` and `with_sample_bp
 
 
       def immutable?(v)
-        return true if v.is_a?(Numeric) || v.is_a?(Symbol) || v.is_a?(TrueClass) || v.is_a?(FalseClass) || v.is_a?(NilClass)
-        if v.is_a?(SonicPi::Core::SPVector)
-          v.each do |el|
-            return false if not immutable?(el)
-          end
-          return true
-        end
-        return false
+        return v.is_a?(Numeric) || v.is_a?(Symbol) || v.is_a?(TrueClass) || v.is_a?(FalseClass) || v.is_a?(NilClass) || (v.is_a?(SonicPi::Core::SPVector) && v.all? {|el| immutable?(el)})
       end
 
 

--- a/app/server/sonicpi/lib/sonicpi/lang/core.rb
+++ b/app/server/sonicpi/lib/sonicpi/lang/core.rb
@@ -2512,11 +2512,23 @@ Affected by calls to `use_bpm`, `with_bpm`, `use_sample_bpm` and `with_sample_bp
 
 
 
+      def immutable?(v)
+        return true if v.is_a?(Numeric) || v.is_a?(Symbol) || v.is_a?(TrueClass) || v.is_a?(FalseClass)
+        if v.is_a?(SonicPi::Core::SPVector)
+          v.each do |el|
+            return false if not immutable?(el)
+          end
+          return true
+        end
+        return false
+      end
+
+
       def cue(cue_id, *opts)
         args_h = resolve_synth_opts_hash_or_array(opts)
         args_h.each do |k, v|
           raise "Invalid cue key type. Must be a Symbol" unless k.is_a? Symbol
-          raise "Invalid cue value type (#{v.class}) for key #{k.inspect}. Must be immutable - currently accepted types: Numbers, Symbols and Booleans." unless v.is_a?(Numeric) || v.is_a?(Symbol) || v.is_a?(TrueClass) || v.is_a?(FalseClass)
+          raise "Invalid cue value type (#{v.class}) for key #{k.inspect}. Must be immutable - currently accepted types: Numbers, Symbols and Booleans." unless immutable?(v)
         end
 
 

--- a/app/server/sonicpi/lib/sonicpi/lang/core.rb
+++ b/app/server/sonicpi/lib/sonicpi/lang/core.rb
@@ -2521,7 +2521,7 @@ Affected by calls to `use_bpm`, `with_bpm`, `use_sample_bpm` and `with_sample_bp
         args_h = resolve_synth_opts_hash_or_array(opts)
         args_h.each do |k, v|
           raise "Invalid cue key type. Must be a Symbol" unless k.is_a? Symbol
-          raise "Invalid cue value type (#{v.class}) for key #{k.inspect}. Must be immutable - currently accepted types: Numbers, Symbols and Booleans." unless immutable?(v)
+          raise "Invalid cue value type (#{v.class}) for key #{k.inspect}. Must be immutable - currently accepted types: Numbers, Symbols, Booleans and Nil, or Vectors/Rings of immutable types" unless immutable?(v)
         end
 
 

--- a/app/server/sonicpi/lib/sonicpi/lang/core.rb
+++ b/app/server/sonicpi/lib/sonicpi/lang/core.rb
@@ -2513,7 +2513,7 @@ Affected by calls to `use_bpm`, `with_bpm`, `use_sample_bpm` and `with_sample_bp
 
 
       def immutable?(v)
-        return true if v.is_a?(Numeric) || v.is_a?(Symbol) || v.is_a?(TrueClass) || v.is_a?(FalseClass)
+        return true if v.is_a?(Numeric) || v.is_a?(Symbol) || v.is_a?(TrueClass) || v.is_a?(FalseClass) || v.is_a?(NilClass)
         if v.is_a?(SonicPi::Core::SPVector)
           v.each do |el|
             return false if not immutable?(el)


### PR DESCRIPTION
I don't have much experience with Ruby, so this may be very ugly/unidiomatic, and it is still completely untested so may not work at all, just wanted to check the general approach is OK before going too far.