### PR TITLE
Revert back to qwt include directory.

### DIFF
--- a/app/gui/qt/scope.h
+++ b/app/gui/qt/scope.h
@@ -15,8 +15,8 @@
 #define SCOPE_H
 
 #include <QWidget>
-#include <qwt/qwt_plot.h>
-#include <qwt/qwt_plot_curve.h>
+#include <qwt_plot.h>
+#include <qwt_plot_curve.h>
 
 #include <server_shm.hpp>
 #include <memory>


### PR DESCRIPTION
This should fix the build on OS X.
Thanks to @rbnpi for reporting this on gitter.im.