### PR TITLE
Add new function fx_names

### DIFF
--- a/app/server/sonicpi/lib/sonicpi/lang/sound.rb
+++ b/app/server/sonicpi/lib/sonicpi/lang/sound.rb
@@ -3684,6 +3684,17 @@ kill bar"]
           examples:      []
 
 
+      def fx_names
+        Synths::BaseInfo.all_fx.ring
+      end
+      doc name:          :fx_names,
+          introduced:    Version.new(2,10,0),
+          summary:       "Get all FX names",
+          doc:           "Return a list of all the FX available",
+          args:          [],
+          opts:          nil,
+          accepts_block: false,
+          examples:      []
 
 
       def load_synthdefs(path=synthdef_path)

--- a/app/server/sonicpi/lib/sonicpi/synths/synthinfo.rb
+++ b/app/server/sonicpi/lib/sonicpi/synths/synthinfo.rb
@@ -3751,6 +3751,9 @@ Note that if the microphone and speaker are close together (on a laptop or in a 
     end
 
     class FXInfo < BaseInfo
+      def user_facing?
+        true
+      end
 
       def trigger_with_logical_clock?
         true
@@ -7052,6 +7055,11 @@ Use FX `:band_eq` with a negative db for the opposite effect - to attenuate a gi
 
       def self.all_synths
         @@synth_infos.select {|k, v| v.is_a?(SonicPiSynth) && v.user_facing?}.keys
+      end
+
+      def self.all_fx
+        fx = @@synth_infos.select {|k, v| v.is_a?(FXInfo) && v.user_facing? && !k.to_s.include?('replace_')}.keys
+        fx.map { |k, v| k.to_s[3..-1].to_sym }
       end
 
       def self.info_doc_html_map(klass)


### PR DESCRIPTION
@samaaron @xavriley - at Xavier's suggestion, here's an implementation of the fx_names function. How does it look?

This adds a new function to return a ring of the names of all user facing FX.
The list is constructed by 1) filtering ```@@synth_infos``` for FX where ```user_facing?``` == true and the name doesn't include 'replace_', and 2) formatting these names to match the FX symbols as used by the user.
