### PR TITLE
Proofreading - fix various docstrings/error messages

### DIFF
--- a/app/server/sonicpi/lib/sonicpi/lang/core.rb
+++ b/app/server/sonicpi/lib/sonicpi/lang/core.rb
@@ -1727,7 +1727,7 @@ end
           accepts_block:  false,
           doc:            "Given a max number, produces a whole number between `0` and the supplied max value exclusively. If max is a range produces an int within the range. With no args returns either `0` or `1`",
           examples:       ["
-  print rand_i(5) #=> will print a either 0, 1, 2, 3, or 4 to the output pane"]
+  print rand_i(5) #=> will print either 0, 1, 2, 3, or 4 to the output pane"]
 
 
 
@@ -2150,7 +2150,7 @@ end
 
       def with_bpm_mul(mul, &block)
         raise "with_bpm_mul must be called with a do/end block. Perhaps you meant use_bpm_mul" unless block
-        raise "use_bpm_mul's mul should be a positive value. You tried to use: #{mul}" unless mul > 0
+        raise "with_bpm_mul's mul should be a positive value. You tried to use: #{mul}" unless mul > 0
         current_mul = Thread.current.thread_variable_get(:sonic_pi_spider_sleep_mul)
         new_mul = current_mul.to_f / mul
         Thread.current.thread_variable_set(:sonic_pi_spider_sleep_mul, new_mul)
@@ -2214,7 +2214,7 @@ end
 
       def density(d, &block)
         raise "density must be called with a do/end block." unless block
-        raise "density must be a positive number. Got: #{d.inspect}." unless d.is_a?(Numeric) && d >= 0
+        raise "density must be a positive number. Got: #{d.inspect}." unless d.is_a?(Numeric) && d > 0
         reps = d < 1 ? 1.0 : d
         with_bpm_mul d do
           if block.arity == 0
@@ -2268,7 +2268,7 @@ end
           summary:       "Get current random seed",
           doc:           "Returns the current random seed.
 
-This can be set via the fns `use_random_seed` and `with_random_seed. It is incremented every time you use the random number generator via fns such as `choose` and `rand`.",
+This can be set via the fns `use_random_seed` and `with_random_seed`. It is incremented every time you use the random number generator via fns such as `choose` and `rand`.",
           args:          [],
           opts:          nil,
           accepts_block: false,
@@ -2638,7 +2638,7 @@ Affected by calls to `use_bpm`, `with_bpm`, `use_sample_bpm` and `with_sample_bp
       doc name:           :sync_bpm,
           introduced:     Version.new(2,10,0),
           summary:        "Sync and inherit BPM from other threads ",
-          doc:            "An alias for `sync` with the `bpm_sync:` opt set to true.`",
+          doc:            "An alias for `sync` with the `bpm_sync:` opt set to true.",
           args:           [[:cue_id, :symbol]],
           opts:           {},
           accepts_block:  false,

--- a/app/server/sonicpi/lib/sonicpi/lang/sound.rb
+++ b/app/server/sonicpi/lib/sonicpi/lang/sound.rb
@@ -900,7 +900,7 @@ play 50 # Plays note 50.01"]
           summary:       "Cent tuning",
           doc:           "Uniformly tunes your music by shifting all notes played by the specified number of cents. To shift up by a cent use a cent tuning of 1. To shift down use negative numbers. One semitone consists of 100 cents.
 
-See `with_cent_tuning` for setting the cent tuning value only for a specific `do`/`end` block. To tranpose entire semitones see `use_transpose`.",
+See `with_cent_tuning` for setting the cent tuning value only for a specific `do`/`end` block. To transpose entire semitones see `use_transpose`.",
           args:          [[:cent_shift, :number]],
           opts:          nil,
           accepts_block: false,
@@ -925,7 +925,7 @@ play 50 # Plays note 50.01"]
       doc name:           :with_cent_tuning,
           introduced:     Version.new(2,9,0),
           summary:        "Block-level cent tuning",
-          doc:            "Similar to `use_cent_tuning` except only applies cent shift to code within supplied `do`/`end` block. Previous cent tuning value is restored after block. One semitone consists of 100 cents. To tranpose entire semitones see `with_transpose`.",
+          doc:            "Similar to `use_cent_tuning` except only applies cent shift to code within supplied `do`/`end` block. Previous cent tuning value is restored after block. One semitone consists of 100 cents. To transpose entire semitones see `with_transpose`.",
           args:           [[:cent_shift, :number]],
           opts:           nil,
           accepts_block:  true,
@@ -3338,7 +3338,7 @@ puts note('C', octave: 2)
       returns:        :ring,
       opts:           {:pitches => "An array of notes (symbols or ints) to filter on. Octave information is ignored."},
       accepts_block:  false,
-      doc:            "Produces a ring of all the notes between a low note and a high note. By default this is chromatic (all the notes) but can be filtered with a :pitches argument. This opens the door to arpeggiator style sequences and other useful patterns. If you try to specify only pitches which aren't in the range it will raise an error - you have been warned!",
+      doc:            "Produces a ring of all the notes between a low note and a high note. By default this is chromatic (all the notes) but can be filtered with a pitches: argument. This opens the door to arpeggiator style sequences and other useful patterns. If you try to specify only pitches which aren't in the range it will raise an error - you have been warned!",
       examples:       [
         "(note_range :c4, :c5) # => (ring 60,61,62,63,64,65,66,67,68,69,70,71,72)",
         "(note_range :c4, :c5, pitches: (chord :c, :major)) # => (ring 60,64,67,72)",
@@ -3994,7 +3994,7 @@ kill bar"]
 You may not trigger external synthdefs unless you enable the following GUI preference:
 
 ```
-Studio -> Synths -> Enable external synths and FX
+Studio -> Synths and FX -> Enable external synths and FX
 ```
 
 Also, if you wish your synth to work with Sonic Pi's automatic stereo sound infrastructure *you need to ensure your synth outputs a stereo signal* to an audio bus with an index specified by a synth arg named `out_bus`. For example, the following synth would work nicely:


### PR DESCRIPTION
This just fixes several typos & omissions, and several markdown formatting problems, in various docstrings and exception messages.