### PR TITLE
GUI - make window show on correct screen in fullscreen

### DIFF
--- a/app/gui/qt/mainwindow.cpp
+++ b/app/gui/qt/mainwindow.cpp
@@ -22,6 +22,8 @@
 #include <QSysInfo>
 #include <QDate>
 #include <QDesktopServices>
+#include <QDesktopWidget>
+#include <QWindow>
 #include <QDir>
 #include <QAction>
 #include <QApplication>
@@ -568,11 +570,13 @@ void MainWindow::toggleFullScreenMode() {
 
 void MainWindow::updateFullScreenMode(){
   if (full_screen->isChecked()) {
+    int currentScreen = QApplication::desktop()->screenNumber(this);
     mainWidgetLayout->setMargin(0);
     outputWidget->setTitleBarWidget(blankWidget);
     this->setWindowFlags(Qt::FramelessWindowHint);
-    this->setWindowState(Qt::WindowFullScreen);
     this->show();
+    this->windowHandle()->setScreen(qApp->screens()[currentScreen]);
+    this->setWindowState(Qt::WindowFullScreen);
   }
   else {
     mainWidgetLayout->setMargin(9);


### PR DESCRIPTION
This update gets the screen number of the desktop that most contains the main window widget (eg 'currentScreen') before switching to fullscreen, and then moves the window to appear at the screen indicated by that index in qApp->screens().
This prevents the window from defaulting to one particular screen all the time (eg always appearing on an external monitor instead of a laptop's screen if fullscreen mode was activated from the laptop screen).