### PR TITLE
Fix Travis build for Qt4 and Qt5.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,9 +26,11 @@ before_install:
  - |
    if [[ $USE_QT4 ]]
    then
-      sudo apt-get --yes install libqscintilla2-dev qt4-dev-tools qt4-default
+      sudo apt-get --yes install libqscintilla2-dev qt4-dev-tools qt4-default libqwt-dev libboost-all-dev
    else
-      sudo apt-get --yes install libqt5scintilla2-dev qtbase5-dev qttools5-dev qttools5-dev-tools qt5-default
+      sudo add-apt-repository ppa:latthias/qgis-travis-deps -y
+      sudo apt-get update -q
+      sudo apt-get --yes install libqt5scintilla2-dev qtbase5-dev qttools5-dev qttools5-dev-tools qt5-default libqt5opengl5-dev libqt5svg5-dev libqwt-qt5-dev libboost-all-dev
    fi
 
 script:

--- a/app/gui/qt/SonicPi.pro
+++ b/app/gui/qt/SonicPi.pro
@@ -11,19 +11,10 @@
 # notice is included.
 #++
 
-#-------------------------------------------------
-#
-# Project created by QtCreator 2014-02-28T14:51:06
-#
-#-------------------------------------------------
-
 TARGET = 'sonic-pi'
-CONFIG += debug
-CONFIG += link_pkgconfig qscintilla2 qwt
-PKGCONFIG += libboost 
-#tlsf
+CONFIG += qwt
 
-QT += core gui concurrent network 
+QT += core gui concurrent network
 greaterThan(QT_MAJOR_VERSION, 4) {
   QT += widgets
 }
@@ -32,20 +23,21 @@ QMAKE_CXXFLAGS += -std=c++11 -Wall -Werror -Wextra -Wno-unused-variable -Wno-unu
 
 # Linux only
 unix:!macx {
-  debug {
-    QMAKE_CXXFLAGS += -ggdb
+  LIBS += -lrt
+  lessThan(QT_MAJOR_VERSION, 5) {
+    LIBS += -lqscintilla2
+  } else {
+    LIBS += -lqt5scintilla2
   }
 }
 
 # Mac OS X only
 macx {
-  QT_CONFIG -= no-pkg-config
+  TARGET = 'Sonic Pi'
   CONFIG += warn_off
-
+  LIBS += -lqscintilla2
   QMAKE_CXXFLAGS += -stdlib=libc++
   QMAKE_MACOSX_DEPLOYMENT_TARGET=10.10
-
-  TARGET = 'Sonic Pi'
 }
 
 # Windows only


### PR DESCRIPTION
This fixes the Travis CI build for the github repo.

Travis uses Ubuntu 14.04, which doesn't contain the proper qwt libs. A PPA containing them was added. Once Travis offers 16.04, the rules should be changed and the PPA removed accordingly.

The SonicPi.pro file by @Factoid contained leftover debug setting, which were removed. The Qt-version based selector of the proper qscintilla libs was put back in, as it wouldn't build properly otherwise. 