### PR TITLE
Fix Travis build

### DIFF
--- a/app/gui/qt/SonicPi.pro
+++ b/app/gui/qt/SonicPi.pro
@@ -35,6 +35,7 @@ unix:!macx {
   } else {
     LIBS += -lqt5scintilla2
   }
+  QMAKE_CXXFLAGS += -std=gnu++11
   debug {
     QMAKE_CXXFLAGS += -ggdb
   }

--- a/app/gui/qt/SonicPi.pro
+++ b/app/gui/qt/SonicPi.pro
@@ -30,6 +30,11 @@ QMAKE_CXXFLAGS += -Wall -Werror -Wextra -Wno-unused-variable -Wno-unused-paramet
 # Linux only
 unix:!macx {
   LIBS += -lrt
+  lessThan(QT_MAJOR_VERSION, 5) {
+    LIBS += -lqscintilla2
+  } else {
+    LIBS += -lqt5scintilla2
+  }
   debug {
     QMAKE_CXXFLAGS += -ggdb
   }

--- a/app/gui/qt/scope.cpp
+++ b/app/gui/qt/scope.cpp
@@ -33,7 +33,9 @@ ScopePanel::ScopePanel( const std::string& name, QWidget* parent ) : QWidget(par
   plot_curve.setItemAttribute( QwtPlotItem::AutoScale );
   plot_curve.attach(&plot);
   plot_curve.setPen(* new QPen(QColor("deeppink"), 2));
+#if QWT_VERSION >= 0x60100
   plot_curve.setPaintAttribute( QwtPlotCurve::PaintAttribute::FilterPoints );
+#endif
 
   plot.setAxisScale(QwtPlot::Axis::yLeft,-1,1);
   plot.setAxisScale(QwtPlot::Axis::xBottom,0,4096);

--- a/app/gui/qt/scope.h
+++ b/app/gui/qt/scope.h
@@ -14,10 +14,9 @@
 #ifndef SCOPE_H
 #define SCOPE_H
 
-#include <QtWidgets>
-//#include <QDockWidget>
-#include <qwt_plot.h>
-#include <qwt_plot_curve.h>
+#include <QWidget>
+#include <qwt/qwt_plot.h>
+#include <qwt/qwt_plot_curve.h>
 
 #include <server_shm.hpp>
 #include <memory>


### PR DESCRIPTION
Hi @Factoid, please review this, this fixes the Travis and the Ubuntu 14.04 build.

The `FilterPoints` attribute is useful for the scope, but it is a new addition since qwt 6.1.x, while the scope still works without it and there's only qwt 6.0.x in Travis / Ubuntu 14.04. This makes the code use it only if the proper version of qwt is installed.

Your original .pro file works on current Ubuntu 16.04, but the explicit addition of the Qt4 or Qt5 scintilla lib to `LIBS` still seems to be necessary for earlier Travis / Ubuntu 14.04.

Including `QtWidgets` seems to work with Qt5 only. Things still compile and work if one just includes the widget actually in use in `scope.h`, which is `QWidget`.