### PR TITLE
Proofreading - fix various typos, improve grammar, fix some examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,8 +31,8 @@ We also have a number of exciting new sounds to play with including some
 beautifully sounding chiptune synths, fun retro FX and new drum samples
 including a full tabla set and a cowbell.
 
-Finally, even more boot issues on both OS X and Windows that have been
-fixed making this the most polished and stable release to date.
+Finally, even more boot issues on both OS X and Windows have been
+fixed, making this the most polished and stable release to date.
 
 Now go and get your live code on!
 
@@ -182,7 +182,7 @@ Now go and get your live code on!
 * `C-i` now always displays docs where available (previously it was
   possible for docs not to be displayed).
 * Sliding between chords now works correctly  
-* Windows version will now boot mutiple networked machines logged in
+* Windows version will now boot on mutiple networked machines logged in
   with the same account.
 
 

--- a/app/gui/qt/mainwindow.cpp
+++ b/app/gui/qt/mainwindow.cpp
@@ -986,7 +986,7 @@ void MainWindow::initPrefsWindow() {
   enable_external_synths_cb->setToolTip(tr("When enabled, Sonic Pi will allow\nsynths and FX loaded via load_synthdefs\nto be triggered.\n\nWhen disabled, Sonic Pi will complain\nwhen you attempt to use a synth or FX\nwhich isn't recognised."));
 
   synth_trigger_timing_guarantees_cb = new QCheckBox(tr("Enforce timing guarantees"));
-  synth_trigger_timing_guarantees_cb->setToolTip(tr("When enabled, Sonic Pi will refuse\nto trigger synths and FX if\nit is too late to do so\n\nWhen disabled, Sonic Pi will always\nattemptto trigger synths and FX\neven when a little late."));
+  synth_trigger_timing_guarantees_cb->setToolTip(tr("When enabled, Sonic Pi will refuse\nto trigger synths and FX if\nit is too late to do so\n\nWhen disabled, Sonic Pi will always\nattempt to trigger synths and FX\neven when a little late."));
 
   QVBoxLayout *debug_box_layout = new QVBoxLayout;
   debug_box_layout->addWidget(print_output);

--- a/app/server/sonicpi/lib/sonicpi/lang/sound.rb
+++ b/app/server/sonicpi/lib/sonicpi/lang/sound.rb
@@ -445,7 +445,7 @@ sample :loop_amen  #=> unless time is too far behind, this will trigger even whe
 
 
       def with_timing_guarantees(v, &block)
-        raise "use_timing_guarantees requires a do/end block. Perhaps you meant use_timing_guarnatees" unless block
+        raise "with_timing_guarantees requires a do/end block. Perhaps you meant use_timing_guarantees" unless block
         current = Thread.current.thread_variable_get(:sonic_pi_mod_sound_timing_guarantees)
         Thread.current.thread_variable_set(:sonic_pi_mod_sound_timing_guarantees, v)
         res = block.call
@@ -3047,7 +3047,7 @@ sample :loop_amen, start: 0.125, finish: 0.25 # Play the second eighth of the sa
 
 sample :loop_amen, start: 0.25, finish: 0.125 # Play the second eighth of the sample backwards",
         "
-# Play a section of a sample half speed backwards
+# Play a section of a sample at quarter speed backwards
 
 sample :loop_amen, start: 0.125, finish: 0.25, rate: -0.25 # Play the second eighth of the
                                                            # amen break backwards at a
@@ -3136,7 +3136,7 @@ sample dir                                              # Play the first sample 
 
 sample dir, 1                                           # Play the second sample in the directory
 
-sample dir, 99                                          # Play the 99th sample in the directory, or if there
+sample dir, 99                                          # Play the 100th sample in the directory, or if there
                                                         # are fewer, treat the directory like a ring and keep
                                                         # wrapping the index round until a sample is found.
                                                         # For example, if there are 90 samples, the 10th sample
@@ -3168,7 +3168,7 @@ sample dir, /beat[0-9]0/, \"100\"                       # Play the first sample 
 sample \"tabla_\"                                       # Play the first built-in sample that contains the substring
                                                         # \"tabla\"
 
-sample \"tabla_\", 2                                    # Play the second built-in sample that contains the substring
+sample \"tabla_\", 2                                    # Play the third built-in sample that contains the substring
                                                         # \"tabla\"",
         "
 # Play with whole directories of samples


### PR DESCRIPTION
Several typos and grammar improvements have been made. Also, I noticed that in the examples for the sample fn, when showing the use of indexing into the sample candidates with a number, several of the indexes as described were out by 1. They've now been fixed.