### PR TITLE
Make app go fullscreen on correct screen again

### DIFF
--- a/app/gui/qt/mainwindow.cpp
+++ b/app/gui/qt/mainwindow.cpp
@@ -556,11 +556,11 @@ void MainWindow::updateFullScreenMode(){
     mainWidgetLayout->setMargin(0);
     outputWidget->setTitleBarWidget(blankWidget);
     this->setWindowFlags(Qt::FramelessWindowHint);
+    int currentScreen = QApplication::desktop()->screenNumber(this);
     this->show();
 
 #if QT_VERSION >= 0x050400
     //requires Qt5
-    int currentScreen = QApplication::desktop()->screenNumber(this);
     this->windowHandle()->setScreen(qApp->screens()[currentScreen]);
 #endif
 


### PR DESCRIPTION
In order to make fullscreen mode target the correct desktop screen, it seems that it is necessary to check the current screen *before* making the window visible.