### PR TITLE
Moving towards weblate #2: Activate translation sync of Qt GUI through weblate

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,9 @@ Sonic Pi is under active development, and welcomes new contributors:
 * [Testing](TESTING.md)
 * [Translation](TRANSLATION.md)
 
-[![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/samaaron/sonic-pi?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![Weblate](https://hosted.weblate.org/widgets/sonic-pi/-/svg-badge.svg)](https://hosted.weblate.org/engage/sonic-pi/)
 <br/>
 [![Travis CI](https://travis-ci.org/samaaron/sonic-pi.svg?branch=master)](https://travis-ci.org/samaaron/sonic-pi)
+<br/>
+[![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/samaaron/sonic-pi?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 

--- a/TRANSLATION-WORKFLOW.md
+++ b/TRANSLATION-WORKFLOW.md
@@ -52,20 +52,21 @@ it can be translated.
 Whenever message strings are changed or a major feature introduces new 
 ones, you need to update the `.ts` files.
 
-To initiate a translation update, rebase your repo with the current 
-HEAD of the master branch and then do
+To initiate a translation update, update your repo to the current HEAD 
+of the master branch, update the Qt linguist files using `lupdate`, 
+commit the update and push it back to the master branch.
 
 ```
+  git pull
   cd app/gui/qt
   lupdate -pro SonicPi.pro -no-obsolete
+  git commit lang/sonic-pi_*.ts
+  git push
 ```
 
 This will update all Qt linguist files in 
 `app/gui/qt/lang/sonic-pi_<LANG>.ts` with the new message strings from 
 your code and remove obsolete entries.
-
-After that, commit the updated `.ts` files and push them back to the 
-master branch.
 
 Weblate will then fetch them automatically, translators will update 
 them and the finished translations will flow back into the master 

--- a/TRANSLATION-WORKFLOW.md
+++ b/TRANSLATION-WORKFLOW.md
@@ -1,0 +1,72 @@
+# Making Sonic Pi translatable
+
+[![Weblate](https://hosted.weblate.org/widgets/sonic-pi/-/svg-badge.svg)](https://hosted.weblate.org/engage/sonic-pi/)
+
+(This document is meant for contributors to the Sonic Pi codebase. If 
+you're a translator who wants to help bring Sonic Pi to your language 
+please read the [Translation Guide Workflow](TRANSLATION.md).)
+
+[Weblate](https://weblate.org) is open-source web-based translation 
+editor. Their development team runs a hosted version of the tool and 
+they have kindly offered us to use the service for free. (Thanks!)
+
+The Weblate server keeps a copy of Sonic Pi's upstream git repository. 
+Translators commit to the cloned repository on the Weblate server.
+
+Sonic Pi's upstream git repository is tracked by Weblate, it will 
+pull changes from and push updates to us.
+
+## Setup
+
+This is a one-time setup for the master repository and needs to be done 
+by @samaaron.
+
+- [Sign up](https://hosted.weblate.org/accounts/register/),
+  preferably using your Github account authorization.
+
+- To enable Weblate pulling updates from the master repository, add the
+  [Weblate service](https://docs.weblate.org/en/latest/admin/continuous.html#github-setup)
+  in the repository settings and use the URL
+  `https://hosted.weblate.org` in the Weblate service settings.
+
+- To enable Weblate pushing translation updates back to the master 
+  repository, add the [Weblate push user](@weblate) to the 
+  collaborators  in the master branch's repository settings.
+
+After this, translations will be synced automatically between Github 
+and Weblate.
+
+## Workflow
+
+Translations for the Qt GUI are located in 
+[`app/gui/qt/lang/sonic-pi_<LANG>.ts`](./app/gui/qt/lang/). Do not edit 
+these, that's what we use Weblate for.
+
+The translatable message strings are marked in your C++ code using the 
+[`tr()`](https://wiki.qt.io/QtInternationalization#What_is_tr.28.29.3F) 
+macro. There is an extensive [I18N 
+Tutorial](http://doc.qt.io/qt-5/internationalization.html) for Qt, but 
+the condensed version is: When you mark a message string with `tr()`, 
+it can be translated.
+
+Whenever message strings are changed or a major feature introduces new 
+ones, you need to update the `.ts` files.
+
+To initiate a translation update, rebase your repo with the current 
+HEAD of the master branch and then do
+
+```
+  cd app/gui/qt
+  lupdate -pro SonicPi.pro -no-obsolete
+```
+
+This will update all Qt linguist files in 
+`app/gui/qt/lang/sonic-pi_<LANG>.ts` with the new message strings from 
+your code and remove obsolete entries.
+
+After that, commit the updated `.ts` files and push them back to the 
+master branch.
+
+Weblate will then fetch them automatically, translators will update 
+them and the finished translations will flow back into the master 
+repository.

--- a/TRANSLATION.md
+++ b/TRANSLATION.md
@@ -1,57 +1,68 @@
 # Translating Sonic Pi
 
-At present, you can translate the tutorial and the Qt GUI, only.
+[![Weblate](https://hosted.weblate.org/widgets/sonic-pi/-/svg-badge.svg)](https://hosted.weblate.org/engage/sonic-pi/)
 
-Translations for the tutorial are located in
-[`etc/doc/tutorial`](./etc/doc/tutorial/).
+(This document is meant for translators who want to help bring Sonic Pi 
+to their language. If you're contributing code to Sonic Pi and want to 
+make sure that your feature is translatable and the translation always 
+up-to-date, please read the primer to the [Translation 
+Workflow](TRANSLATION-WORKFLOW.md) for coders.)
 
-Translations for the Qt GUI are located in
-[`app/gui/qt/lang/sonic-pi_<LANG>.ts`](./app/gui/qt/lang/).
+Sonic Pi is designed to be used by school kids as early as primary 
+school. We want to make sure that it's usable outside the 
+English-speaking world and if you want to help kids in your country to 
+be able to play with it, please consider translating Sonic Pi to your 
+language.
 
-## Translating the tutorial
+A number of awesome contributors have already translated much of Sonic 
+Pi to their language. We always appreciate help by those willing to 
+proofread, spellcheck or update the existing translations. 
 
-- Sign up with [github](https://help.github.com/categories/bootcamp/)
-- Fork the [Sonic Pi repo](https://github.com/samaaron/sonic-pi)
-  to your own github repo, `git clone` it to your computer
-- `cd etc/doc/tutorial`
-- Want to add a new language to the tutorial? Then copy the `en/`
-  folder and add the new files to your repo with `git add <NEWLANG>/*.md`
-- When you're happy, `git commit`, `git push` to your github repo.
-- [Send a pull request](https://help.github.com/articles/creating-a-pull-request/) to the Sonic Pi repo.
+Thanks to everybody involved!
 
-## Translating the Qt GUI
+As Sonic Pi development moves fast, there are always updates to the 
+screen messages and the tutorial. To help translators keep track of 
+these changes, _we are currently moving to 
+*[Weblate](https://hosted.weblate.org/engage/sonic-pi/)*_, an 
+open-source web-based translation editor.
 
-- Sign up with [github](https://help.github.com/categories/bootcamp/)
-- Fork the [Sonic Pi repo](https://github.com/samaaron/sonic-pi)
-  to your own github repo, `git clone` it to your computer
-- [Build Sonic Pi](./INSTALL.md),
-  first the server extensions, then the Qt GUI.
-- `cd app/gui/qt`
-- Want to add a new language to the Qt GUI? Then first add a reference
-  to the new language file to `SonicPi.Pro` and `SonicPi.qrc`, then run
-  `lupdate -pro SonicPi.pro` to have the new .ts file created for you.
-- Edit the translation with Qt Linguist,
-  `linguist lang/sonic-pi_<LANG>.ts`.
-- Build a new binary, test it.
-- When you're happy, `git add` if you added a new language, then
-  `git commit`, `git push` to your github repo.
-- [Send a pull request](https://help.github.com/articles/creating-a-pull-request/) to the Sonic Pi repo.
+The nice thing about Weblate is that from now on, you don't need to be 
+a developer to help translate Sonic Pi (and you don't need to know 
+anything about github or the other tools we use during development).
 
-## Adding a new translation string to the Qt GUI
+## What you can translate
 
-Messages you want to have translated need to be marked with `tr()`
-in the source.
+The Sonic Pi Qt GUI is the application you use on your desktop screen.
+It contains few screen strings and translating it is fairly easy.
 
-If you added or changed a translation string during development,
-don't forget to run `lupdate -pro SonicPi.pro` afterwards to update
-the `.ts` files.
+The tutorial is a fairly long document. Translating it takes 
+significantly longer, but it's very rewarding as it is the best way to 
+introduce new users to Sonic Pi.
 
-Then push them back to github and ask the translators to pull and
-translate them.
+It is planned to make the language reference translatable in the 
+future, too.
 
-(The translation workflow will hopefully become much easier once
-Transifex is integrated.)
+## How to fix or contribute a translation
 
-## To-Do
+So if you want to...
 
-- Transifex integration
+- proofread an existing translation
+- correct a mistake in a translation
+- translate Sonic Pi to a whole new language
+
+...all you need to do is visit [Sonic Pi on 
+Weblate](https://hosted.weblate.org/engage/sonic-pi/), sign up and 
+follow the instructions there.
+
+_Please note_ that we are still in the process of moving to Weblate. 
+You can already translate the Qt GUI there, but the tutorial will 
+follow soon.
+
+Weblate gives you a number of helpful tools, e.g. it spots common 
+mistakes, you can keep a glossary of recurring terms and be notified 
+when a new string needs to be translated.
+
+By the way, if you spot a spelling mistake in the English texts, please 
+[file an issue](https://github.com/samaaron/sonic-pi/issues) or correct 
+it with a pull request here on github, as you cannot change those via 
+Weblate.

--- a/app/gui/qt/lang/sonic-pi_de.ts
+++ b/app/gui/qt/lang/sonic-pi_de.ts
@@ -1,33 +1,32 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0" language="de_DE">
-<defaultcodec>UTF-8</defaultcodec>
+<TS version="2.1" language="de_DE">
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../mainwindow.cpp" line="360"/>
+        <location filename="../mainwindow.cpp" line="459"/>
         <source>Preferences</source>
         <translation>Einstellungen</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="373"/>
+        <location filename="../mainwindow.cpp" line="472"/>
         <source>Log</source>
         <translation>Protokoll</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="445"/>
-        <location filename="../mainwindow.cpp" line="2152"/>
-        <location filename="../mainwindow.cpp" line="2170"/>
+        <location filename="../mainwindow.cpp" line="184"/>
+        <location filename="../mainwindow.cpp" line="2607"/>
+        <location filename="../mainwindow.cpp" line="2627"/>
         <source>Sonic Pi</source>
         <translation>Sonic Pi</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="803"/>
+        <location filename="../mainwindow.cpp" line="911"/>
         <source>Raspberry Pi System Volume</source>
         <translation>Raspberry Pi Lautstärke</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="809"/>
+        <location filename="../mainwindow.cpp" line="917"/>
         <source>Toggle stereo inversion.
 If enabled, audio sent to the left speaker will
 be routed to the right speaker and visa versa.</source>
@@ -36,7 +35,7 @@ Der Ton des linken Kanals wird zum rechten
 Lautsprecher geschickt und umgekehrt.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="812"/>
+        <location filename="../mainwindow.cpp" line="920"/>
         <source>Toggle mono mode.
 If enabled both right and left audio is mixed and
 the same signal is sent to both speakers.
@@ -50,32 +49,32 @@ Praktisch, wenn der externe Verstärker nur
 Mono-Ton verarbeiten kann.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="828"/>
+        <location filename="../mainwindow.cpp" line="933"/>
         <source>Raspberry Pi Audio Output</source>
         <translation>Raspberry Pi Audio-Ausgabe</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="830"/>
+        <location filename="../mainwindow.cpp" line="935"/>
         <source>&amp;Default</source>
         <translation>&amp;Standard</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="831"/>
+        <location filename="../mainwindow.cpp" line="936"/>
         <source>&amp;Headphones</source>
         <translation>&amp;Kopfhörerbuchse</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="832"/>
+        <location filename="../mainwindow.cpp" line="937"/>
         <source>&amp;HDMI</source>
         <translation>&amp;HDMI</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="853"/>
+        <location filename="../mainwindow.cpp" line="958"/>
         <source>Configure debug behaviour</source>
         <translation>Debug-Optionen bearbeiten</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="856"/>
+        <location filename="../mainwindow.cpp" line="964"/>
         <source>Toggle log messages.
 If disabled, activity such as synth and sample
 triggering will not be printed to the log by default.</source>
@@ -84,17 +83,17 @@ Die Protokoll-Nachrichten, wenn ein Synth oder
 Sample ausgelöst wird, lassen sich hier abschalten.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="815"/>
+        <location filename="../mainwindow.cpp" line="976"/>
         <source>Safe mode</source>
         <translation>Sichere Synth-Parameter</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="858"/>
+        <location filename="../mainwindow.cpp" line="966"/>
         <source>Clear log on run</source>
         <translation>Protokoll vor Ausführen leeren</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="859"/>
+        <location filename="../mainwindow.cpp" line="967"/>
         <source>Toggle log clearing on run.
 If enabled, the log is cleared each
 time the run button is pressed.</source>
@@ -103,78 +102,73 @@ Löscht das alte Protokoll bei jedem
 Klick auf den Ausführen-Button.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="924"/>
+        <location filename="../mainwindow.cpp" line="1054"/>
         <source>Toggle line number visibility.</source>
         <translation>Anzeige der Zeilennummern an-/abschalten.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="936"/>
+        <location filename="../mainwindow.cpp" line="1066"/>
         <source>Dark mode</source>
         <translation>Dunkle Oberfläche</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1249"/>
+        <location filename="../mainwindow.cpp" line="1447"/>
         <source>Running Code...</source>
         <oldsource>Running Code....</oldsource>
         <translation>Führe Programm aus...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1305"/>
+        <location filename="../mainwindow.cpp" line="1510"/>
         <source>Beautifying...</source>
         <oldsource>Beautifying....</oldsource>
         <translation>Textausrichtung...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1325"/>
+        <location filename="../mainwindow.cpp" line="1530"/>
         <source>Reloading...</source>
         <oldsource>Reloading....</oldsource>
         <translation>Neu laden...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1356"/>
+        <location filename="../mainwindow.cpp" line="1561"/>
         <source>Enabling Mixer HPF...</source>
         <oldsource>Enabling Mixer HPF....</oldsource>
         <translation>Mixer-Hochpassfilter aktiv...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1365"/>
+        <location filename="../mainwindow.cpp" line="1570"/>
         <source>Disabling Mixer HPF...</source>
         <oldsource>Disabling Mixer HPF....</oldsource>
         <translation>Mixer-Hochpassfilter inaktiv...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1275"/>
-        <source>Workspace %1</source>
-        <translation>Arbeitsbereich %1</translation>
-    </message>
-    <message>
-        <location filename="../mainwindow.cpp" line="296"/>
+        <location filename="../mainwindow.cpp" line="387"/>
         <source>Buffer %1</source>
         <translation>Buffer %1</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="459"/>
+        <location filename="../mainwindow.cpp" line="235"/>
         <source>Welcome to Sonic Pi</source>
         <translation>Sonic Pi begrüßt Dich!</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="601"/>
+        <location filename="../mainwindow.cpp" line="708"/>
         <source>Indenting selection...</source>
         <translation>Auswahl einrücken...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="605"/>
+        <location filename="../mainwindow.cpp" line="712"/>
         <source>Indenting line...</source>
         <translation>Zeile einrücken...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="804"/>
+        <location filename="../mainwindow.cpp" line="912"/>
         <source>Use this slider to change the system volume of your Raspberry Pi.</source>
         <oldsource>Use this slider to change the system volume of your Raspberry Pi</oldsource>
         <translation>Hier veränderst Du die Systemlautstärke Deines Raspberry Pi.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="807"/>
+        <location filename="../mainwindow.cpp" line="915"/>
         <source>Advanced audio settings for working with
 external PA systems when performing with Sonic Pi.</source>
         <oldsource>Advanced audio settings for working with external PA systems when performing with Sonic Pi.</oldsource>
@@ -182,17 +176,7 @@ external PA systems when performing with Sonic Pi.</source>
 an einem externen Verstärker gut gebrauchen kann.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="808"/>
-        <source>Invert Stereo</source>
-        <translation>Stereokanäle tauschen</translation>
-    </message>
-    <message>
-        <location filename="../mainwindow.cpp" line="811"/>
-        <source>Force Mono</source>
-        <translation>Mono-Ton erzwingen</translation>
-    </message>
-    <message>
-        <location filename="../mainwindow.cpp" line="829"/>
+        <location filename="../mainwindow.cpp" line="934"/>
         <source>Your Raspberry Pi has two forms of audio output.
 Firstly, there is the headphone jack of the Raspberry Pi itself.
 Secondly, some HDMI monitors/TVs support audio through the HDMI port.
@@ -208,53 +192,38 @@ Zweitens: Der digitale HDMI-Monitoranschluss, der den Ton zum Monitor/Fernseher 
 Hier wählst Du aus, über welchen davon die Tonausgabe gehen soll.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="882"/>
-        <location filename="../mainwindow.cpp" line="1004"/>
+        <location filename="../mainwindow.cpp" line="1012"/>
+        <location filename="../mainwindow.cpp" line="1144"/>
         <source>Updates</source>
         <translation>Updates</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="884"/>
+        <location filename="../mainwindow.cpp" line="1014"/>
         <source>Check for updates</source>
         <translation>Auf Updates prüfen</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="988"/>
+        <location filename="../mainwindow.cpp" line="1118"/>
         <source>Editor</source>
         <translation>Editor</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="923"/>
+        <location filename="../mainwindow.cpp" line="1053"/>
         <source>Show line numbers</source>
         <translation>Zeilennummern anzeigen</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="153"/>
+        <location filename="../mainwindow.cpp" line="277"/>
         <source>Sonic Pi update info</source>
         <translation>Sonic Pi Update-Info</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="634"/>
-        <source>Commenting selection...</source>
-        <translation>Auswahl auskommentieren...</translation>
-    </message>
-    <message>
-        <location filename="../mainwindow.cpp" line="638"/>
-        <source>Commenting line...</source>
-        <translation>Zeile auskommentieren...</translation>
-    </message>
-    <message>
-        <location filename="../mainwindow.cpp" line="717"/>
-        <source>Ruby could not be started, is it installed and in your PATH?</source>
-        <translation>Konnte ruby nicht starten, ist es korrekt installiert?</translation>
-    </message>
-    <message>
-        <location filename="../mainwindow.cpp" line="806"/>
+        <location filename="../mainwindow.cpp" line="914"/>
         <source>Advanced Audio</source>
         <translation>Erweiterte Audio-Einstellungen</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="816"/>
+        <location filename="../mainwindow.cpp" line="977"/>
         <source>Toggle synth argument checking functions.
 If disabled, certain synth opt values may
 create unexpectedly loud or uncomfortable sounds.</source>
@@ -263,22 +232,63 @@ Ohne diese Prüfung können Synth-Werte auch mal
 unerwartet laute oder unangenehme Sounds erzeugen.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="852"/>
+        <location filename="../mainwindow.cpp" line="957"/>
         <source>Logging</source>
         <translation>Protokollieren</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="855"/>
+        <location filename="../mainwindow.cpp" line="452"/>
+        <location filename="../mainwindow.cpp" line="2360"/>
+        <source>Scope</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="741"/>
+        <source>Toggle selection comment...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="745"/>
+        <source>Toggle line comment...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="803"/>
+        <source>The Sonic Pi Server could not be started!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="916"/>
+        <source>Invert stereo</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="919"/>
+        <source>Force mono</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="960"/>
+        <source>Synths and FX</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="961"/>
+        <source>Modify behaviour of synths and FX</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="963"/>
         <source>Log synths</source>
         <translation>Synths protokollieren</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="861"/>
+        <location filename="../mainwindow.cpp" line="969"/>
         <source>Log cues</source>
         <translation>Einsatz protokollieren</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="862"/>
+        <location filename="../mainwindow.cpp" line="970"/>
         <source>Enable or disable logging of cues.
 If disabled, cues will still trigger.
 However, they will not be visible in the logs.</source>
@@ -287,503 +297,608 @@ Falls deaktiviert, wird der Einsatz weiterhin ausgelöst.
 Dennoch sind sie im Protokoll nicht mehr sichtbar.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="871"/>
+        <location filename="../mainwindow.cpp" line="972"/>
+        <source>Log auto scroll</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="973"/>
+        <source>Toggle log auto scrolling.
+If enabled the log is scrolled to the bottom after every new message is displayed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="980"/>
+        <source>Enable external synths and FX</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="981"/>
+        <source>When enabled, Sonic Pi will allow
+synths and FX loaded via load_synthdefs
+to be triggered.
+
+When disabled, Sonic Pi will complain
+when you attempt to use a synth or FX
+which isn&apos;t recognised.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="983"/>
+        <source>Enforce timing guarantees</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="984"/>
+        <source>When enabled, Sonic Pi will refuse
+to trigger synths and FX if
+it is too late to do so
+
+When disabled, Sonic Pi will always
+attempt to trigger synths and FX
+even when a little late.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1001"/>
         <source>Transparency</source>
         <translation>Transparenz</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="886"/>
+        <location filename="../mainwindow.cpp" line="1016"/>
         <source>Toggle automatic update checking.
 This check involves sending anonymous information about your platform and version.</source>
         <translation>Automatisches Suchen nach Updates aktivieren.
 Diese Suche versendet anonyme Informationen über Deine Plattform und Version.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="887"/>
+        <location filename="../mainwindow.cpp" line="1017"/>
         <source>Check now</source>
         <translation>Jetzt prüfen</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="888"/>
+        <location filename="../mainwindow.cpp" line="1018"/>
         <source>Force a check for updates now.
 This check involves sending anonymous information about your platform and version.</source>
         <translation>Jetzt nach Updates suchen.
 Diese Suche versendet anonyme Informationen über Deine Plattform und Version.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="889"/>
+        <location filename="../mainwindow.cpp" line="1019"/>
         <source>Get update</source>
         <translation>Update herunterladen</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="890"/>
+        <location filename="../mainwindow.cpp" line="1020"/>
         <source>Visit http://sonic-pi.net to download new version</source>
         <translation>Besuche http://sonic-pi.net, um die neue Version herunterzuladen</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="895"/>
+        <location filename="../mainwindow.cpp" line="1025"/>
         <source>Update Info</source>
         <translation>Update-Info</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="914"/>
+        <location filename="../mainwindow.cpp" line="1044"/>
         <source>Show and Hide</source>
         <translation>Ein-/Ausblenden</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="915"/>
+        <location filename="../mainwindow.cpp" line="1045"/>
         <source>Configure editor display options.</source>
         <translation>Ansichtsoptionen für das Editorfenster konfigurieren.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="916"/>
+        <location filename="../mainwindow.cpp" line="1046"/>
         <source>Look and Feel</source>
         <translation>Darstellung</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="917"/>
+        <location filename="../mainwindow.cpp" line="1047"/>
         <source>Configure editor look and feel.</source>
         <translation>Darstellung für das Editorfenster konfigurieren.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="918"/>
+        <location filename="../mainwindow.cpp" line="1048"/>
         <source>Automation</source>
         <translation>Automatismen</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="919"/>
+        <location filename="../mainwindow.cpp" line="1049"/>
         <source>Configure automation features.</source>
         <translation>Konfigurieren von praktischen automatischen Vorgängen</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="920"/>
+        <location filename="../mainwindow.cpp" line="1050"/>
         <source>Auto-align</source>
         <translation>Auto-Ausrichtung</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="921"/>
+        <location filename="../mainwindow.cpp" line="1051"/>
         <source>Automatically align code on Run</source>
         <translation>Lasse den Code beim Start automatisch ausrichten.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="925"/>
+        <location filename="../mainwindow.cpp" line="1055"/>
         <source>Show log</source>
         <translation>Protokollfenster anzeigen</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="926"/>
+        <location filename="../mainwindow.cpp" line="1056"/>
         <source>Toggle visibility of the log.</source>
         <translation>Protokollfenster anzeigen.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="928"/>
+        <location filename="../mainwindow.cpp" line="1058"/>
         <source>Show buttons</source>
         <translation>Menüleiste anzeigen</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="929"/>
+        <location filename="../mainwindow.cpp" line="1059"/>
         <source>Toggle visibility of the control buttons.</source>
         <translation>Menüleiste anzeigen.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="931"/>
+        <location filename="../mainwindow.cpp" line="1061"/>
         <source>Show tabs</source>
         <translation>Tabs anzeigen</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="933"/>
+        <location filename="../mainwindow.cpp" line="1063"/>
         <source>Toggle visibility of the buffer selection tabs.</source>
         <translation>Buffer-Auswahl anzeigen.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="934"/>
+        <location filename="../mainwindow.cpp" line="1064"/>
         <source>Full screen</source>
         <translation>Vollbild</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="935"/>
+        <location filename="../mainwindow.cpp" line="1065"/>
         <source>Toggle full screen mode.</source>
         <translation>In den Vollbildmodus umschalten.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="937"/>
+        <location filename="../mainwindow.cpp" line="1067"/>
         <source>Toggle dark mode.</source>
         <translation>Zu dunkler Oberfläche umschalten.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="937"/>
+        <location filename="../mainwindow.cpp" line="1067"/>
         <source>
 Dark mode is perfect for live coding in night clubs.</source>
         <translation>
 Die dunkle Oberfläche eignet sich hervorragend zum Live-Coden in Nachtklubs.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="976"/>
+        <location filename="../mainwindow.cpp" line="1106"/>
         <source>Audio</source>
         <translation>Audio</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="989"/>
+        <location filename="../mainwindow.cpp" line="1119"/>
         <source>Studio</source>
         <translation>Studio</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2448"/>
+        <location filename="../mainwindow.cpp" line="1259"/>
+        <source>Sonic Pi Boot Error
+
+Apologies, a critical error occurred during startup</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1361"/>
+        <location filename="../mainwindow.cpp" line="1362"/>
+        <location filename="../mainwindow.cpp" line="1374"/>
+        <location filename="../mainwindow.cpp" line="1375"/>
+        <source>Buffer files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1362"/>
+        <source>Load Sonic Pi Buffer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1362"/>
+        <location filename="../mainwindow.cpp" line="1375"/>
+        <source>Text files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1362"/>
+        <location filename="../mainwindow.cpp" line="1375"/>
+        <source>Ruby files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1362"/>
+        <location filename="../mainwindow.cpp" line="1375"/>
+        <source>All files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1752"/>
+        <source>Log Auto Scroll on...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1754"/>
+        <source>Log Auto Scroll off...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2338"/>
+        <source>Run the code in the current buffer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2351"/>
+        <source>Load</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2352"/>
+        <source>Load an external file in the current buffer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2361"/>
+        <source>View audio output</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2508"/>
+        <source>Wavefile (*.wav)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2908"/>
         <source>Welcome back. Now get your live code on...</source>
         <translation>Willkommen zurück. Legen wir los mit dem Live-Code...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1181"/>
+        <location filename="../mainwindow.cpp" line="1375"/>
         <source>Save Current Buffer</source>
         <translation>Aktuellen Buffer speichern</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1291"/>
+        <location filename="../mainwindow.cpp" line="1496"/>
         <source>Zooming In...</source>
         <translation>Text vergrößern...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1298"/>
+        <location filename="../mainwindow.cpp" line="1503"/>
         <source>Zooming Out...</source>
         <translation>Text verkleinern...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1332"/>
+        <location filename="../mainwindow.cpp" line="1537"/>
         <source>Checking for updates...</source>
         <translation>Auf Updates prüfen...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1340"/>
+        <location filename="../mainwindow.cpp" line="1545"/>
         <source>Enabling update checking...</source>
         <translation>Update-Prüfung aktiv...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1348"/>
+        <location filename="../mainwindow.cpp" line="1553"/>
         <source>Disabling update checking...</source>
         <translation>Update-Prüfung inaktiv...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1373"/>
+        <location filename="../mainwindow.cpp" line="1578"/>
         <source>Enabling Mixer LPF...</source>
         <oldsource>Enabling Mixer LPF....</oldsource>
         <translation>Mixer-Tiefpassfilter aktiv...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1382"/>
+        <location filename="../mainwindow.cpp" line="1587"/>
         <source>Disabling Mixer LPF...</source>
         <oldsource>Disabling Mixer LPF....</oldsource>
         <translation>Mixer-Tiefpassfilter inaktiv...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1390"/>
+        <location filename="../mainwindow.cpp" line="1595"/>
         <source>Enabling Inverted Stereo...</source>
         <oldsource>Enabling Inverted Stereo....</oldsource>
         <translation>Stereo-Kanaltausch aktiv...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1398"/>
+        <location filename="../mainwindow.cpp" line="1603"/>
         <source>Enabling Standard Stereo...</source>
         <oldsource>Enabling Standard Stereo....</oldsource>
         <translation>Stereo-Kanaltausch inaktiv...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1406"/>
+        <location filename="../mainwindow.cpp" line="1611"/>
         <source>Mono Mode...</source>
         <oldsource>Mono Mode....</oldsource>
         <translation>Mono-Ton aktiv...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1414"/>
+        <location filename="../mainwindow.cpp" line="1619"/>
         <source>Stereo Mode...</source>
         <oldsource>Stereo Mode....</oldsource>
         <translation>Stereo-Ton aktiv...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1423"/>
+        <location filename="../mainwindow.cpp" line="1628"/>
         <source>Stopping...</source>
         <translation>Stopp...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1507"/>
+        <location filename="../mainwindow.cpp" line="1736"/>
         <source>Updating System Volume...</source>
         <translation>Setze System-Lautstärke...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1729"/>
+        <location filename="../mainwindow.cpp" line="2155"/>
         <source>Switching To Headphone Audio Output...</source>
         <translation>Umschalten auf Kopfhörerbuchse...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1745"/>
+        <location filename="../mainwindow.cpp" line="2171"/>
         <source>Switching To HDMI Audio Output...</source>
         <translation>Umschalten auf HDMI-Anschluss...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1760"/>
+        <location filename="../mainwindow.cpp" line="2186"/>
         <source>Switching To Default Audio Output...</source>
         <translation>Umschalten auf Standard-Tonausgabe...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1912"/>
+        <location filename="../mainwindow.cpp" line="2348"/>
         <source>Save current buffer as an external file</source>
         <translation>Aktuellen Buffer als externe Datei speichern</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1930"/>
+        <location filename="../mainwindow.cpp" line="2374"/>
         <source>Start recording to WAV audio file</source>
         <translation>Tonausgabe in WAV-Datei aufnehmen</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1935"/>
+        <location filename="../mainwindow.cpp" line="2379"/>
         <source>Improve readability of code</source>
         <translation>Lesbarkeit des Codes verbessern</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2076"/>
+        <location filename="../mainwindow.cpp" line="2527"/>
         <source>Ready...</source>
         <translation>Bereit...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2163"/>
+        <location filename="../mainwindow.cpp" line="2619"/>
         <source>File loaded...</source>
         <translation>Datei geladen...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2188"/>
+        <location filename="../mainwindow.cpp" line="2646"/>
         <source>File saved...</source>
         <translation>Datei gespeichert...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2413"/>
+        <location filename="../mainwindow.cpp" line="2873"/>
         <source>Last checked %1</source>
         <translation>Zuletzt überprüft am %1</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2415"/>
+        <location filename="../mainwindow.cpp" line="2875"/>
         <source>Sonic Pi checks for updates
 every two weeks.</source>
         <translation>Sonic Pi sucht alle zwei Wochen nach Aktualisierungen.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2417"/>
+        <location filename="../mainwindow.cpp" line="2877"/>
         <source>This is Sonic Pi %1</source>
         <translation>Dies ist Sonic Pi %1</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2418"/>
+        <location filename="../mainwindow.cpp" line="2878"/>
         <source>Version %2 is now available!</source>
         <translation>Version %2 ist jetzt verfügbar!</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2422"/>
+        <location filename="../mainwindow.cpp" line="2882"/>
         <source>New version available!
 Get Sonic Pi %1</source>
         <translation>Eine neue Version ist verfügbar! Lade Sonic Pi %1 herunter</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1902"/>
+        <location filename="../mainwindow.cpp" line="2337"/>
         <source>Run</source>
         <translation>Ausführen</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1903"/>
-        <source>Run the code in the current workspace</source>
-        <translation>Das Programm im aktuellen Arbeitsbereich ausführen</translation>
-    </message>
-    <message>
-        <location filename="../mainwindow.cpp" line="1907"/>
+        <location filename="../mainwindow.cpp" line="2343"/>
         <source>Stop</source>
         <translation>Stopp</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1908"/>
+        <location filename="../mainwindow.cpp" line="2344"/>
         <source>Stop all running code</source>
         <translation>Alle laufenden Programme beenden</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1911"/>
+        <location filename="../mainwindow.cpp" line="2347"/>
         <source>Save As...</source>
         <translation>Speichern als...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1915"/>
+        <location filename="../mainwindow.cpp" line="2355"/>
         <source>Info</source>
         <translation>Info</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1916"/>
+        <location filename="../mainwindow.cpp" line="2356"/>
         <source>See information about Sonic Pi</source>
         <translation>Einige Informationen über Sonic Pi</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="414"/>
-        <location filename="../mainwindow.cpp" line="1920"/>
+        <location filename="../mainwindow.cpp" line="513"/>
+        <location filename="../mainwindow.cpp" line="2364"/>
         <source>Help</source>
         <translation>Hilfe</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="991"/>
-        <location filename="../mainwindow.cpp" line="996"/>
+        <location filename="../mainwindow.cpp" line="1121"/>
+        <location filename="../mainwindow.cpp" line="1131"/>
         <source>Performance</source>
         <translation>Auftritt</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="992"/>
+        <location filename="../mainwindow.cpp" line="1122"/>
         <source>Settings useful for performing with Sonic Pi</source>
         <translation>Praktische Einstellungen für die Bühne</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1087"/>
+        <location filename="../mainwindow.cpp" line="1259"/>
         <source>Server boot error...</source>
         <translation>Fehler bei Server-Start...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1087"/>
-        <source>Apologies, a critical error occurred during startup</source>
-        <translation>Entschuldigung, beim Start ging etwas schief</translation>
-    </message>
-    <message>
-        <location filename="../mainwindow.cpp" line="1087"/>
+        <location filename="../mainwindow.cpp" line="1259"/>
         <source>Please consider reporting a bug at</source>
         <translation>Bitte melde den Fehler doch auf</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1921"/>
+        <location filename="../mainwindow.cpp" line="2365"/>
         <source>Toggle help pane</source>
         <translation>Hilfetexte anzeigen</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1924"/>
+        <location filename="../mainwindow.cpp" line="2368"/>
         <source>Prefs</source>
         <translation>Einstellungen</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1925"/>
+        <location filename="../mainwindow.cpp" line="2369"/>
         <source>Toggle preferences pane</source>
         <translation>Einstellungen anzeigen</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1929"/>
-        <location filename="../mainwindow.cpp" line="2051"/>
-        <location filename="../mainwindow.cpp" line="2052"/>
+        <location filename="../mainwindow.cpp" line="2373"/>
+        <location filename="../mainwindow.cpp" line="2502"/>
+        <location filename="../mainwindow.cpp" line="2503"/>
         <source>Start Recording</source>
         <translation>Aufnahme starten</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1934"/>
+        <location filename="../mainwindow.cpp" line="2378"/>
         <source>Auto-Align Text</source>
         <oldsource>Auto Align Text</oldsource>
         <translation>Text automatisch ausrichten</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1939"/>
-        <location filename="../mainwindow.cpp" line="1940"/>
+        <location filename="../mainwindow.cpp" line="2385"/>
         <source>Increase Text Size</source>
         <translation>Text vergrößern</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1944"/>
-        <location filename="../mainwindow.cpp" line="1945"/>
+        <location filename="../mainwindow.cpp" line="2392"/>
         <source>Decrease Text Size</source>
         <translation>Text verkleinern</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1950"/>
+        <location filename="../mainwindow.cpp" line="2397"/>
         <source>Tools</source>
         <translation>Werkzeuge</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1997"/>
+        <location filename="../mainwindow.cpp" line="2448"/>
         <source>About</source>
         <translation>Über Sonic Pi</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1998"/>
+        <location filename="../mainwindow.cpp" line="2449"/>
         <source>Core Team</source>
         <translation>Kern-Team</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1999"/>
+        <location filename="../mainwindow.cpp" line="2450"/>
         <source>Contributors</source>
         <translation>Mitwirkende</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2000"/>
+        <location filename="../mainwindow.cpp" line="2451"/>
         <source>Community</source>
         <translation>Gemeinschaft</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2001"/>
+        <location filename="../mainwindow.cpp" line="2452"/>
         <source>License</source>
         <translation>Lizenz</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2002"/>
+        <location filename="../mainwindow.cpp" line="2453"/>
         <source>History</source>
         <translation>Änderungen</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2023"/>
+        <location filename="../mainwindow.cpp" line="2474"/>
         <source>Sonic Pi - Info</source>
         <translation>Über Sonic Pi</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2043"/>
-        <location filename="../mainwindow.cpp" line="2044"/>
+        <location filename="../mainwindow.cpp" line="2494"/>
+        <location filename="../mainwindow.cpp" line="2495"/>
         <source>Stop Recording</source>
         <translation>Aufnahme stoppen</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2057"/>
+        <location filename="../mainwindow.cpp" line="2508"/>
         <source>Save Recording</source>
         <translation>Aufnahme speichern</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2153"/>
+        <location filename="../mainwindow.cpp" line="2608"/>
         <source>Cannot read file %1:
 %2.</source>
         <translation>Kann Datei %1 nicht laden:
 %2.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2171"/>
+        <location filename="../mainwindow.cpp" line="2628"/>
         <source>Cannot write file %1:
 %2.</source>
         <translation>Kann Datei %1 nicht schreiben:
 %2.</translation>
     </message>
     <message>
-        <location filename="../ruby_help.h" line="80"/>
-        <location filename="../ruby_help.h" line="139"/>
-        <location filename="../ruby_help.h" line="199"/>
-        <location filename="../ruby_help.h" line="218"/>
-        <location filename="../ruby_help.h" line="278"/>
-        <location filename="../ruby_help.h" line="338"/>
+        <location filename="../ruby_help.h" line="93"/>
+        <location filename="../ruby_help.h" line="154"/>
+        <location filename="../ruby_help.h" line="215"/>
+        <location filename="../ruby_help.h" line="274"/>
+        <location filename="../ruby_help.h" line="293"/>
+        <location filename="../ruby_help.h" line="367"/>
+        <location filename="../ruby_help.h" line="442"/>
         <source>Tutorial</source>
         <translation>Tutorial</translation>
     </message>
     <message>
-        <location filename="../ruby_help.h" line="370"/>
+        <location filename="../ruby_help.h" line="476"/>
         <source>Examples</source>
         <translation>Beispiele</translation>
     </message>
     <message>
-        <location filename="../ruby_help.h" line="410"/>
+        <location filename="../ruby_help.h" line="522"/>
         <source>Synths</source>
         <translation>Synths</translation>
     </message>
     <message>
-        <location filename="../ruby_help.h" line="446"/>
+        <location filename="../ruby_help.h" line="564"/>
         <source>Fx</source>
         <translation>Fx</translation>
     </message>
     <message>
-        <location filename="../ruby_help.h" line="463"/>
+        <location filename="../ruby_help.h" line="583"/>
         <source>Samples</source>
         <translation>Samples</translation>
     </message>
     <message>
-        <location filename="../ruby_help.h" line="629"/>
+        <location filename="../ruby_help.h" line="779"/>
         <source>Lang</source>
         <translation>Lang</translation>
     </message>
@@ -797,11 +912,11 @@ Get Sonic Pi %1</source>
     </message>
 </context>
 <context>
-    <name>SonicPiUDPServer</name>
+    <name>SonicPiUDPOSCServer</name>
     <message>
-        <location filename="../sonicpiudpserver.cpp" line="24"/>
+        <location filename="../sonic_pi_udp_osc_server.cpp" line="38"/>
         <source>Is Sonic Pi already running?  Can&apos;t open UDP port 4558.</source>
-        <translation>Läuft Sonic Pi bereits?  Konnte UDP-Port 4558 nicht öffnen.</translation>
+        <translation type="unfinished">Läuft Sonic Pi bereits?  Konnte UDP-Port 4558 nicht öffnen.</translation>
     </message>
 </context>
 </TS>

--- a/app/gui/qt/lang/sonic-pi_es.ts
+++ b/app/gui/qt/lang/sonic-pi_es.ts
@@ -1,91 +1,80 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0" language="es_ES">
-<defaultcodec>UTF-8</defaultcodec>
+<TS version="2.1" language="es_ES">
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../mainwindow.cpp" line="152"/>
+        <location filename="../mainwindow.cpp" line="277"/>
         <source>Sonic Pi update info</source>
         <translation>Información de actualización de Sonic Pi</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="295"/>
+        <location filename="../mainwindow.cpp" line="387"/>
         <source>Buffer %1</source>
         <translation>Buffer %1</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="350"/>
+        <location filename="../mainwindow.cpp" line="459"/>
         <source>Preferences</source>
         <translation>Preferencias</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="363"/>
+        <location filename="../mainwindow.cpp" line="472"/>
         <source>Log</source>
         <translation>Log</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="401"/>
-        <location filename="../mainwindow.cpp" line="1841"/>
+        <location filename="../mainwindow.cpp" line="513"/>
+        <location filename="../mainwindow.cpp" line="2364"/>
         <source>Help</source>
         <translation>Ayuda</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="432"/>
-        <location filename="../mainwindow.cpp" line="2073"/>
-        <location filename="../mainwindow.cpp" line="2091"/>
+        <location filename="../mainwindow.cpp" line="184"/>
+        <location filename="../mainwindow.cpp" line="2607"/>
+        <location filename="../mainwindow.cpp" line="2627"/>
         <source>Sonic Pi</source>
         <translation>Sonic Pi</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="446"/>
+        <location filename="../mainwindow.cpp" line="235"/>
         <source>Welcome to Sonic Pi</source>
         <translation>Bienvenido a Sonic Pi</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="584"/>
+        <location filename="../mainwindow.cpp" line="708"/>
         <source>Indenting selection...</source>
         <translation>Indentando selección...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="588"/>
+        <location filename="../mainwindow.cpp" line="712"/>
         <source>Indenting line...</source>
         <translation>Indentando linea...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="667"/>
-        <source>Ruby could not be started, is it installed and in your PATH?</source>
-        <translation>Ruby no pudo ser iniciado, ¿estás seguro de que está instalado y de que se encuentra en tu PATH?</translation>
-    </message>
-    <message>
-        <location filename="../mainwindow.cpp" line="753"/>
+        <location filename="../mainwindow.cpp" line="911"/>
         <source>Raspberry Pi System Volume</source>
         <translation>Sistema de Volumen de Raspberry Pi</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="754"/>
+        <location filename="../mainwindow.cpp" line="912"/>
         <source>Use this slider to change the system volume of your Raspberry Pi.</source>
-        <translation>Usa este "slider" para cambiar el volumen del sistema en tu Raspberry Pi.</translation>
+        <translation>Usa este &quot;slider&quot; para cambiar el volumen del sistema en tu Raspberry Pi.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="756"/>
+        <location filename="../mainwindow.cpp" line="914"/>
         <source>Advanced Audio</source>
         <translation>Audio Avanzado</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="757"/>
+        <location filename="../mainwindow.cpp" line="915"/>
         <source>Advanced audio settings for working with
 external PA systems when performing with Sonic Pi.</source>
         <translation>Configuraciones de audio avanzadas para trabajar con 
 sistemas externos PA al momento de hacer performing con Sonic Pi.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="758"/>
-        <source>Invert Stereo</source>
-        <translation>Estéreo Invertido</translation>
-    </message>
-    <message>
-        <location filename="../mainwindow.cpp" line="759"/>
+        <location filename="../mainwindow.cpp" line="917"/>
         <source>Toggle stereo inversion.
 If enabled, audio sent to the left speaker will
 be routed to the right speaker and visa versa.</source>
@@ -94,11 +83,7 @@ Si se encuentra activado, el audio del altavoz izquierdo
 se desviará al altavoz derecho, o viceversa.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="761"/>
-        <source>Force Mono</source>
-        <translation>Forzar Mono</translation> </message>
-    <message>
-        <location filename="../mainwindow.cpp" line="762"/>
+        <location filename="../mainwindow.cpp" line="920"/>
         <source>Toggle mono mode.
 If enabled both right and left audio is mixed and
 the same signal is sent to both speakers.
@@ -110,12 +95,12 @@ y enviará la misma señal en ambos altavoces. Esto es útil cuando se trabaja c
 sistemas externos que solo soportan mono.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="765"/>
+        <location filename="../mainwindow.cpp" line="976"/>
         <source>Safe mode</source>
         <translation>Modo Seguro</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="766"/>
+        <location filename="../mainwindow.cpp" line="977"/>
         <source>Toggle synth argument checking functions.
 If disabled, certain synth opt values may
 create unexpectedly loud or uncomfortable sounds.</source>
@@ -124,12 +109,43 @@ Si se encuentra deshabilitado, ciertas opciones generarán sonidos muy
 fuertes o incómodos.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="778"/>
+        <location filename="../mainwindow.cpp" line="933"/>
         <source>Raspberry Pi Audio Output</source>
         <translation>Salida de Audio Raspberry Pi</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="779"/>
+        <location filename="../mainwindow.cpp" line="452"/>
+        <location filename="../mainwindow.cpp" line="2360"/>
+        <source>Scope</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="741"/>
+        <source>Toggle selection comment...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="745"/>
+        <source>Toggle line comment...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="803"/>
+        <source>The Sonic Pi Server could not be started!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="916"/>
+        <source>Invert stereo</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="919"/>
+        <source>Force mono</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="934"/>
         <source>Your Raspberry Pi has two forms of audio output.
 Firstly, there is the headphone jack of the Raspberry Pi itself.
 Secondly, some HDMI monitors/TVs support audio through the HDMI port.
@@ -140,37 +156,47 @@ Segundo, algunos monitores HDMI soportan salida de audio por medio del puerto HD
 Usa estos botones para forzar la salida de audio en alguna de estas dos opciones.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="780"/>
+        <location filename="../mainwindow.cpp" line="935"/>
         <source>&amp;Default</source>
         <translation>&amp;Por defecto</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="781"/>
+        <location filename="../mainwindow.cpp" line="936"/>
         <source>&amp;Headphones</source>
         <translation>&amp;Auriculares</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="782"/>
+        <location filename="../mainwindow.cpp" line="937"/>
         <source>&amp;HDMI</source>
         <translation>&amp;HDMI</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="802"/>
+        <location filename="../mainwindow.cpp" line="957"/>
         <source>Logging</source>
         <translation>Acceso</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="803"/>
+        <location filename="../mainwindow.cpp" line="958"/>
         <source>Configure debug behaviour</source>
         <translation>Configurar comportamiento en depuración</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="805"/>
+        <location filename="../mainwindow.cpp" line="960"/>
+        <source>Synths and FX</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="961"/>
+        <source>Modify behaviour of synths and FX</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="963"/>
         <source>Log synths</source>
         <translation>Registro de sintetizador</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="806"/>
+        <location filename="../mainwindow.cpp" line="964"/>
         <source>Toggle log messages.
 If disabled, activity such as synth and sample
 triggering will not be printed to the log by default.</source>
@@ -179,12 +205,12 @@ Si esta opción está deshabilitada, actividades como el disparador del sintetiz
 o muestra no se imprimirán en el registro por defecto.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="808"/>
+        <location filename="../mainwindow.cpp" line="966"/>
         <source>Clear log on run</source>
         <translation>Limpiar registro al iniciar</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="809"/>
+        <location filename="../mainwindow.cpp" line="967"/>
         <source>Toggle log clearing on run.
 If enabled, the log is cleared each
 time the run button is pressed.</source>
@@ -193,12 +219,12 @@ Si se encuentra habilitado, el registro se limpiará
 cada vez que se presione el botón de iniciar.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="811"/>
+        <location filename="../mainwindow.cpp" line="969"/>
         <source>Log cues</source>
         <translation>Registro de señales</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="812"/>
+        <location filename="../mainwindow.cpp" line="970"/>
         <source>Enable or disable logging of cues.
 If disabled, cues will still trigger.
 However, they will not be visible in the logs.</source>
@@ -207,534 +233,652 @@ Si se deshabilita, las señales se inicializarán normalmente
 pero no se podrán visualizar en los registros.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="823"/>
-        <location filename="../mainwindow.cpp" line="938"/>
+        <location filename="../mainwindow.cpp" line="972"/>
+        <source>Log auto scroll</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="973"/>
+        <source>Toggle log auto scrolling.
+If enabled the log is scrolled to the bottom after every new message is displayed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="980"/>
+        <source>Enable external synths and FX</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="981"/>
+        <source>When enabled, Sonic Pi will allow
+synths and FX loaded via load_synthdefs
+to be triggered.
+
+When disabled, Sonic Pi will complain
+when you attempt to use a synth or FX
+which isn&apos;t recognised.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="983"/>
+        <source>Enforce timing guarantees</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="984"/>
+        <source>When enabled, Sonic Pi will refuse
+to trigger synths and FX if
+it is too late to do so
+
+When disabled, Sonic Pi will always
+attempt to trigger synths and FX
+even when a little late.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1001"/>
+        <source>Transparency</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1012"/>
+        <location filename="../mainwindow.cpp" line="1144"/>
         <source>Updates</source>
         <translation>Actualizaciones</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="825"/>
+        <location filename="../mainwindow.cpp" line="1014"/>
         <source>Check for updates</source>
         <translation>Comprobar nuevas actualizaciones</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="827"/>
+        <location filename="../mainwindow.cpp" line="1016"/>
         <source>Toggle automatic update checking.
 This check involves sending anonymous information about your platform and version.</source>
         <translation>Cambia la opción del comprobación automática de actualizaciones.  
 Esta verificación conlleva enviar información anónima de tu plataforma y versión actuales.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="828"/>
+        <location filename="../mainwindow.cpp" line="1017"/>
         <source>Check now</source>
         <translation>Comprobar ahora</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="829"/>
+        <location filename="../mainwindow.cpp" line="1018"/>
         <source>Force a check for updates now.
 This check involves sending anonymous information about your platform and version.</source>
         <translation>Comprobar inmediatamente la existencia de actualizaciones.  
 Esta verificación conlleva enviar información anónima de tu plataforma y versión actuales.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="830"/>
+        <location filename="../mainwindow.cpp" line="1019"/>
         <source>Get update</source>
         <translation>Obtener actualizaciones</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="831"/>
+        <location filename="../mainwindow.cpp" line="1020"/>
         <source>Visit http://sonic-pi.net to download new version</source>
         <translation>Visita http://sonic-pi.net para descargar una nueva versión</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="836"/>
+        <location filename="../mainwindow.cpp" line="1025"/>
         <source>Update Info</source>
         <translation>Actualizar Info</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="855"/>
+        <location filename="../mainwindow.cpp" line="1044"/>
         <source>Show and Hide</source>
         <translation>Mostrar y Ocultar</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="856"/>
+        <location filename="../mainwindow.cpp" line="1045"/>
         <source>Configure editor display options.</source>
         <translation>Configurar opciones de pantalla del editor.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="857"/>
+        <location filename="../mainwindow.cpp" line="1046"/>
         <source>Look and Feel</source>
         <translation>Aspecto</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="858"/>
+        <location filename="../mainwindow.cpp" line="1047"/>
         <source>Configure editor look and feel.</source>
         <translation>Configura el aspecto del editor.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="859"/>
+        <location filename="../mainwindow.cpp" line="1048"/>
         <source>Automation</source>
         <translation>Automatización</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="860"/>
+        <location filename="../mainwindow.cpp" line="1049"/>
         <source>Configure automation features.</source>
         <translation>Configura las características de automatización.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="861"/>
+        <location filename="../mainwindow.cpp" line="1050"/>
         <source>Auto-align</source>
         <translation>Alineamiento automático</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="862"/>
+        <location filename="../mainwindow.cpp" line="1051"/>
         <source>Automatically align code on Run</source>
         <translation>Alinea automáticamente el código al ejecutarlo</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="864"/>
+        <location filename="../mainwindow.cpp" line="1053"/>
         <source>Show line numbers</source>
         <translation>Mostrar número de lineas</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="865"/>
+        <location filename="../mainwindow.cpp" line="1054"/>
         <source>Toggle line number visibility.</source>
         <translation>Cambia la visibilidad del número de lineas.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="866"/>
+        <location filename="../mainwindow.cpp" line="1055"/>
         <source>Show log</source>
         <translation>Mostrar registro</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="867"/>
+        <location filename="../mainwindow.cpp" line="1056"/>
         <source>Toggle visibility of the log.</source>
         <translation>Cambia opción de visibilidad del registro.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="869"/>
+        <location filename="../mainwindow.cpp" line="1058"/>
         <source>Show buttons</source>
         <translation>Mostrar botones</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="870"/>
+        <location filename="../mainwindow.cpp" line="1059"/>
         <source>Toggle visibility of the control buttons.</source>
         <translation>Cambia la opción de visibilidad de las opciones del registro.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="872"/>
+        <location filename="../mainwindow.cpp" line="1061"/>
         <source>Show tabs</source>
         <translation>Mostrar tabs</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="874"/>
+        <location filename="../mainwindow.cpp" line="1063"/>
         <source>Toggle visibility of the buffer selection tabs.</source>
         <translation>Cambia la visibilidad de los tabs de selección de buffer.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="875"/>
+        <location filename="../mainwindow.cpp" line="1064"/>
         <source>Full screen</source>
         <translation>Pantalla completa</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="876"/>
+        <location filename="../mainwindow.cpp" line="1065"/>
         <source>Toggle full screen mode.</source>
         <translation>Cambia la opción de pantalla completa.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="877"/>
+        <location filename="../mainwindow.cpp" line="1066"/>
         <source>Dark mode</source>
         <translation>Modo oscuro</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="878"/>
+        <location filename="../mainwindow.cpp" line="1067"/>
         <source>Toggle dark mode.</source>
         <translation>Cambia opción de modo oscuro.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="878"/>
+        <location filename="../mainwindow.cpp" line="1067"/>
         <source>
 Dark mode is perfect for live coding in night clubs.</source>
         <translation>
 La opción modo oscuro es perfecta para hacer live coding en discotecas o lugares con poca luminosidad.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="917"/>
+        <location filename="../mainwindow.cpp" line="1106"/>
         <source>Audio</source>
         <translation>Audio</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="929"/>
+        <location filename="../mainwindow.cpp" line="1118"/>
         <source>Editor</source>
         <translation>Editor</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="930"/>
+        <location filename="../mainwindow.cpp" line="1119"/>
         <source>Studio</source>
         <translation>Estudio</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1019"/>
+        <location filename="../mainwindow.cpp" line="1121"/>
+        <location filename="../mainwindow.cpp" line="1131"/>
+        <source>Performance</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1122"/>
+        <source>Settings useful for performing with Sonic Pi</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1259"/>
         <source>Server boot error...</source>
         <translation>Error en la carga de servidor...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1019"/>
-        <source>Apologies, a critical error occurred during startup</source>
-        <translation>Mil disculpas, ocurrió un error crítico en el momento de arrancar la aplicación</translation>
+        <location filename="../mainwindow.cpp" line="2338"/>
+        <source>Run the code in the current buffer</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1019"/>
+        <location filename="../mainwindow.cpp" line="2882"/>
+        <source>New version available!
+Get Sonic Pi %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1259"/>
         <source>Please consider reporting a bug at</source>
         <translation>Por favor, considera reportar este error</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1113"/>
+        <location filename="../mainwindow.cpp" line="1259"/>
+        <source>Sonic Pi Boot Error
+
+Apologies, a critical error occurred during startup</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1361"/>
+        <location filename="../mainwindow.cpp" line="1362"/>
+        <location filename="../mainwindow.cpp" line="1374"/>
+        <location filename="../mainwindow.cpp" line="1375"/>
+        <source>Buffer files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1362"/>
+        <source>Load Sonic Pi Buffer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1362"/>
+        <location filename="../mainwindow.cpp" line="1375"/>
+        <source>Text files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1362"/>
+        <location filename="../mainwindow.cpp" line="1375"/>
+        <source>Ruby files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1362"/>
+        <location filename="../mainwindow.cpp" line="1375"/>
+        <source>All files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1375"/>
         <source>Save Current Buffer</source>
         <translation>Guardar el buffer actual</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1181"/>
+        <location filename="../mainwindow.cpp" line="1447"/>
         <source>Running Code...</source>
         <translation>Corriendo el código...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1207"/>
-        <source>Workspace %1</source>
-        <translation>Directorio de trabajo %1</translation>
-    </message>
-    <message>
-        <location filename="../mainwindow.cpp" line="1223"/>
+        <location filename="../mainwindow.cpp" line="1496"/>
         <source>Zooming In...</source>
         <translation>Aumentando zoom...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1230"/>
+        <location filename="../mainwindow.cpp" line="1503"/>
         <source>Zooming Out...</source>
         <translation>Disminuyendo zoom...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1237"/>
+        <location filename="../mainwindow.cpp" line="1510"/>
         <source>Beautifying...</source>
         <translation>Mejorando interfaz...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1257"/>
+        <location filename="../mainwindow.cpp" line="1530"/>
         <source>Reloading...</source>
         <translation>Recargando...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1264"/>
+        <location filename="../mainwindow.cpp" line="1537"/>
         <source>Checking for updates...</source>
         <translation>Comprobando actualizaciones...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1272"/>
+        <location filename="../mainwindow.cpp" line="1545"/>
         <source>Enabling update checking...</source>
         <translation>Habilitando el chequeo de actualizaciones...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1280"/>
+        <location filename="../mainwindow.cpp" line="1553"/>
         <source>Disabling update checking...</source>
         <translation>Deshabilitando el chequeo de actualizaciones...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1288"/>
+        <location filename="../mainwindow.cpp" line="1561"/>
         <source>Enabling Mixer HPF...</source>
         <translation>Habilitando Mixer HPF...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1297"/>
+        <location filename="../mainwindow.cpp" line="1570"/>
         <source>Disabling Mixer HPF...</source>
         <translation>Deshabilitando chequeo HPF...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1305"/>
+        <location filename="../mainwindow.cpp" line="1578"/>
         <source>Enabling Mixer LPF...</source>
         <translation>Habilitando Mixer LPF...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1314"/>
+        <location filename="../mainwindow.cpp" line="1587"/>
         <source>Disabling Mixer LPF...</source>
         <translation>Deshabilitando Mixer LPF...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1322"/>
+        <location filename="../mainwindow.cpp" line="1595"/>
         <source>Enabling Inverted Stereo...</source>
         <translation>Habilitando Estéreo Invertido...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1330"/>
+        <location filename="../mainwindow.cpp" line="1603"/>
         <source>Enabling Standard Stereo...</source>
         <translation>Habilitando Estéreo Estándar...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1338"/>
+        <location filename="../mainwindow.cpp" line="1611"/>
         <source>Mono Mode...</source>
         <translation>Modo Mono...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1346"/>
+        <location filename="../mainwindow.cpp" line="1619"/>
         <source>Stereo Mode...</source>
         <translation>Modo Estéreo...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1355"/>
+        <location filename="../mainwindow.cpp" line="1628"/>
         <source>Stopping...</source>
         <translation>Parando...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1432"/>
+        <location filename="../mainwindow.cpp" line="1736"/>
         <source>Updating System Volume...</source>
         <translation>Actualizando volumen del sistema...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1650"/>
+        <location filename="../mainwindow.cpp" line="1752"/>
+        <source>Log Auto Scroll on...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1754"/>
+        <source>Log Auto Scroll off...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2155"/>
         <source>Switching To Headphone Audio Output...</source>
         <translation>Cambiando a salida de audio por auriculares...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1666"/>
+        <location filename="../mainwindow.cpp" line="2171"/>
         <source>Switching To HDMI Audio Output...</source>
         <translation>Cambiando a salida de audio por HDMI...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1681"/>
+        <location filename="../mainwindow.cpp" line="2186"/>
         <source>Switching To Default Audio Output...</source>
         <translation>Cambiando a salida de audio por defecto...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1823"/>
+        <location filename="../mainwindow.cpp" line="2337"/>
         <source>Run</source>
         <translation>Ejecutar</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1824"/>
-        <source>Run the code in the current workspace</source>
-        <translation>Ejecutar el código en el workspace actual</translation>
-    </message>
-    <message>
-        <location filename="../mainwindow.cpp" line="1828"/>
+        <location filename="../mainwindow.cpp" line="2343"/>
         <source>Stop</source>
         <translation>Parar</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1829"/>
+        <location filename="../mainwindow.cpp" line="2344"/>
         <source>Stop all running code</source>
         <translation>Parar todo el código que se encuentre ejecutándose</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1832"/>
+        <location filename="../mainwindow.cpp" line="2347"/>
         <source>Save As...</source>
         <translation>Guardar como...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1833"/>
+        <location filename="../mainwindow.cpp" line="2348"/>
         <source>Save current buffer as an external file</source>
         <translation>Guardar el búffer actual como un archivo externo</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1836"/>
+        <location filename="../mainwindow.cpp" line="2351"/>
+        <source>Load</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2352"/>
+        <source>Load an external file in the current buffer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2355"/>
         <source>Info</source>
         <translation>Información</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1837"/>
+        <location filename="../mainwindow.cpp" line="2356"/>
         <source>See information about Sonic Pi</source>
         <translation>Mira información sobre Sonic Pi</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1842"/>
+        <location filename="../mainwindow.cpp" line="2361"/>
+        <source>View audio output</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2365"/>
         <source>Toggle help pane</source>
         <translation>Cambiar opción para mostrar panel de ayuda</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1845"/>
+        <location filename="../mainwindow.cpp" line="2368"/>
         <source>Prefs</source>
         <translation>Preferencias</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1846"/>
+        <location filename="../mainwindow.cpp" line="2369"/>
         <source>Toggle preferences pane</source>
         <translation>Cambiar opción para mostrar panel de preferencias</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1850"/>
-        <location filename="../mainwindow.cpp" line="1972"/>
-        <location filename="../mainwindow.cpp" line="1973"/>
+        <location filename="../mainwindow.cpp" line="2373"/>
+        <location filename="../mainwindow.cpp" line="2502"/>
+        <location filename="../mainwindow.cpp" line="2503"/>
         <source>Start Recording</source>
         <translation>Empezar Grabación</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1851"/>
+        <location filename="../mainwindow.cpp" line="2374"/>
         <source>Start recording to WAV audio file</source>
         <translation>Empezar grabación en archivo de audio WAV</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1855"/>
+        <location filename="../mainwindow.cpp" line="2378"/>
         <source>Auto-Align Text</source>
         <translation>Alinear texto automáticamente</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1856"/>
+        <location filename="../mainwindow.cpp" line="2379"/>
         <source>Improve readability of code</source>
         <translation>Mejorar legibilidad del código</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1860"/>
-        <location filename="../mainwindow.cpp" line="1861"/>
+        <location filename="../mainwindow.cpp" line="2385"/>
         <source>Increase Text Size</source>
         <translation>Incrementar tamaño del texto</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1865"/>
-        <location filename="../mainwindow.cpp" line="1866"/>
+        <location filename="../mainwindow.cpp" line="2392"/>
         <source>Decrease Text Size</source>
         <translation>Decrementar tamaño del texto</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1871"/>
+        <location filename="../mainwindow.cpp" line="2397"/>
         <source>Tools</source>
         <translation>Herramientas</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1918"/>
+        <location filename="../mainwindow.cpp" line="2448"/>
         <source>About</source>
         <translation>Acerca de</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1919"/>
+        <location filename="../mainwindow.cpp" line="2449"/>
         <source>Core Team</source>
         <translation>Miembros del Equipo</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1920"/>
+        <location filename="../mainwindow.cpp" line="2450"/>
         <source>Contributors</source>
         <translation>Contribuyentes</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1921"/>
+        <location filename="../mainwindow.cpp" line="2451"/>
         <source>Community</source>
         <translation>Comunidad</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1922"/>
+        <location filename="../mainwindow.cpp" line="2452"/>
         <source>License</source>
         <translation>Licencia</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1923"/>
+        <location filename="../mainwindow.cpp" line="2453"/>
         <source>History</source>
         <translation>Historia</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1944"/>
+        <location filename="../mainwindow.cpp" line="2474"/>
         <source>Sonic Pi - Info</source>
         <translation>Sonic Pi - Información</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1964"/>
-        <location filename="../mainwindow.cpp" line="1965"/>
+        <location filename="../mainwindow.cpp" line="2494"/>
+        <location filename="../mainwindow.cpp" line="2495"/>
         <source>Stop Recording</source>
         <translation>Parar Grabación</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1978"/>
+        <location filename="../mainwindow.cpp" line="2508"/>
         <source>Save Recording</source>
         <translation>Guardar Grabación</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1997"/>
+        <location filename="../mainwindow.cpp" line="2508"/>
+        <source>Wavefile (*.wav)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2527"/>
         <source>Ready...</source>
         <translation>Listo...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2074"/>
+        <location filename="../mainwindow.cpp" line="2608"/>
         <source>Cannot read file %1:
 %2.</source>
         <translation>No se puede leer el archivo %1: 
 %2.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2084"/>
+        <location filename="../mainwindow.cpp" line="2619"/>
         <source>File loaded...</source>
         <translation>Archivo cargado...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2092"/>
+        <location filename="../mainwindow.cpp" line="2628"/>
         <source>Cannot write file %1:
 %2.</source>
         <translation>No se puede escribir en archivo %1: 
 %2.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2109"/>
+        <location filename="../mainwindow.cpp" line="2646"/>
         <source>File saved...</source>
         <translation>Archivos guardados...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2334"/>
+        <location filename="../mainwindow.cpp" line="2873"/>
         <source>Last checked %1</source>
         <translation>Comprobado por última vez %1</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2336"/>
+        <location filename="../mainwindow.cpp" line="2875"/>
         <source>Sonic Pi checks for updates
 every two weeks.</source>
         <translation>Sonic Pi busca nuevas actualizaciones 
 cada 2 semanas.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2338"/>
+        <location filename="../mainwindow.cpp" line="2877"/>
         <source>This is Sonic Pi %1</source>
         <translation>Esto es Sonic Pi %1</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2339"/>
+        <location filename="../mainwindow.cpp" line="2878"/>
         <source>Version %2 is now available!</source>
         <translation>¡La versión %2 se encuentra disponible!</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2343"/>
-        <source>New versión available!
-Get Sonic Pi %1</source>
-        <translation>¡Nueva versión disponible! 
-Obtén Sonic Pi %1</translation>
-    </message>
-    <message>
-        <location filename="../mainwindow.cpp" line="2369"/>
+        <location filename="../mainwindow.cpp" line="2908"/>
         <source>Welcome back. Now get your live code on...</source>
         <translation>Bienvenido de vuelta. Ahora empieza a codificar música...</translation>
     </message>
     <message>
-        <location filename="../ruby_help.h" line="31"/>
-        <location filename="../ruby_help.h" line="90"/>
-        <location filename="../ruby_help.h" line="150"/>
+        <location filename="../ruby_help.h" line="93"/>
+        <location filename="../ruby_help.h" line="154"/>
+        <location filename="../ruby_help.h" line="215"/>
+        <location filename="../ruby_help.h" line="274"/>
+        <location filename="../ruby_help.h" line="293"/>
+        <location filename="../ruby_help.h" line="367"/>
+        <location filename="../ruby_help.h" line="442"/>
         <source>Tutorial</source>
         <translation>Tutorial</translation>
     </message>
     <message>
-        <location filename="../ruby_help.h" line="183"/>
+        <location filename="../ruby_help.h" line="476"/>
         <source>Examples</source>
         <translation>Ejemplos</translation>
     </message>
     <message>
-        <location filename="../ruby_help.h" line="223"/>
+        <location filename="../ruby_help.h" line="522"/>
         <source>Synths</source>
         <translation>Sintetizadores</translation>
     </message>
     <message>
-        <location filename="../ruby_help.h" line="258"/>
+        <location filename="../ruby_help.h" line="564"/>
         <source>Fx</source>
         <translation>Fx</translation>
     </message>
     <message>
-        <location filename="../ruby_help.h" line="275"/>
+        <location filename="../ruby_help.h" line="583"/>
         <source>Samples</source>
         <translation>Muestras</translation>
     </message>
     <message>
-        <location filename="../ruby_help.h" line="437"/>
+        <location filename="../ruby_help.h" line="779"/>
         <source>Lang</source>
         <translation>Lenguaje</translation>
     </message>
@@ -748,11 +892,11 @@ Obtén Sonic Pi %1</translation>
     </message>
 </context>
 <context>
-    <name>SonicPiUDPServer</name>
+    <name>SonicPiUDPOSCServer</name>
     <message>
-        <location filename="../sonicpiudpserver.cpp" line="24"/>
-        <source>Is Sonic Pi already running?  Can't open UDP port 4558.</source>
-        <translation>¿Hay otra instancia de Sonic Pi ejecutándose?, no se puede abrir el puerto UDP 4558.</translation>
+        <location filename="../sonic_pi_udp_osc_server.cpp" line="38"/>
+        <source>Is Sonic Pi already running?  Can&apos;t open UDP port 4558.</source>
+        <translation type="unfinished">¿Hay otra instancia de Sonic Pi ejecutándose?, no se puede abrir el puerto UDP 4558.</translation>
     </message>
 </context>
 </TS>

--- a/app/gui/qt/lang/sonic-pi_fr.ts
+++ b/app/gui/qt/lang/sonic-pi_fr.ts
@@ -1,112 +1,90 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
 <TS version="2.1" language="fr_FR">
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../mainwindow.cpp" line="262"></location>
+        <location filename="../mainwindow.cpp" line="277"/>
         <source>Sonic Pi update info</source>
         <translation>Info de mise à jour de Sonic Pi</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="366"></location>
+        <location filename="../mainwindow.cpp" line="387"/>
         <source>Buffer %1</source>
         <translation>Buffer %1</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="430"></location>
+        <location filename="../mainwindow.cpp" line="459"/>
         <source>Preferences</source>
         <translation>Préférences</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="443"></location>
+        <location filename="../mainwindow.cpp" line="472"/>
         <source>Log</source>
         <translation>Trace</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="484"></location>
-        <location filename="../mainwindow.cpp" line="2023"></location>
+        <location filename="../mainwindow.cpp" line="513"/>
+        <location filename="../mainwindow.cpp" line="2364"/>
         <source>Help</source>
         <translation>Aide</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="167"></location>
-        <location filename="../mainwindow.cpp" line="2258"></location>
-        <location filename="../mainwindow.cpp" line="2276"></location>
+        <location filename="../mainwindow.cpp" line="184"/>
+        <location filename="../mainwindow.cpp" line="2607"/>
+        <location filename="../mainwindow.cpp" line="2627"/>
         <source>Sonic Pi</source>
         <translation>Sonic Pi</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="220"></location>
+        <location filename="../mainwindow.cpp" line="235"/>
         <source>Welcome to Sonic Pi</source>
         <translation>Bienvenue à Sonic Pi</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="636"></location>
+        <location filename="../mainwindow.cpp" line="708"/>
         <source>Indenting selection...</source>
         <translation>Indentation de la sélection...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="640"></location>
+        <location filename="../mainwindow.cpp" line="712"/>
         <source>Indenting line...</source>
         <translation>Indentation de la ligne...</translation>
     </message>
     <message>
-        <source>Commenting selection...</source>
-        <translation type="vanished">Commentant la sélection...</translation>
-    </message>
-    <message>
-        <source>Commenting line...</source>
-        <translation type="vanished">Commentant la ligne...</translation>
-    </message>
-    <message>
-        <source>Ruby could not be started, is it installed and in your PATH?</source>
-        <translation type="vanished">Ruby ne peut être lancé, est-il installé et dans votre PATH ?</translation>
-    </message>
-    <message>
-        <location filename="../mainwindow.cpp" line="669"></location>
+        <location filename="../mainwindow.cpp" line="741"/>
         <source>Toggle selection comment...</source>
         <translation>Commenter/Décommenter la sélection ...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="673"></location>
+        <location filename="../mainwindow.cpp" line="745"/>
         <source>Toggle line comment...</source>
         <translation>Commenter/Décommenter la ligne ...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="747"></location>
-        <source>The Sonic Pi server could not be started!</source>
-        <translation>Le serveur Sonic Pi n'a pas pu être lancé !</translation>
-    </message>
-    <message>
-        <location filename="../mainwindow.cpp" line="849"></location>
+        <location filename="../mainwindow.cpp" line="911"/>
         <source>Raspberry Pi System Volume</source>
         <translation>Volume du son du Raspberry Pi</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="850"></location>
+        <location filename="../mainwindow.cpp" line="912"/>
         <source>Use this slider to change the system volume of your Raspberry Pi.</source>
         <translation>Utilisez ce curseur pour changer le volume du son de votre Raspberry Pi.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="852"></location>
+        <location filename="../mainwindow.cpp" line="914"/>
         <source>Advanced Audio</source>
         <translation>Audio avancé</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="853"></location>
+        <location filename="../mainwindow.cpp" line="915"/>
         <source>Advanced audio settings for working with
 external PA systems when performing with Sonic Pi.</source>
-        <translation>Paramètres audio avancés pour l'utilisation
-d'un amplificateur externe avec Sonic Pi.</translation>
+        <translation>Paramètres audio avancés pour l&apos;utilisation
+d&apos;un amplificateur externe avec Sonic Pi.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="854"></location>
-        <source>Invert Stereo</source>
-        <translation>Stéréo inversée</translation>
-    </message>
-    <message>
-        <location filename="../mainwindow.cpp" line="855"></location>
+        <location filename="../mainwindow.cpp" line="917"/>
         <source>Toggle stereo inversion.
 If enabled, audio sent to the left speaker will
 be routed to the right speaker and visa versa.</source>
@@ -115,30 +93,25 @@ Si activée, le son destiné au haut-parleur de gauche sera
 dirigé vers le haut-parleur de droite et vice et versa.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="857"></location>
-        <source>Force Mono</source>
-        <translation>Mono forcé</translation>
-    </message>
-    <message>
-        <location filename="../mainwindow.cpp" line="858"></location>
+        <location filename="../mainwindow.cpp" line="920"/>
         <source>Toggle mono mode.
 If enabled both right and left audio is mixed and
 the same signal is sent to both speakers.
 Useful when working with external systems that
 can only handle mono.</source>
         <translation>Bascule en mode mono.
-Si activée, l'audio de gauche est mélangé avec celui de droite
+Si activée, l&apos;audio de gauche est mélangé avec celui de droite
 et le même signal est dirigé vers les deux haut-parleurs. 
 Utile quand on travaille avec des systèmes externes qui 
 ne supportent que le mono.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="861"></location>
+        <location filename="../mainwindow.cpp" line="976"/>
         <source>Safe mode</source>
         <translation>Mode sécurisé</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="862"></location>
+        <location filename="../mainwindow.cpp" line="977"/>
         <source>Toggle synth argument checking functions.
 If disabled, certain synth opt values may
 create unexpectedly loud or uncomfortable sounds.</source>
@@ -147,81 +120,112 @@ Si désactivée, certaines valeurs des options de synth peuvent
 engendrer des sons forts ou inconfortables de manière imprévue.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="874"></location>
+        <location filename="../mainwindow.cpp" line="933"/>
         <source>Raspberry Pi Audio Output</source>
         <translation>Sortie audio du Raspberry Pi</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="875"></location>
+        <location filename="../mainwindow.cpp" line="452"/>
+        <location filename="../mainwindow.cpp" line="2360"/>
+        <source>Scope</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="803"/>
+        <source>The Sonic Pi Server could not be started!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="916"/>
+        <source>Invert stereo</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="919"/>
+        <source>Force mono</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="934"/>
         <source>Your Raspberry Pi has two forms of audio output.
 Firstly, there is the headphone jack of the Raspberry Pi itself.
 Secondly, some HDMI monitors/TVs support audio through the HDMI port.
 Use these buttons to force the output to the one you want.</source>
         <translation>Votre Raspberry Pi a deux sorties audio.
 Premièrement, il y a la prise jack pour écouteurs du Raspberry PI lui-même.
-Deuxièmement, des moniteurs ou TV supportent l'audio via la prise HDMI.
+Deuxièmement, des moniteurs ou TV supportent l&apos;audio via la prise HDMI.
 Utilisez ces boutons pour forcer la sortie vers ce que vous souhaitez.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="876"></location>
+        <location filename="../mainwindow.cpp" line="935"/>
         <source>&amp;Default</source>
         <translation>&amp;Défaut</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="877"></location>
+        <location filename="../mainwindow.cpp" line="936"/>
         <source>&amp;Headphones</source>
         <translation>&amp;Écouteurs</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="878"></location>
+        <location filename="../mainwindow.cpp" line="937"/>
         <source>&amp;HDMI</source>
         <translation>&amp;HDMI</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="898"></location>
+        <location filename="../mainwindow.cpp" line="957"/>
         <source>Logging</source>
         <translation>Trace</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="899"></location>
+        <location filename="../mainwindow.cpp" line="958"/>
         <source>Configure debug behaviour</source>
         <translation>Configuration du comportement de débogage</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="901"></location>
+        <location filename="../mainwindow.cpp" line="960"/>
+        <source>Synths and FX</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="961"/>
+        <source>Modify behaviour of synths and FX</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="963"/>
         <source>Log synths</source>
         <translation>Trace les synthés</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="902"></location>
+        <location filename="../mainwindow.cpp" line="964"/>
         <source>Toggle log messages.
 If disabled, activity such as synth and sample
 triggering will not be printed to the log by default.</source>
         <translation>Bascule des messages de trace.
-Si désactivée, l'activité telle que le jeu des synthés et des échantillons 
+Si désactivée, l&apos;activité telle que le jeu des synthés et des échantillons 
 ne sera pas affichée dans la trace par défaut.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="904"></location>
+        <location filename="../mainwindow.cpp" line="966"/>
         <source>Clear log on run</source>
         <translation>Efface la trace avant exécution</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="905"></location>
+        <location filename="../mainwindow.cpp" line="967"/>
         <source>Toggle log clearing on run.
 If enabled, the log is cleared each
 time the run button is pressed.</source>
-        <translation>Bascule de l'effacement de la trace avant exécution.
+        <translation>Bascule de l&apos;effacement de la trace avant exécution.
 Si activé, la trace est effacée à chaque appui 
 sur le bouton run.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="907"></location>
+        <location filename="../mainwindow.cpp" line="969"/>
         <source>Log cues</source>
         <translation>Trace des cues</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="908"></location>
+        <location filename="../mainwindow.cpp" line="970"/>
         <source>Enable or disable logging of cues.
 If disabled, cues will still trigger.
 However, they will not be visible in the logs.</source>
@@ -230,592 +234,655 @@ Si désactivée, les cues continueront à être émis.
 Toutefois, ils ne seront pas visibles dans la trace.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="917"></location>
+        <location filename="../mainwindow.cpp" line="972"/>
+        <source>Log auto scroll</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="973"/>
+        <source>Toggle log auto scrolling.
+If enabled the log is scrolled to the bottom after every new message is displayed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="980"/>
+        <source>Enable external synths and FX</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="981"/>
+        <source>When enabled, Sonic Pi will allow
+synths and FX loaded via load_synthdefs
+to be triggered.
+
+When disabled, Sonic Pi will complain
+when you attempt to use a synth or FX
+which isn&apos;t recognised.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="983"/>
+        <source>Enforce timing guarantees</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="984"/>
+        <source>When enabled, Sonic Pi will refuse
+to trigger synths and FX if
+it is too late to do so
+
+When disabled, Sonic Pi will always
+attempt to trigger synths and FX
+even when a little late.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1001"/>
         <source>Transparency</source>
         <translation>Transparence</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="928"></location>
-        <location filename="../mainwindow.cpp" line="1060"></location>
+        <location filename="../mainwindow.cpp" line="1012"/>
+        <location filename="../mainwindow.cpp" line="1144"/>
         <source>Updates</source>
         <translation>Mises à jour</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="930"></location>
+        <location filename="../mainwindow.cpp" line="1014"/>
         <source>Check for updates</source>
         <translation>Vérification des mises à jour</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="932"></location>
+        <location filename="../mainwindow.cpp" line="1016"/>
         <source>Toggle automatic update checking.
 This check involves sending anonymous information about your platform and version.</source>
         <translation>Activer/Désactiver la vérification automatique des mises à jour.
 Cette vérification implique l&apos;envoi d&apos;informations anonymes sur votre plateforme et votre version.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="933"></location>
+        <location filename="../mainwindow.cpp" line="1017"/>
         <source>Check now</source>
         <translation>Vérification sur le champ</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="934"></location>
+        <location filename="../mainwindow.cpp" line="1018"/>
         <source>Force a check for updates now.
 This check involves sending anonymous information about your platform and version.</source>
         <translation>Force une vérification des mises à jour.
 Cette vérification implique l&apos;envoi d&apos;informations anonymes à propos de votre plateforme et de votre version.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="935"></location>
+        <location filename="../mainwindow.cpp" line="1019"/>
         <source>Get update</source>
-        <translation>Obtention d'une mise à jour</translation>
+        <translation>Obtention d&apos;une mise à jour</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="936"></location>
+        <location filename="../mainwindow.cpp" line="1020"/>
         <source>Visit http://sonic-pi.net to download new version</source>
         <translation>Visitez http://sonic-pi.net pour télécharger une nouvelle version</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="941"></location>
+        <location filename="../mainwindow.cpp" line="1025"/>
         <source>Update Info</source>
         <translation>Information de mise à jour</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="960"></location>
+        <location filename="../mainwindow.cpp" line="1044"/>
         <source>Show and Hide</source>
         <translation>Montre et cache</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="961"></location>
+        <location filename="../mainwindow.cpp" line="1045"/>
         <source>Configure editor display options.</source>
-        <translation>Configuration des options d'affichage de l'éditeur.</translation>
+        <translation>Configuration des options d&apos;affichage de l&apos;éditeur.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="962"></location>
+        <location filename="../mainwindow.cpp" line="1046"/>
         <source>Look and Feel</source>
         <translation>Look and Feel</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="963"></location>
+        <location filename="../mainwindow.cpp" line="1047"/>
         <source>Configure editor look and feel.</source>
-        <translation>Configuration du look and feel de l'éditeur.</translation>
+        <translation>Configuration du look and feel de l&apos;éditeur.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="964"></location>
+        <location filename="../mainwindow.cpp" line="1048"/>
         <source>Automation</source>
         <translation>Automatisation</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="965"></location>
+        <location filename="../mainwindow.cpp" line="1049"/>
         <source>Configure automation features.</source>
         <translation>Configurer les fonctionnalités d&apos;automatisation.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="966"></location>
+        <location filename="../mainwindow.cpp" line="1050"/>
         <source>Auto-align</source>
         <translation>Alignement automatique</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="967"></location>
+        <location filename="../mainwindow.cpp" line="1051"/>
         <source>Automatically align code on Run</source>
-        <translation>Alignement automatique du code à l'exécution</translation>
+        <translation>Alignement automatique du code à l&apos;exécution</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="969"></location>
+        <location filename="../mainwindow.cpp" line="1053"/>
         <source>Show line numbers</source>
         <translation>Affichage des numéros de ligne</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="970"></location>
+        <location filename="../mainwindow.cpp" line="1054"/>
         <source>Toggle line number visibility.</source>
         <translation>Activer/désactiver la visibilité des numéros de ligne.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="971"></location>
+        <location filename="../mainwindow.cpp" line="1055"/>
         <source>Show log</source>
         <translation>Affichage de la trace</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="972"></location>
+        <location filename="../mainwindow.cpp" line="1056"/>
         <source>Toggle visibility of the log.</source>
         <translation>Activer/désactiver la visibilité du journal.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="974"></location>
+        <location filename="../mainwindow.cpp" line="1058"/>
         <source>Show buttons</source>
         <translation>Affichage des boutons</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="975"></location>
+        <location filename="../mainwindow.cpp" line="1059"/>
         <source>Toggle visibility of the control buttons.</source>
         <translation>Activer/désactiver la visibilité des boutons de contrôle.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="977"></location>
+        <location filename="../mainwindow.cpp" line="1061"/>
         <source>Show tabs</source>
         <translation>Affichage des onglets</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="979"></location>
+        <location filename="../mainwindow.cpp" line="1063"/>
         <source>Toggle visibility of the buffer selection tabs.</source>
         <translation>Activer/désactiver l&apos;affichage des onglets de sélection des buffers.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="980"></location>
+        <location filename="../mainwindow.cpp" line="1064"/>
         <source>Full screen</source>
         <translation>Plein écran</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="981"></location>
+        <location filename="../mainwindow.cpp" line="1065"/>
         <source>Toggle full screen mode.</source>
         <translation>Activer/désactiver le mode plein écran.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="982"></location>
+        <location filename="../mainwindow.cpp" line="1066"/>
         <source>Dark mode</source>
         <translation>Mode sombre</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="983"></location>
+        <location filename="../mainwindow.cpp" line="1067"/>
         <source>Toggle dark mode.</source>
         <translation>Activer/désactiver le mode sombre.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="983"></location>
+        <location filename="../mainwindow.cpp" line="1067"/>
         <source>
 Dark mode is perfect for live coding in night clubs.</source>
         <translation>
 Le thème sombre est parfait pour coder en boîte de nuit.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1243"></location>
-        <source>Load Sonic-Pi file</source>
-        <translation>Charger un fichier Sonic Pi</translation>
-    </message>
-    <message>
-        <location filename="../mainwindow.cpp" line="2001"></location>
+        <location filename="../mainwindow.cpp" line="2338"/>
         <source>Run the code in the current buffer</source>
         <translation>Exécuter le code du buffer courant</translation>
     </message>
     <message>
-        <source>Dark mode is perfect for live coding in night clubs.</source>
-        <translation type="vanished">Le mode sombre est parfait pour le codage en live dans les boites de nuit.</translation>
-    </message>
-    <message>
-        <location filename="../mainwindow.cpp" line="1022"></location>
+        <location filename="../mainwindow.cpp" line="1106"/>
         <source>Audio</source>
         <translation>Audio</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1034"></location>
+        <location filename="../mainwindow.cpp" line="1118"/>
         <source>Editor</source>
         <translation>Éditeur</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1035"></location>
+        <location filename="../mainwindow.cpp" line="1119"/>
         <source>Studio</source>
         <translation>Studio</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1037"></location>
-        <location filename="../mainwindow.cpp" line="1047"></location>
+        <location filename="../mainwindow.cpp" line="1121"/>
+        <location filename="../mainwindow.cpp" line="1131"/>
         <source>Performance</source>
         <translation>Interprétation</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1038"></location>
+        <location filename="../mainwindow.cpp" line="1122"/>
         <source>Settings useful for performing with Sonic Pi</source>
-        <translation>Paramètres utiles pour l'interprétation avec Sonic Pi</translation>
+        <translation>Paramètres utiles pour l&apos;interprétation avec Sonic Pi</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1148"></location>
+        <location filename="../mainwindow.cpp" line="1259"/>
         <source>Server boot error...</source>
         <translation>Erreur du lanceur du serveur...</translation>
     </message>
     <message>
-        <source>Apologies, a critical error occurred during startup</source>
-        <translation type="vanished">Veuillez nous excuser, une erreur critique s&apos;est produite pendant le démarrage</translation>
-    </message>
-    <message>
-        <location filename="../mainwindow.cpp" line="1148"></location>
+        <location filename="../mainwindow.cpp" line="1259"/>
         <source>Please consider reporting a bug at</source>
-        <translation>Envisagez SVP la signalisation d'un bogue à</translation>
+        <translation>Envisagez SVP la signalisation d&apos;un bogue à</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1148"></location>
+        <location filename="../mainwindow.cpp" line="1259"/>
         <source>Sonic Pi Boot Error
 
 Apologies, a critical error occurred during startup</source>
         <translation>Erreur de démarrage de Sonic Pi
 
-Veuillez nous excuser, une erreur critique s'est produite pendant le démarrage</translation>
+Veuillez nous excuser, une erreur critique s&apos;est produite pendant le démarrage</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1255"></location>
+        <location filename="../mainwindow.cpp" line="1361"/>
+        <location filename="../mainwindow.cpp" line="1362"/>
+        <location filename="../mainwindow.cpp" line="1374"/>
+        <location filename="../mainwindow.cpp" line="1375"/>
+        <source>Buffer files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1362"/>
+        <source>Load Sonic Pi Buffer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1362"/>
+        <location filename="../mainwindow.cpp" line="1375"/>
+        <source>Text files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1362"/>
+        <location filename="../mainwindow.cpp" line="1375"/>
+        <source>Ruby files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1362"/>
+        <location filename="../mainwindow.cpp" line="1375"/>
+        <source>All files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1375"/>
         <source>Save Current Buffer</source>
         <translation>Sauvegarde du buffer courant</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1255"></location>
-        <source>Ruby (*.rb)</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../mainwindow.cpp" line="1326"></location>
+        <location filename="../mainwindow.cpp" line="1447"/>
         <source>Running Code...</source>
         <translation>Exécution du code...</translation>
     </message>
     <message>
-        <source>Workspace %1</source>
-        <translation type="vanished">Buffer %1</translation>
-    </message>
-    <message>
-        <location filename="../mainwindow.cpp" line="1368"></location>
+        <location filename="../mainwindow.cpp" line="1496"/>
         <source>Zooming In...</source>
         <translation>Zoom arrière...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1375"></location>
+        <location filename="../mainwindow.cpp" line="1503"/>
         <source>Zooming Out...</source>
         <translation>Zoom avant...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1382"></location>
+        <location filename="../mainwindow.cpp" line="1510"/>
         <source>Beautifying...</source>
         <translation>Embellissement...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1402"></location>
+        <location filename="../mainwindow.cpp" line="1530"/>
         <source>Reloading...</source>
         <translation>Rechargement...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1409"></location>
+        <location filename="../mainwindow.cpp" line="1537"/>
         <source>Checking for updates...</source>
         <translation>Vérification des mises à jour...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1417"></location>
+        <location filename="../mainwindow.cpp" line="1545"/>
         <source>Enabling update checking...</source>
         <translation>Activation de la vérification des mises à jour...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1425"></location>
+        <location filename="../mainwindow.cpp" line="1553"/>
         <source>Disabling update checking...</source>
         <translation>Désactivation de la vérification des mises à jour...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1433"></location>
+        <location filename="../mainwindow.cpp" line="1561"/>
         <source>Enabling Mixer HPF...</source>
         <translation>Activation du filtre passe-haut...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1442"></location>
+        <location filename="../mainwindow.cpp" line="1570"/>
         <source>Disabling Mixer HPF...</source>
         <translation>Désactivation du filtre passe-haut...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1450"></location>
+        <location filename="../mainwindow.cpp" line="1578"/>
         <source>Enabling Mixer LPF...</source>
         <translation>Activation du filtre passe-bas...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1459"></location>
+        <location filename="../mainwindow.cpp" line="1587"/>
         <source>Disabling Mixer LPF...</source>
         <translation>Désactivation du filtre passe-bas...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1467"></location>
+        <location filename="../mainwindow.cpp" line="1595"/>
         <source>Enabling Inverted Stereo...</source>
-        <translation>Activation de l'inversion stéréo...</translation>
+        <translation>Activation de l&apos;inversion stéréo...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1475"></location>
+        <location filename="../mainwindow.cpp" line="1603"/>
         <source>Enabling Standard Stereo...</source>
         <translation>Activation de la stéréo standard...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1483"></location>
+        <location filename="../mainwindow.cpp" line="1611"/>
         <source>Mono Mode...</source>
         <translation>Mode mono...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1491"></location>
+        <location filename="../mainwindow.cpp" line="1619"/>
         <source>Stereo Mode...</source>
         <translation>Mode stéréo...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1500"></location>
+        <location filename="../mainwindow.cpp" line="1628"/>
         <source>Stopping...</source>
         <translation>Arrêt...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1596"></location>
+        <location filename="../mainwindow.cpp" line="1736"/>
         <source>Updating System Volume...</source>
         <translation>Mise à jour du volume système...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1818"></location>
+        <location filename="../mainwindow.cpp" line="1752"/>
+        <source>Log Auto Scroll on...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1754"/>
+        <source>Log Auto Scroll off...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2155"/>
         <source>Switching To Headphone Audio Output...</source>
         <translation>Aiguillage vers la sortie écouteurs...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1834"></location>
+        <location filename="../mainwindow.cpp" line="2171"/>
         <source>Switching To HDMI Audio Output...</source>
         <translation>Aiguillage vers la sortie HDMI...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1849"></location>
+        <location filename="../mainwindow.cpp" line="2186"/>
         <source>Switching To Default Audio Output...</source>
         <translation>Aiguillage vers la sortie par défaut...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2000"></location>
+        <location filename="../mainwindow.cpp" line="2337"/>
         <source>Run</source>
         <translation>Lancer</translation>
     </message>
     <message>
-        <source>Run the code in the current workspace</source>
-        <translation type="vanished">Exécute le code dans le buffer courant</translation>
-    </message>
-    <message>
-        <location filename="../mainwindow.cpp" line="2006"></location>
+        <location filename="../mainwindow.cpp" line="2343"/>
         <source>Stop</source>
         <translation>Stop</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2007"></location>
+        <location filename="../mainwindow.cpp" line="2344"/>
         <source>Stop all running code</source>
-        <translation>Arrête l'exécution de tous les codes</translation>
+        <translation>Arrête l&apos;exécution de tous les codes</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2010"></location>
+        <location filename="../mainwindow.cpp" line="2347"/>
         <source>Save As...</source>
         <translation>Enregistrer sous...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2011"></location>
+        <location filename="../mainwindow.cpp" line="2348"/>
         <source>Save current buffer as an external file</source>
         <translation>Enregistre le buffer courant dans un fichier externe</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2014"></location>
+        <location filename="../mainwindow.cpp" line="2351"/>
         <source>Load</source>
         <translation>Charger</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2015"></location>
+        <location filename="../mainwindow.cpp" line="2352"/>
         <source>Load an external file in the current buffer</source>
         <translation>Charger un fichier externe dans le buffer courant</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2018"></location>
+        <location filename="../mainwindow.cpp" line="2355"/>
         <source>Info</source>
         <translation>Info</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2019"></location>
+        <location filename="../mainwindow.cpp" line="2356"/>
         <source>See information about Sonic Pi</source>
-        <translation>Voir l'information sur Sonic Pi</translation>
+        <translation>Voir l&apos;information sur Sonic Pi</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2024"></location>
+        <location filename="../mainwindow.cpp" line="2361"/>
+        <source>View audio output</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2365"/>
         <source>Toggle help pane</source>
-        <translation>Bascule de l'affichage du panneau d'aide</translation>
+        <translation>Bascule de l&apos;affichage du panneau d&apos;aide</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2027"></location>
+        <location filename="../mainwindow.cpp" line="2368"/>
         <source>Prefs</source>
         <translation>Prefs</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2028"></location>
+        <location filename="../mainwindow.cpp" line="2369"/>
         <source>Toggle preferences pane</source>
-        <translation>Bascule de l'affichage du panneau des préférences</translation>
+        <translation>Bascule de l&apos;affichage du panneau des préférences</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2032"></location>
-        <location filename="../mainwindow.cpp" line="2158"></location>
-        <location filename="../mainwindow.cpp" line="2159"></location>
+        <location filename="../mainwindow.cpp" line="2373"/>
+        <location filename="../mainwindow.cpp" line="2502"/>
+        <location filename="../mainwindow.cpp" line="2503"/>
         <source>Start Recording</source>
-        <translation>Démarrage de l'enregistrement</translation>
+        <translation>Démarrage de l&apos;enregistrement</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2033"></location>
+        <location filename="../mainwindow.cpp" line="2374"/>
         <source>Start recording to WAV audio file</source>
-        <translation>Démarre l'enregistrement vers un fichier audio WAV</translation>
+        <translation>Démarre l&apos;enregistrement vers un fichier audio WAV</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2037"></location>
+        <location filename="../mainwindow.cpp" line="2378"/>
         <source>Auto-Align Text</source>
         <translation>Alignement automatique du texte</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2038"></location>
+        <location filename="../mainwindow.cpp" line="2379"/>
         <source>Improve readability of code</source>
         <translation>Améliore de la lisibilité du code</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2044"></location>
+        <location filename="../mainwindow.cpp" line="2385"/>
         <source>Increase Text Size</source>
         <translation>Augmente la taille du texte</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2051"></location>
+        <location filename="../mainwindow.cpp" line="2392"/>
         <source>Decrease Text Size</source>
         <translation>Diminue la taille du texte</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2056"></location>
+        <location filename="../mainwindow.cpp" line="2397"/>
         <source>Tools</source>
         <translation>Outils</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2104"></location>
+        <location filename="../mainwindow.cpp" line="2448"/>
         <source>About</source>
         <translation>A propos</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2105"></location>
+        <location filename="../mainwindow.cpp" line="2449"/>
         <source>Core Team</source>
         <translation>Équipe principale</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2106"></location>
+        <location filename="../mainwindow.cpp" line="2450"/>
         <source>Contributors</source>
         <translation>Contributeurs</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2107"></location>
+        <location filename="../mainwindow.cpp" line="2451"/>
         <source>Community</source>
         <translation>Communauté</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2108"></location>
+        <location filename="../mainwindow.cpp" line="2452"/>
         <source>License</source>
         <translation>Licence</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2109"></location>
+        <location filename="../mainwindow.cpp" line="2453"/>
         <source>History</source>
         <translation>Historique</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2130"></location>
+        <location filename="../mainwindow.cpp" line="2474"/>
         <source>Sonic Pi - Info</source>
         <translation>Sonic Pi - Info</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2150"></location>
-        <location filename="../mainwindow.cpp" line="2151"></location>
+        <location filename="../mainwindow.cpp" line="2494"/>
+        <location filename="../mainwindow.cpp" line="2495"/>
         <source>Stop Recording</source>
         <translation>Arrêter l&apos;enregistrement</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2164"></location>
+        <location filename="../mainwindow.cpp" line="2508"/>
         <source>Save Recording</source>
-        <translation>Sauvegarde de l'enregistrement</translation>
+        <translation>Sauvegarde de l&apos;enregistrement</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2164"></location>
+        <location filename="../mainwindow.cpp" line="2508"/>
         <source>Wavefile (*.wav)</source>
         <translation>Fichier Wave (*.wav)</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2183"></location>
+        <location filename="../mainwindow.cpp" line="2527"/>
         <source>Ready...</source>
         <translation>Prêt...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2259"></location>
+        <location filename="../mainwindow.cpp" line="2608"/>
         <source>Cannot read file %1:
 %2.</source>
         <translation>Lecture impossible du fichier %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2269"></location>
+        <location filename="../mainwindow.cpp" line="2619"/>
         <source>File loaded...</source>
         <translation>Fichier chargé...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2277"></location>
+        <location filename="../mainwindow.cpp" line="2628"/>
         <source>Cannot write file %1:
 %2.</source>
         <translation>Écriture impossible du fichier %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2294"></location>
+        <location filename="../mainwindow.cpp" line="2646"/>
         <source>File saved...</source>
         <translation>Fichier enregistré...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2520"></location>
+        <location filename="../mainwindow.cpp" line="2873"/>
         <source>Last checked %1</source>
         <translation>%1 vérifié en dernier</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2522"></location>
+        <location filename="../mainwindow.cpp" line="2875"/>
         <source>Sonic Pi checks for updates
 every two weeks.</source>
         <translation>Sonic Pi vérifie les mises à jour
 toutes les deux semaines.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2524"></location>
+        <location filename="../mainwindow.cpp" line="2877"/>
         <source>This is Sonic Pi %1</source>
-        <translation>C'est Sonic Pi %1</translation>
+        <translation>C&apos;est Sonic Pi %1</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2525"></location>
+        <location filename="../mainwindow.cpp" line="2878"/>
         <source>Version %2 is now available!</source>
         <translation>La version %2 est maintenant disponible !</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2529"></location>
+        <location filename="../mainwindow.cpp" line="2882"/>
         <source>New version available!
 Get Sonic Pi %1</source>
         <translation>Nouvelle version disponible !
 Obtenez Sonic Pi %1</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2553"></location>
+        <location filename="../mainwindow.cpp" line="2908"/>
         <source>Welcome back. Now get your live code on...</source>
         <translation>Bon retour. Obtenez maintenant votre code sur...</translation>
     </message>
     <message>
-        <location filename="../ruby_help.h" line="79"></location>
-        <location filename="../ruby_help.h" line="140"></location>
-        <location filename="../ruby_help.h" line="200"></location>
-        <location filename="../ruby_help.h" line="260"></location>
-        <location filename="../ruby_help.h" line="279"></location>
-        <location filename="../ruby_help.h" line="339"></location>
-        <location filename="../ruby_help.h" line="409"></location>
+        <location filename="../ruby_help.h" line="93"/>
+        <location filename="../ruby_help.h" line="154"/>
+        <location filename="../ruby_help.h" line="215"/>
+        <location filename="../ruby_help.h" line="274"/>
+        <location filename="../ruby_help.h" line="293"/>
+        <location filename="../ruby_help.h" line="367"/>
+        <location filename="../ruby_help.h" line="442"/>
         <source>Tutorial</source>
         <translation>Tutoriel</translation>
     </message>
     <message>
-        <location filename="../ruby_help.h" line="443"></location>
+        <location filename="../ruby_help.h" line="476"/>
         <source>Examples</source>
         <translation>Exemples</translation>
     </message>
     <message>
-        <location filename="../ruby_help.h" line="489"></location>
+        <location filename="../ruby_help.h" line="522"/>
         <source>Synths</source>
         <translation>Synths</translation>
     </message>
     <message>
-        <location filename="../ruby_help.h" line="530"></location>
+        <location filename="../ruby_help.h" line="564"/>
         <source>Fx</source>
         <translation>Fx</translation>
     </message>
     <message>
-        <location filename="../ruby_help.h" line="547"></location>
+        <location filename="../ruby_help.h" line="583"/>
         <source>Samples</source>
         <translation>Échantillons</translation>
     </message>
     <message>
-        <location filename="../ruby_help.h" line="735"></location>
+        <location filename="../ruby_help.h" line="779"/>
         <source>Lang</source>
         <translation>Langage</translation>
     </message>
@@ -823,7 +890,7 @@ Obtenez Sonic Pi %1</translation>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../main.cpp" line="43"></location>
+        <location filename="../main.cpp" line="43"/>
         <source>Sonic Pi</source>
         <translation>Sonic Pi</translation>
     </message>
@@ -831,16 +898,9 @@ Obtenez Sonic Pi %1</translation>
 <context>
     <name>SonicPiUDPOSCServer</name>
     <message>
-        <location filename="../sonic_pi_udp_osc_server.cpp" line="24"></location>
-        <source>Is Sonic Pi already running?  Can't open UDP port 4558.</source>
-        <translation>Y a-t-il une autre instance de Sonic Pi toujours en cours d'exécution ? Ouverture du port UDP 4558 impossible.</translation>
-    </message>
-</context>
-<context>
-    <name>SonicPiUDPServer</name>
-    <message>
+        <location filename="../sonic_pi_udp_osc_server.cpp" line="38"/>
         <source>Is Sonic Pi already running?  Can&apos;t open UDP port 4558.</source>
-        <translation type="vanished">Sonic Pi est-il déjà en cours d&apos;exécution ? Impossible d&apos;ouvrir le port UDP 4558.</translation>
+        <translation>Y a-t-il une autre instance de Sonic Pi toujours en cours d&apos;exécution ? Ouverture du port UDP 4558 impossible.</translation>
     </message>
 </context>
 </TS>

--- a/app/gui/qt/lang/sonic-pi_hu.ts
+++ b/app/gui/qt/lang/sonic-pi_hu.ts
@@ -1,101 +1,80 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0" language="hu_HU">
-<defaultcodec>UTF-8</defaultcodec>
+<TS version="2.1" language="hu_HU">
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../mainwindow.cpp" line="153"/>
+        <location filename="../mainwindow.cpp" line="277"/>
         <source>Sonic Pi update info</source>
         <translation>Sonic Pi frissítési információ</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="296"/>
+        <location filename="../mainwindow.cpp" line="387"/>
         <source>Buffer %1</source>
         <translation>Puffer %1</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="362"/>
+        <location filename="../mainwindow.cpp" line="459"/>
         <source>Preferences</source>
         <translation>Beállítások</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="375"/>
+        <location filename="../mainwindow.cpp" line="472"/>
         <source>Log</source>
         <translation>Napló</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="416"/>
-        <location filename="../mainwindow.cpp" line="1952"/>
+        <location filename="../mainwindow.cpp" line="513"/>
+        <location filename="../mainwindow.cpp" line="2364"/>
         <source>Help</source>
         <translation>Súgó</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="447"/>
-        <location filename="../mainwindow.cpp" line="2184"/>
-        <location filename="../mainwindow.cpp" line="2202"/>
+        <location filename="../mainwindow.cpp" line="184"/>
+        <location filename="../mainwindow.cpp" line="2607"/>
+        <location filename="../mainwindow.cpp" line="2627"/>
         <source>Sonic Pi</source>
         <translation>Sonic Pi</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="461"/>
+        <location filename="../mainwindow.cpp" line="235"/>
         <source>Welcome to Sonic Pi</source>
         <translation>Üdvözlünk a Sonic Pi programban</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="601"/>
+        <location filename="../mainwindow.cpp" line="708"/>
         <source>Indenting selection...</source>
         <translation>Kiválasztás behúzása...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="605"/>
+        <location filename="../mainwindow.cpp" line="712"/>
         <source>Indenting line...</source>
         <translation>Sor behúzása...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="634"/>
-        <source>Commenting selection...</source>
-        <translation>Kiválasztás kikommentelése...</translation>
-    </message>
-    <message>
-        <location filename="../mainwindow.cpp" line="638"/>
-        <source>Commenting line...</source>
-        <translation>Sor kikommentelése...</translation>
-    </message>
-    <message>
-        <location filename="../mainwindow.cpp" line="717"/>
-        <source>Ruby could not be started, is it installed and in your PATH?</source>
-        <translation>Nem sikerült elindítani a Ruby programot. Telepítve van és hozzá van adva a PATH környezeti változóhoz?</translation>
-    </message>
-    <message>
-        <location filename="../mainwindow.cpp" line="803"/>
+        <location filename="../mainwindow.cpp" line="911"/>
         <source>Raspberry Pi System Volume</source>
         <translation>Raspberry Pi rendszerhangerő</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="804"/>
+        <location filename="../mainwindow.cpp" line="912"/>
         <source>Use this slider to change the system volume of your Raspberry Pi.</source>
         <translation>Használd csúszkát a Raspberry Pi rendszerhangerejének megváltoztatásához.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="806"/>
+        <location filename="../mainwindow.cpp" line="914"/>
         <source>Advanced Audio</source>
         <translation>Haladó hangbeállítások</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="807"/>
+        <location filename="../mainwindow.cpp" line="915"/>
         <source>Advanced audio settings for working with
 external PA systems when performing with Sonic Pi.</source>
         <translation>Haladó hangbeállítások külső hangszórókkal történő
 munkához a Sonic Pi-jal való előadásoknál.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="808"/>
-        <source>Invert Stereo</source>
-        <translation>Sztereó invertálása</translation>
-    </message>
-    <message>
-        <location filename="../mainwindow.cpp" line="809"/>
+        <location filename="../mainwindow.cpp" line="917"/>
         <source>Toggle stereo inversion.
 If enabled, audio sent to the left speaker will
 be routed to the right speaker and visa versa.</source>
@@ -104,12 +83,7 @@ Ha be van kapcsolva, akkor a bal hangszórónak küldött
 hang át lesz vezetve a jobb hangszóróra és fordítva.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="811"/>
-        <source>Force Mono</source>
-        <translation>Monó kényszerítése</translation>
-    </message>
-    <message>
-        <location filename="../mainwindow.cpp" line="812"/>
+        <location filename="../mainwindow.cpp" line="920"/>
         <source>Toggle mono mode.
 If enabled both right and left audio is mixed and
 the same signal is sent to both speakers.
@@ -122,12 +96,12 @@ Hasznos az olyan renszerekkel történő munkához,
 amelyek csak monó hangot tudnak kezelni.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="815"/>
+        <location filename="../mainwindow.cpp" line="976"/>
         <source>Safe mode</source>
         <translation>Biztonságos mód</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="816"/>
+        <location filename="../mainwindow.cpp" line="977"/>
         <source>Toggle synth argument checking functions.
 If disabled, certain synth opt values may
 create unexpectedly loud or uncomfortable sounds.</source>
@@ -136,12 +110,43 @@ Ha ki van kapcsolva, akkor egyes synth opt értékek esetleg
 váratlanul hangos és kellemetlen hangokat alkothatnak.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="828"/>
+        <location filename="../mainwindow.cpp" line="933"/>
         <source>Raspberry Pi Audio Output</source>
         <translation>Raspberry Pi hangkimenet</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="829"/>
+        <location filename="../mainwindow.cpp" line="452"/>
+        <location filename="../mainwindow.cpp" line="2360"/>
+        <source>Scope</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="741"/>
+        <source>Toggle selection comment...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="745"/>
+        <source>Toggle line comment...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="803"/>
+        <source>The Sonic Pi Server could not be started!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="916"/>
+        <source>Invert stereo</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="919"/>
+        <source>Force mono</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="934"/>
         <source>Your Raspberry Pi has two forms of audio output.
 Firstly, there is the headphone jack of the Raspberry Pi itself.
 Secondly, some HDMI monitors/TVs support audio through the HDMI port.
@@ -152,37 +157,47 @@ Másrészt egyes HDMI monitorok és TV-k támogatják a hangot a HDMI porton ker
 Használd ezeket a gombokat a neked megfelelő kimenet kényszerítéséhez.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="830"/>
+        <location filename="../mainwindow.cpp" line="935"/>
         <source>&amp;Default</source>
         <translation>&amp;Alapértelmezés</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="831"/>
+        <location filename="../mainwindow.cpp" line="936"/>
         <source>&amp;Headphones</source>
         <translation>&amp;Fejhallgató</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="832"/>
+        <location filename="../mainwindow.cpp" line="937"/>
         <source>&amp;HDMI</source>
         <translation>&amp;HDMI</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="852"/>
+        <location filename="../mainwindow.cpp" line="957"/>
         <source>Logging</source>
         <translation>Naplózás</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="853"/>
+        <location filename="../mainwindow.cpp" line="958"/>
         <source>Configure debug behaviour</source>
         <translation>Hibakeresés működésének konfigurálása</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="855"/>
+        <location filename="../mainwindow.cpp" line="960"/>
+        <source>Synths and FX</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="961"/>
+        <source>Modify behaviour of synths and FX</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="963"/>
         <source>Log synths</source>
         <translation>Synth-ek naplózása</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="856"/>
+        <location filename="../mainwindow.cpp" line="964"/>
         <source>Toggle log messages.
 If disabled, activity such as synth and sample
 triggering will not be printed to the log by default.</source>
@@ -191,12 +206,12 @@ Ha ki van kapcsolva, akkor tevékenységek - mint a synth- és
 minta-kioldás - alapértelmezés szerint nem kerülnek be a naplóba.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="858"/>
+        <location filename="../mainwindow.cpp" line="966"/>
         <source>Clear log on run</source>
         <translation>Napló törlése futtatáskor</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="859"/>
+        <location filename="../mainwindow.cpp" line="967"/>
         <source>Toggle log clearing on run.
 If enabled, the log is cleared each
 time the run button is pressed.</source>
@@ -205,12 +220,12 @@ Ha be van kapcsolva, akkor a napló a futtás gomb
 megnyomásakor mindig törlésre kerül.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="861"/>
+        <location filename="../mainwindow.cpp" line="969"/>
         <source>Log cues</source>
         <translation>Jelzések naplózása</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="862"/>
+        <location filename="../mainwindow.cpp" line="970"/>
         <source>Enable or disable logging of cues.
 If disabled, cues will still trigger.
 However, they will not be visible in the logs.</source>
@@ -219,551 +234,651 @@ Ha ki van kapcsolva, a jelzések továbbra is kioldják a
 megfelelő eseményt, de nem lesznek láthatóak a naplóban.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="871"/>
+        <location filename="../mainwindow.cpp" line="972"/>
+        <source>Log auto scroll</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="973"/>
+        <source>Toggle log auto scrolling.
+If enabled the log is scrolled to the bottom after every new message is displayed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="980"/>
+        <source>Enable external synths and FX</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="981"/>
+        <source>When enabled, Sonic Pi will allow
+synths and FX loaded via load_synthdefs
+to be triggered.
+
+When disabled, Sonic Pi will complain
+when you attempt to use a synth or FX
+which isn&apos;t recognised.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="983"/>
+        <source>Enforce timing guarantees</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="984"/>
+        <source>When enabled, Sonic Pi will refuse
+to trigger synths and FX if
+it is too late to do so
+
+When disabled, Sonic Pi will always
+attempt to trigger synths and FX
+even when a little late.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1001"/>
         <source>Transparency</source>
         <translation>Áttetszőség</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="882"/>
-        <location filename="../mainwindow.cpp" line="1014"/>
+        <location filename="../mainwindow.cpp" line="1012"/>
+        <location filename="../mainwindow.cpp" line="1144"/>
         <source>Updates</source>
         <translation>Frissítések</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="884"/>
+        <location filename="../mainwindow.cpp" line="1014"/>
         <source>Check for updates</source>
         <translation>Frissítések keresése</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="886"/>
+        <location filename="../mainwindow.cpp" line="1016"/>
         <source>Toggle automatic update checking.
 This check involves sending anonymous information about your platform and version.</source>
         <translation>Frissítések automatikus ellenőrzésének ki-/bekapcsolása.
 Ez az ellenőrzés a platformmal és verzióval kapcsolatos, névtelen információk küldésével jár.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="887"/>
+        <location filename="../mainwindow.cpp" line="1017"/>
         <source>Check now</source>
         <translation>Ellenőrzés most</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="888"/>
+        <location filename="../mainwindow.cpp" line="1018"/>
         <source>Force a check for updates now.
 This check involves sending anonymous information about your platform and version.</source>
         <translation>Frissítések keresésének kényszerítése most.
 Ez az ellenőrzés a platformmal és verzióval kapcsolatos, névtelen információk küldésével jár.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="889"/>
+        <location filename="../mainwindow.cpp" line="1019"/>
         <source>Get update</source>
         <translation>Frissítés beszerzése</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="890"/>
+        <location filename="../mainwindow.cpp" line="1020"/>
         <source>Visit http://sonic-pi.net to download new version</source>
         <translation>Látogasd meg a http://sonic-pi.net weboldalt az új verzió letöltéséhez</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="895"/>
+        <location filename="../mainwindow.cpp" line="1025"/>
         <source>Update Info</source>
         <translation>Frissítési információ</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="914"/>
+        <location filename="../mainwindow.cpp" line="1044"/>
         <source>Show and Hide</source>
         <translation>Mutatás és elrejtés</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="915"/>
+        <location filename="../mainwindow.cpp" line="1045"/>
         <source>Configure editor display options.</source>
         <translation>Szerkesztő kijelzési opcióinak konfigurálása.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="916"/>
+        <location filename="../mainwindow.cpp" line="1046"/>
         <source>Look and Feel</source>
         <translation>Megjelenés</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="917"/>
+        <location filename="../mainwindow.cpp" line="1047"/>
         <source>Configure editor look and feel.</source>
         <translation>Szerkesztő megjelenésének konfigurálása.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="918"/>
+        <location filename="../mainwindow.cpp" line="1048"/>
         <source>Automation</source>
         <translation>Automatizálás</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="919"/>
+        <location filename="../mainwindow.cpp" line="1049"/>
         <source>Configure automation features.</source>
         <translation>Automatizálási funkciók konfigurálása.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="920"/>
+        <location filename="../mainwindow.cpp" line="1050"/>
         <source>Auto-align</source>
         <translation>Automatikus igazítás</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="921"/>
+        <location filename="../mainwindow.cpp" line="1051"/>
         <source>Automatically align code on Run</source>
         <translation>A kód automatikus igazítása futtatáskor</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="923"/>
+        <location filename="../mainwindow.cpp" line="1053"/>
         <source>Show line numbers</source>
         <translation>Sorok számának mutatása</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="924"/>
+        <location filename="../mainwindow.cpp" line="1054"/>
         <source>Toggle line number visibility.</source>
         <translation>A sorszámok mutatásának ki-/bekapcsolása.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="925"/>
+        <location filename="../mainwindow.cpp" line="1055"/>
         <source>Show log</source>
         <translation>Napló mutatása</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="926"/>
+        <location filename="../mainwindow.cpp" line="1056"/>
         <source>Toggle visibility of the log.</source>
         <translation>A napló mutatásának ki-/bekapcsolása.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="928"/>
+        <location filename="../mainwindow.cpp" line="1058"/>
         <source>Show buttons</source>
         <translation>Vezérlőgombok mutatása</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="929"/>
+        <location filename="../mainwindow.cpp" line="1059"/>
         <source>Toggle visibility of the control buttons.</source>
         <translation>A vezérlőgombok mutatásának ki-/bekapcsolása.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="931"/>
+        <location filename="../mainwindow.cpp" line="1061"/>
         <source>Show tabs</source>
         <translation>Fülek mutatása</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="933"/>
+        <location filename="../mainwindow.cpp" line="1063"/>
         <source>Toggle visibility of the buffer selection tabs.</source>
         <translation>A pufferválasztási fülek láthatóságának ki-/bekapcsolása.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="934"/>
+        <location filename="../mainwindow.cpp" line="1064"/>
         <source>Full screen</source>
         <translation>Teljes képernyő</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="935"/>
+        <location filename="../mainwindow.cpp" line="1065"/>
         <source>Toggle full screen mode.</source>
         <translation>Teljes képernyős mód ki-/bekapcsolása.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="936"/>
+        <location filename="../mainwindow.cpp" line="1066"/>
         <source>Dark mode</source>
         <translation>Sötét mód</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="937"/>
+        <location filename="../mainwindow.cpp" line="1067"/>
         <source>Toggle dark mode.</source>
         <translation>Sötét mód ki-/bekapcsolása.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="937"/>
+        <location filename="../mainwindow.cpp" line="1067"/>
         <source>
 Dark mode is perfect for live coding in night clubs.</source>
         <translation>A sötét mód tökéletes klubokban és
 szórakozóhelyeken végzett élő kódoláshoz.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="976"/>
+        <location filename="../mainwindow.cpp" line="1106"/>
         <source>Audio</source>
         <translation>Hang</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="988"/>
+        <location filename="../mainwindow.cpp" line="1118"/>
         <source>Editor</source>
         <translation>Szerkesztő</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="989"/>
+        <location filename="../mainwindow.cpp" line="1119"/>
         <source>Studio</source>
         <translation>Stúdió</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="991"/>
-        <location filename="../mainwindow.cpp" line="1001"/>
+        <location filename="../mainwindow.cpp" line="1121"/>
+        <location filename="../mainwindow.cpp" line="1131"/>
         <source>Performance</source>
         <translation>Előadás</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="992"/>
+        <location filename="../mainwindow.cpp" line="1122"/>
         <source>Settings useful for performing with Sonic Pi</source>
         <translation>Beállítások, amik hasznosak a Sonic Pi-jal való előadáshoz</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1097"/>
+        <location filename="../mainwindow.cpp" line="1259"/>
         <source>Server boot error...</source>
         <translation>Szerver bootolási hiba...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1097"/>
-        <source>Apologies, a critical error occurred during startup</source>
-        <translation>Elnézést kérünk, egy kritikus hiba történt az indítás közben</translation>
+        <location filename="../mainwindow.cpp" line="2338"/>
+        <source>Run the code in the current buffer</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1097"/>
+        <location filename="../mainwindow.cpp" line="1259"/>
         <source>Please consider reporting a bug at</source>
         <translation>Kérjük fontold meg a hiba jelentését a következő helyen</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1191"/>
+        <location filename="../mainwindow.cpp" line="1259"/>
+        <source>Sonic Pi Boot Error
+
+Apologies, a critical error occurred during startup</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1361"/>
+        <location filename="../mainwindow.cpp" line="1362"/>
+        <location filename="../mainwindow.cpp" line="1374"/>
+        <location filename="../mainwindow.cpp" line="1375"/>
+        <source>Buffer files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1362"/>
+        <source>Load Sonic Pi Buffer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1362"/>
+        <location filename="../mainwindow.cpp" line="1375"/>
+        <source>Text files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1362"/>
+        <location filename="../mainwindow.cpp" line="1375"/>
+        <source>Ruby files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1362"/>
+        <location filename="../mainwindow.cpp" line="1375"/>
+        <source>All files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1375"/>
         <source>Save Current Buffer</source>
         <translation>Jelenlegi puffer mentése</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1259"/>
+        <location filename="../mainwindow.cpp" line="1447"/>
         <source>Running Code...</source>
         <translation>Kód futtatása...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1285"/>
-        <source>Workspace %1</source>
-        <translation>Munkaterület %1</translation>
-    </message>
-    <message>
-        <location filename="../mainwindow.cpp" line="1301"/>
+        <location filename="../mainwindow.cpp" line="1496"/>
         <source>Zooming In...</source>
         <translation>Nagyítás...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1308"/>
+        <location filename="../mainwindow.cpp" line="1503"/>
         <source>Zooming Out...</source>
         <translation>Kicsinyítés...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1315"/>
+        <location filename="../mainwindow.cpp" line="1510"/>
         <source>Beautifying...</source>
         <translation>Megszépítés...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1335"/>
+        <location filename="../mainwindow.cpp" line="1530"/>
         <source>Reloading...</source>
         <translation>Újratöltés...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1342"/>
+        <location filename="../mainwindow.cpp" line="1537"/>
         <source>Checking for updates...</source>
         <translation>Frissítések keresése...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1350"/>
+        <location filename="../mainwindow.cpp" line="1545"/>
         <source>Enabling update checking...</source>
         <translation>Frissítések keresésének bekapcsolása...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1358"/>
+        <location filename="../mainwindow.cpp" line="1553"/>
         <source>Disabling update checking...</source>
         <translation>Frissítések keresésének kikapcsolása...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1366"/>
+        <location filename="../mainwindow.cpp" line="1561"/>
         <source>Enabling Mixer HPF...</source>
         <translation>Mixer HPF bekapcsolása...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1375"/>
+        <location filename="../mainwindow.cpp" line="1570"/>
         <source>Disabling Mixer HPF...</source>
         <translation>Mixer HPF kikapcsolása...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1383"/>
+        <location filename="../mainwindow.cpp" line="1578"/>
         <source>Enabling Mixer LPF...</source>
         <translation>Mixer LPF bekapcsolása...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1392"/>
+        <location filename="../mainwindow.cpp" line="1587"/>
         <source>Disabling Mixer LPF...</source>
         <translation>Mixer LPF kikapcsolása...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1400"/>
+        <location filename="../mainwindow.cpp" line="1595"/>
         <source>Enabling Inverted Stereo...</source>
         <translation>Invertált sztereó bekapcsolása...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1408"/>
+        <location filename="../mainwindow.cpp" line="1603"/>
         <source>Enabling Standard Stereo...</source>
         <translation>Sztenderd sztereó bekapcsolása...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1416"/>
+        <location filename="../mainwindow.cpp" line="1611"/>
         <source>Mono Mode...</source>
         <translation>Monó mód...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1424"/>
+        <location filename="../mainwindow.cpp" line="1619"/>
         <source>Stereo Mode...</source>
         <translation>Sztereó mód...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1433"/>
+        <location filename="../mainwindow.cpp" line="1628"/>
         <source>Stopping...</source>
         <translation>Megállítás...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1529"/>
+        <location filename="../mainwindow.cpp" line="1736"/>
         <source>Updating System Volume...</source>
         <translation>Rendszerhangerő frissítése...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1751"/>
+        <location filename="../mainwindow.cpp" line="1752"/>
+        <source>Log Auto Scroll on...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1754"/>
+        <source>Log Auto Scroll off...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2155"/>
         <source>Switching To Headphone Audio Output...</source>
         <translation>Váltás a fejhallgató-hangkimenetre...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1767"/>
+        <location filename="../mainwindow.cpp" line="2171"/>
         <source>Switching To HDMI Audio Output...</source>
         <translation>Váltás a HDMI-hangkimenetre...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1782"/>
+        <location filename="../mainwindow.cpp" line="2186"/>
         <source>Switching To Default Audio Output...</source>
         <translation>Váltás az alapértelmezett hangkimenetre...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1933"/>
+        <location filename="../mainwindow.cpp" line="2337"/>
         <source>Run</source>
         <translation>Futtatás</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1934"/>
-        <source>Run the code in the current workspace</source>
-        <translation>A kód futtatása a jelenlegi munkaterületen</translation>
-    </message>
-    <message>
-        <location filename="../mainwindow.cpp" line="1939"/>
+        <location filename="../mainwindow.cpp" line="2343"/>
         <source>Stop</source>
         <translation>Megállítás</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1940"/>
+        <location filename="../mainwindow.cpp" line="2344"/>
         <source>Stop all running code</source>
         <translation>Minden futó kód megállítása</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1943"/>
+        <location filename="../mainwindow.cpp" line="2347"/>
         <source>Save As...</source>
         <translation>Mentés másként...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1944"/>
+        <location filename="../mainwindow.cpp" line="2348"/>
         <source>Save current buffer as an external file</source>
         <translation>Jelenlegi puffer mentése külső fájlként</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1947"/>
+        <location filename="../mainwindow.cpp" line="2351"/>
+        <source>Load</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2352"/>
+        <source>Load an external file in the current buffer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2355"/>
         <source>Info</source>
         <translation>Infó</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1948"/>
+        <location filename="../mainwindow.cpp" line="2356"/>
         <source>See information about Sonic Pi</source>
         <translation>Információk megtekintése a Sonic Pi-ról</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1953"/>
+        <location filename="../mainwindow.cpp" line="2361"/>
+        <source>View audio output</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2365"/>
         <source>Toggle help pane</source>
         <translation>Súgó-panel mutatása/elrejtése</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1956"/>
+        <location filename="../mainwindow.cpp" line="2368"/>
         <source>Prefs</source>
         <translation>Beállítások</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1957"/>
+        <location filename="../mainwindow.cpp" line="2369"/>
         <source>Toggle preferences pane</source>
         <translation>Beállítások-panel mutatása/elrejtése</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1961"/>
-        <location filename="../mainwindow.cpp" line="2083"/>
-        <location filename="../mainwindow.cpp" line="2084"/>
+        <location filename="../mainwindow.cpp" line="2373"/>
+        <location filename="../mainwindow.cpp" line="2502"/>
+        <location filename="../mainwindow.cpp" line="2503"/>
         <source>Start Recording</source>
         <translation>Felvétel elindítása</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1962"/>
+        <location filename="../mainwindow.cpp" line="2374"/>
         <source>Start recording to WAV audio file</source>
         <translation>Felvétel elindítása WAV hangfájlba</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1966"/>
+        <location filename="../mainwindow.cpp" line="2378"/>
         <source>Auto-Align Text</source>
         <translation>Szöveg automatikus igazítása</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1967"/>
+        <location filename="../mainwindow.cpp" line="2379"/>
         <source>Improve readability of code</source>
         <translation>A kód olvashatóságának javítása</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1971"/>
-        <location filename="../mainwindow.cpp" line="1972"/>
+        <location filename="../mainwindow.cpp" line="2385"/>
         <source>Increase Text Size</source>
         <translation>Betűméret növelése</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1976"/>
-        <location filename="../mainwindow.cpp" line="1977"/>
+        <location filename="../mainwindow.cpp" line="2392"/>
         <source>Decrease Text Size</source>
         <translation>Betűméret csökkentése</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1982"/>
+        <location filename="../mainwindow.cpp" line="2397"/>
         <source>Tools</source>
         <translation>Eszközök</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2029"/>
+        <location filename="../mainwindow.cpp" line="2448"/>
         <source>About</source>
         <translation>Névjegy</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2030"/>
+        <location filename="../mainwindow.cpp" line="2449"/>
         <source>Core Team</source>
         <translation>Fejlesztőcsapat</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2031"/>
+        <location filename="../mainwindow.cpp" line="2450"/>
         <source>Contributors</source>
         <translation>Támogató fejlesztők</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2032"/>
+        <location filename="../mainwindow.cpp" line="2451"/>
         <source>Community</source>
         <translation>Közösség</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2033"/>
+        <location filename="../mainwindow.cpp" line="2452"/>
         <source>License</source>
         <translation>Licenc</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2034"/>
+        <location filename="../mainwindow.cpp" line="2453"/>
         <source>History</source>
         <translation>Történet</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2055"/>
+        <location filename="../mainwindow.cpp" line="2474"/>
         <source>Sonic Pi - Info</source>
         <translation>Sonic Pi - Infó</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2075"/>
-        <location filename="../mainwindow.cpp" line="2076"/>
+        <location filename="../mainwindow.cpp" line="2494"/>
+        <location filename="../mainwindow.cpp" line="2495"/>
         <source>Stop Recording</source>
         <translation>Felvétel megállítása</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2089"/>
+        <location filename="../mainwindow.cpp" line="2508"/>
         <source>Save Recording</source>
         <translation>Felvétel mentése</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2108"/>
+        <location filename="../mainwindow.cpp" line="2508"/>
+        <source>Wavefile (*.wav)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2527"/>
         <source>Ready...</source>
         <translation>Kész...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2185"/>
+        <location filename="../mainwindow.cpp" line="2608"/>
         <source>Cannot read file %1:
 %2.</source>
         <translation>Nem sikerült a %1 fájl olvasása: %2.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2195"/>
+        <location filename="../mainwindow.cpp" line="2619"/>
         <source>File loaded...</source>
         <translation>Fájl betöltve...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2203"/>
+        <location filename="../mainwindow.cpp" line="2628"/>
         <source>Cannot write file %1:
 %2.</source>
         <translation>Nem sikerült a %1 fájl írása: %2.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2220"/>
+        <location filename="../mainwindow.cpp" line="2646"/>
         <source>File saved...</source>
         <translation>Fájl mentve...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2445"/>
+        <location filename="../mainwindow.cpp" line="2873"/>
         <source>Last checked %1</source>
         <translation>Legutóbb ellenőrizve %1</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2447"/>
+        <location filename="../mainwindow.cpp" line="2875"/>
         <source>Sonic Pi checks for updates
 every two weeks.</source>
         <translation>A Sonic Pi frissítéseket keres
 minden második héten.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2449"/>
+        <location filename="../mainwindow.cpp" line="2877"/>
         <source>This is Sonic Pi %1</source>
         <translation>Ez a Sonic Pi %1</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2450"/>
+        <location filename="../mainwindow.cpp" line="2878"/>
         <source>Version %2 is now available!</source>
         <translation>Már elérhető a %2 verzió!</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2454"/>
+        <location filename="../mainwindow.cpp" line="2882"/>
         <source>New version available!
 Get Sonic Pi %1</source>
         <translation>Új verzió elérhető!
 Szerezd be: Sonic Pi %1</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2480"/>
+        <location filename="../mainwindow.cpp" line="2908"/>
         <source>Welcome back. Now get your live code on...</source>
         <translation>Üdvözlünk ismét. Kezdődjön az élő kódolás...</translation>
     </message>
     <message>
-        <location filename="../ruby_help.h" line="80"/>
-        <location filename="../ruby_help.h" line="99"/>
-        <location filename="../ruby_help.h" line="159"/>
-        <location filename="../ruby_help.h" line="218"/>
-        <location filename="../ruby_help.h" line="278"/>
-        <location filename="../ruby_help.h" line="339"/>
+        <location filename="../ruby_help.h" line="93"/>
+        <location filename="../ruby_help.h" line="154"/>
+        <location filename="../ruby_help.h" line="215"/>
+        <location filename="../ruby_help.h" line="274"/>
+        <location filename="../ruby_help.h" line="293"/>
+        <location filename="../ruby_help.h" line="367"/>
+        <location filename="../ruby_help.h" line="442"/>
         <source>Tutorial</source>
         <translation>Bevezetés</translation>
     </message>
     <message>
-        <location filename="../ruby_help.h" line="371"/>
+        <location filename="../ruby_help.h" line="476"/>
         <source>Examples</source>
         <translation>Példák</translation>
     </message>
     <message>
-        <location filename="../ruby_help.h" line="412"/>
+        <location filename="../ruby_help.h" line="522"/>
         <source>Synths</source>
         <translation>Synth-ek</translation>
     </message>
     <message>
-        <location filename="../ruby_help.h" line="448"/>
+        <location filename="../ruby_help.h" line="564"/>
         <source>Fx</source>
         <translation>Fx</translation>
     </message>
     <message>
-        <location filename="../ruby_help.h" line="465"/>
+        <location filename="../ruby_help.h" line="583"/>
         <source>Samples</source>
         <translation>Hangminták</translation>
     </message>
     <message>
-        <location filename="../ruby_help.h" line="638"/>
+        <location filename="../ruby_help.h" line="779"/>
         <source>Lang</source>
         <translation>Programnyelv</translation>
     </message>
@@ -777,11 +892,11 @@ Szerezd be: Sonic Pi %1</translation>
     </message>
 </context>
 <context>
-    <name>SonicPiUDPServer</name>
+    <name>SonicPiUDPOSCServer</name>
     <message>
-        <location filename="../sonicpiudpserver.cpp" line="24"/>
+        <location filename="../sonic_pi_udp_osc_server.cpp" line="38"/>
         <source>Is Sonic Pi already running?  Can&apos;t open UDP port 4558.</source>
-        <translation>Esetleg már fut a Sonic Pi?  Nem sikerül megnyitni a 4558-as UDP portot.</translation>
+        <translation type="unfinished">Esetleg már fut a Sonic Pi?  Nem sikerül megnyitni a 4558-as UDP portot.</translation>
     </message>
 </context>
 </TS>

--- a/app/gui/qt/lang/sonic-pi_is.ts
+++ b/app/gui/qt/lang/sonic-pi_is.ts
@@ -1,112 +1,86 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0" language="is_IS">
-<defaultcodec>UTF-8</defaultcodec>
+<TS version="2.1" language="is_IS">
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../mainwindow.cpp" line="153"/>
+        <location filename="../mainwindow.cpp" line="277"/>
         <source>Sonic Pi update info</source>
         <translation>Upplýsingar um Sonic Pi uppfærslur</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="296"/>
+        <location filename="../mainwindow.cpp" line="387"/>
         <source>Buffer %1</source>
         <translation>Rissblað %1</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="360"/>
+        <location filename="../mainwindow.cpp" line="459"/>
         <source>Preferences</source>
         <translation>Stillingar</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="373"/>
+        <location filename="../mainwindow.cpp" line="472"/>
         <source>Log</source>
         <translation>Atburðaskrá</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="414"/>
-        <location filename="../mainwindow.cpp" line="1920"/>
+        <location filename="../mainwindow.cpp" line="513"/>
+        <location filename="../mainwindow.cpp" line="2364"/>
         <source>Help</source>
         <translation>Hjálp</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="445"/>
-        <location filename="../mainwindow.cpp" line="2152"/>
-        <location filename="../mainwindow.cpp" line="2170"/>
+        <location filename="../mainwindow.cpp" line="184"/>
+        <location filename="../mainwindow.cpp" line="2607"/>
+        <location filename="../mainwindow.cpp" line="2627"/>
         <source>Sonic Pi</source>
         <translation>Sonic Pi</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="459"/>
+        <location filename="../mainwindow.cpp" line="235"/>
         <source>Welcome to Sonic Pi</source>
         <translation>Velkomin(n) í Sonic Pi</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="601"/>
+        <location filename="../mainwindow.cpp" line="708"/>
         <source>Indenting selection...</source>
         <translation>Dreg inn val...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="605"/>
+        <location filename="../mainwindow.cpp" line="712"/>
         <source>Indenting line...</source>
         <translation>Dreg inn línu...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="634"/>
-        <source>Commenting selection...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../mainwindow.cpp" line="638"/>
-        <source>Commenting line...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../mainwindow.cpp" line="717"/>
-        <source>Ruby could not be started, is it installed and in your PATH?</source>
-        <translation>Gat ekki ræst Ruby, er það sett upp og í PATH?</translation>
-    </message>
-    <message>
-        <location filename="../mainwindow.cpp" line="803"/>
+        <location filename="../mainwindow.cpp" line="911"/>
         <source>Raspberry Pi System Volume</source>
         <translation>Hljóðstyrkur kerfis á Raspberry Pi</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="804"/>
+        <location filename="../mainwindow.cpp" line="912"/>
         <source>Use this slider to change the system volume of your Raspberry Pi.</source>
         <translation>Notaðu þennan sleða til að breyta hljóðstyrk kerfisins á Raspberry Pi.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="806"/>
+        <location filename="../mainwindow.cpp" line="914"/>
         <source>Advanced Audio</source>
         <translation>Flóknari hjóðstillingar</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="807"/>
+        <location filename="../mainwindow.cpp" line="915"/>
         <source>Advanced audio settings for working with
 external PA systems when performing with Sonic Pi.</source>
         <translation>Flóknari hljóðstillingar sem notast með ytri\nhljóðkerfum þegar komið er fram með Sonic Pi.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="808"/>
-        <source>Invert Stereo</source>
-        <translation>Viðsnúinn víðómur</translation>
-    </message>
-    <message>
-        <location filename="../mainwindow.cpp" line="809"/>
+        <location filename="../mainwindow.cpp" line="917"/>
         <source>Toggle stereo inversion.
 If enabled, audio sent to the left speaker will
 be routed to the right speaker and visa versa.</source>
         <translation>Breyta viðsnúnum víðóm.\nEf virkjað þá er hljóð ætlað í vinstri hátalara\nsent í hægri hátalara og öfugt.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="811"/>
-        <source>Force Mono</source>
-        <translation>Þvinga einóm</translation>
-    </message>
-    <message>
-        <location filename="../mainwindow.cpp" line="812"/>
+        <location filename="../mainwindow.cpp" line="920"/>
         <source>Toggle mono mode.
 If enabled both right and left audio is mixed and
 the same signal is sent to both speakers.
@@ -115,24 +89,55 @@ can only handle mono.</source>
         <translation>Breyta einóma ham.\nEf virkjað þá er hægri og vinstri hljóðrás blandað og\nsama merki sent í báða hátalara.\nGagnlegt þegar unnið er með ytri hljóðkerfi\nsem höndla bara einóm.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="815"/>
+        <location filename="../mainwindow.cpp" line="976"/>
         <source>Safe mode</source>
         <translation>Öruggur hamur</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="816"/>
+        <location filename="../mainwindow.cpp" line="977"/>
         <source>Toggle synth argument checking functions.
 If disabled, certain synth opt values may
 create unexpectedly loud or uncomfortable sounds.</source>
         <translation>Breyta yfirferð viðfanga á hljóðgervla.\nEf ekki virkjað þá gæti sum viðföng á hljóðgervla valdið hávaða eða\nóþægilegum hljóðum þegar ekki er búist við þeim.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="828"/>
+        <location filename="../mainwindow.cpp" line="933"/>
         <source>Raspberry Pi Audio Output</source>
         <translation>Hljóðúttak á Raspberry Pi</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="829"/>
+        <location filename="../mainwindow.cpp" line="452"/>
+        <location filename="../mainwindow.cpp" line="2360"/>
+        <source>Scope</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="741"/>
+        <source>Toggle selection comment...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="745"/>
+        <source>Toggle line comment...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="803"/>
+        <source>The Sonic Pi Server could not be started!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="916"/>
+        <source>Invert stereo</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="919"/>
+        <source>Force mono</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="934"/>
         <source>Your Raspberry Pi has two forms of audio output.
 Firstly, there is the headphone jack of the Raspberry Pi itself.
 Secondly, some HDMI monitors/TVs support audio through the HDMI port.
@@ -140,607 +145,717 @@ Use these buttons to force the output to the one you want.</source>
         <translation>Raspberry Pi tölvan þín hefur tvennskonar úttak fyrir hljóð.\nAnnarsvegar er tengi fyrir heyrnartól á sjálfri Raspberry Pi tölvunni. Hinsvegar styðja sumir HDMI skjáir/sjónvörp hljóð í gegnum HDMI tengið.\nNotaðu þessa takka til að þvinga hljóðiðí það úttak sem þú vilt.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="830"/>
+        <location filename="../mainwindow.cpp" line="935"/>
         <source>&amp;Default</source>
         <translation>&amp;Sjálfgefið</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="831"/>
+        <location filename="../mainwindow.cpp" line="936"/>
         <source>&amp;Headphones</source>
         <translation>&amp;Heyrnartól</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="832"/>
+        <location filename="../mainwindow.cpp" line="937"/>
         <source>&amp;HDMI</source>
         <translation>&amp;HDMI</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="852"/>
+        <location filename="../mainwindow.cpp" line="957"/>
         <source>Logging</source>
         <translation>Skráning atburða</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="853"/>
+        <location filename="../mainwindow.cpp" line="958"/>
         <source>Configure debug behaviour</source>
         <translation>Stilla hegðun við aflúsun</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="855"/>
+        <location filename="../mainwindow.cpp" line="960"/>
+        <source>Synths and FX</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="961"/>
+        <source>Modify behaviour of synths and FX</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="963"/>
         <source>Log synths</source>
         <translation>Skrá atburði hljóðgervla</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="856"/>
+        <location filename="../mainwindow.cpp" line="964"/>
         <source>Toggle log messages.
 If disabled, activity such as synth and sample
 triggering will not be printed to the log by default.</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="858"/>
+        <location filename="../mainwindow.cpp" line="966"/>
         <source>Clear log on run</source>
         <translation>Hreinsa atburðaskrá við keyrslu</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="859"/>
+        <location filename="../mainwindow.cpp" line="967"/>
         <source>Toggle log clearing on run.
 If enabled, the log is cleared each
 time the run button is pressed.</source>
         <translation>Breyta hreinsun atburðaskráar við keyrslu.\nEf virkjað þá er atburðaskráin hreinsuð\nhvert sinn sem stutt er á keyra hnappinn.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="861"/>
+        <location filename="../mainwindow.cpp" line="969"/>
         <source>Log cues</source>
         <translation>Skrá atburði um &quot;cues&quot;</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="862"/>
+        <location filename="../mainwindow.cpp" line="970"/>
         <source>Enable or disable logging of cues.
 If disabled, cues will still trigger.
 However, they will not be visible in the logs.</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="871"/>
+        <location filename="../mainwindow.cpp" line="972"/>
+        <source>Log auto scroll</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="973"/>
+        <source>Toggle log auto scrolling.
+If enabled the log is scrolled to the bottom after every new message is displayed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="980"/>
+        <source>Enable external synths and FX</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="981"/>
+        <source>When enabled, Sonic Pi will allow
+synths and FX loaded via load_synthdefs
+to be triggered.
+
+When disabled, Sonic Pi will complain
+when you attempt to use a synth or FX
+which isn&apos;t recognised.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="983"/>
+        <source>Enforce timing guarantees</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="984"/>
+        <source>When enabled, Sonic Pi will refuse
+to trigger synths and FX if
+it is too late to do so
+
+When disabled, Sonic Pi will always
+attempt to trigger synths and FX
+even when a little late.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1001"/>
         <source>Transparency</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="882"/>
-        <location filename="../mainwindow.cpp" line="1004"/>
+        <location filename="../mainwindow.cpp" line="1012"/>
+        <location filename="../mainwindow.cpp" line="1144"/>
         <source>Updates</source>
         <translation>Uppfærslur</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="884"/>
+        <location filename="../mainwindow.cpp" line="1014"/>
         <source>Check for updates</source>
         <translation>Athuga með uppfærslur</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="886"/>
+        <location filename="../mainwindow.cpp" line="1016"/>
         <source>Toggle automatic update checking.
 This check involves sending anonymous information about your platform and version.</source>
         <translation>Breyta sjálfvirkum athugunum á uppfærslum.\nÞetta felur í sér að senda nafnlausar upplýsingar um búnað þinn og útgáfu.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="887"/>
+        <location filename="../mainwindow.cpp" line="1017"/>
         <source>Check now</source>
         <translation>Athuga núna</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="888"/>
+        <location filename="../mainwindow.cpp" line="1018"/>
         <source>Force a check for updates now.
 This check involves sending anonymous information about your platform and version.</source>
         <translation>Þvinga athugun á uppfærslum núna.\nÞetta felur í sér að senda nafnlausar upplýsingar um búnað þinn og útgáfu.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="889"/>
+        <location filename="../mainwindow.cpp" line="1019"/>
         <source>Get update</source>
         <translation>Sækja uppfærslu</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="890"/>
+        <location filename="../mainwindow.cpp" line="1020"/>
         <source>Visit http://sonic-pi.net to download new version</source>
         <translation>Heimsæktu http://sonic-pi.net til að sækja nýjustu útgáfu</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="895"/>
+        <location filename="../mainwindow.cpp" line="1025"/>
         <source>Update Info</source>
         <translation>Uppfærslu upplýsingar</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="914"/>
+        <location filename="../mainwindow.cpp" line="1044"/>
         <source>Show and Hide</source>
         <translation>Sýna og fela</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="915"/>
+        <location filename="../mainwindow.cpp" line="1045"/>
         <source>Configure editor display options.</source>
         <translation>Stilla framsetningu ritils.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="916"/>
+        <location filename="../mainwindow.cpp" line="1046"/>
         <source>Look and Feel</source>
         <translation>Útlit og hegðun</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="917"/>
+        <location filename="../mainwindow.cpp" line="1047"/>
         <source>Configure editor look and feel.</source>
         <translation>Stilla útlit og hegðun ritils.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="918"/>
+        <location filename="../mainwindow.cpp" line="1048"/>
         <source>Automation</source>
         <translation>Sjálfvirkni</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="919"/>
+        <location filename="../mainwindow.cpp" line="1049"/>
         <source>Configure automation features.</source>
         <translation>Stilla sjálfvirkni.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="920"/>
+        <location filename="../mainwindow.cpp" line="1050"/>
         <source>Auto-align</source>
         <translation>Jafna sjálfvirkt</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="921"/>
+        <location filename="../mainwindow.cpp" line="1051"/>
         <source>Automatically align code on Run</source>
         <translation>Jafna kóða sjálfvirkt við keyrslu</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="923"/>
+        <location filename="../mainwindow.cpp" line="1053"/>
         <source>Show line numbers</source>
         <translation>Sýna línunúmer</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="924"/>
+        <location filename="../mainwindow.cpp" line="1054"/>
         <source>Toggle line number visibility.</source>
         <translation>Breyta sýnileika línunúmera.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="925"/>
+        <location filename="../mainwindow.cpp" line="1055"/>
         <source>Show log</source>
         <translation>Sýna atburðaskrá</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="926"/>
+        <location filename="../mainwindow.cpp" line="1056"/>
         <source>Toggle visibility of the log.</source>
         <translation>Breyta sýnileika atburðaskrár.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="928"/>
+        <location filename="../mainwindow.cpp" line="1058"/>
         <source>Show buttons</source>
         <translation>Sýna hnappa</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="929"/>
+        <location filename="../mainwindow.cpp" line="1059"/>
         <source>Toggle visibility of the control buttons.</source>
         <translation>Breyta sýnileika stýrihnappa.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="931"/>
+        <location filename="../mainwindow.cpp" line="1061"/>
         <source>Show tabs</source>
         <translation>Sýna flipa</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="933"/>
+        <location filename="../mainwindow.cpp" line="1063"/>
         <source>Toggle visibility of the buffer selection tabs.</source>
         <translation>Breyta sýnileika flipa fyrir rissblöð.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="934"/>
+        <location filename="../mainwindow.cpp" line="1064"/>
         <source>Full screen</source>
         <translation>Fylla skjá</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="935"/>
+        <location filename="../mainwindow.cpp" line="1065"/>
         <source>Toggle full screen mode.</source>
         <translation>Breyta í/frá fullum skjá.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="936"/>
+        <location filename="../mainwindow.cpp" line="1066"/>
         <source>Dark mode</source>
         <translation>Dökkur hamur</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="937"/>
+        <location filename="../mainwindow.cpp" line="1067"/>
         <source>Toggle dark mode.</source>
         <translation>Breyta í/úr dökkum ham.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="937"/>
+        <location filename="../mainwindow.cpp" line="1067"/>
         <source>
 Dark mode is perfect for live coding in night clubs.</source>
         <translation>Dökki hamurinn hentar sérlega vel þegar komið er fram í næturklúbbum.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="976"/>
+        <location filename="../mainwindow.cpp" line="1106"/>
         <source>Audio</source>
         <translation>Hljóð</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="988"/>
+        <location filename="../mainwindow.cpp" line="1118"/>
         <source>Editor</source>
         <translation>Ritill</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="989"/>
+        <location filename="../mainwindow.cpp" line="1119"/>
         <source>Studio</source>
         <translation>Hljóðver</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="991"/>
-        <location filename="../mainwindow.cpp" line="996"/>
+        <location filename="../mainwindow.cpp" line="1121"/>
+        <location filename="../mainwindow.cpp" line="1131"/>
         <source>Performance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="992"/>
+        <location filename="../mainwindow.cpp" line="1122"/>
         <source>Settings useful for performing with Sonic Pi</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1087"/>
+        <location filename="../mainwindow.cpp" line="1259"/>
         <source>Server boot error...</source>
         <translation>Villa við gangsetningu þjóns...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1087"/>
-        <source>Apologies, a critical error occurred during startup</source>
-        <translation>Afsakið, krítísk villa varð við ræsingu</translation>
+        <location filename="../mainwindow.cpp" line="2338"/>
+        <source>Run the code in the current buffer</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1087"/>
+        <location filename="../mainwindow.cpp" line="1259"/>
         <source>Please consider reporting a bug at</source>
         <translation>Kæmi til greina að tilkynna villu á</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1181"/>
+        <location filename="../mainwindow.cpp" line="1259"/>
+        <source>Sonic Pi Boot Error
+
+Apologies, a critical error occurred during startup</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1361"/>
+        <location filename="../mainwindow.cpp" line="1362"/>
+        <location filename="../mainwindow.cpp" line="1374"/>
+        <location filename="../mainwindow.cpp" line="1375"/>
+        <source>Buffer files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1362"/>
+        <source>Load Sonic Pi Buffer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1362"/>
+        <location filename="../mainwindow.cpp" line="1375"/>
+        <source>Text files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1362"/>
+        <location filename="../mainwindow.cpp" line="1375"/>
+        <source>Ruby files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1362"/>
+        <location filename="../mainwindow.cpp" line="1375"/>
+        <source>All files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1375"/>
         <source>Save Current Buffer</source>
         <translation>Vista virka rissblað</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1249"/>
+        <location filename="../mainwindow.cpp" line="1447"/>
         <source>Running Code...</source>
         <translation>Keyri kóða...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1275"/>
-        <source>Workspace %1</source>
-        <translation>Vinnusvæði %1</translation>
-    </message>
-    <message>
-        <location filename="../mainwindow.cpp" line="1291"/>
+        <location filename="../mainwindow.cpp" line="1496"/>
         <source>Zooming In...</source>
         <translation>Þysja inn...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1298"/>
+        <location filename="../mainwindow.cpp" line="1503"/>
         <source>Zooming Out...</source>
         <translation>Þysja út...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1305"/>
+        <location filename="../mainwindow.cpp" line="1510"/>
         <source>Beautifying...</source>
         <translation>Fegra...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1325"/>
+        <location filename="../mainwindow.cpp" line="1530"/>
         <source>Reloading...</source>
         <translation>Endurhleð...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1332"/>
+        <location filename="../mainwindow.cpp" line="1537"/>
         <source>Checking for updates...</source>
         <translation>Athuga með uppfærslur...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1340"/>
+        <location filename="../mainwindow.cpp" line="1545"/>
         <source>Enabling update checking...</source>
         <translation>Virkja uppfærsluathugun...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1348"/>
+        <location filename="../mainwindow.cpp" line="1553"/>
         <source>Disabling update checking...</source>
         <translation>Afvirka uppfærsluathugun...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1356"/>
+        <location filename="../mainwindow.cpp" line="1561"/>
         <source>Enabling Mixer HPF...</source>
         <translation>Virkja mixer HPF...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1365"/>
+        <location filename="../mainwindow.cpp" line="1570"/>
         <source>Disabling Mixer HPF...</source>
         <translation>Afvirkja Mixer HPF...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1373"/>
+        <location filename="../mainwindow.cpp" line="1578"/>
         <source>Enabling Mixer LPF...</source>
         <translation>Virkja Mixer LPF...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1382"/>
+        <location filename="../mainwindow.cpp" line="1587"/>
         <source>Disabling Mixer LPF...</source>
         <translation>Afvirkja Mixer LPF...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1390"/>
+        <location filename="../mainwindow.cpp" line="1595"/>
         <source>Enabling Inverted Stereo...</source>
         <translation>Virkja speglaðan víðóm...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1398"/>
+        <location filename="../mainwindow.cpp" line="1603"/>
         <source>Enabling Standard Stereo...</source>
         <translation>Virkja venjulegan víðóm...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1406"/>
+        <location filename="../mainwindow.cpp" line="1611"/>
         <source>Mono Mode...</source>
         <translation>Einóma hamur...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1414"/>
+        <location filename="../mainwindow.cpp" line="1619"/>
         <source>Stereo Mode...</source>
         <translation>Víðóma hamur...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1423"/>
+        <location filename="../mainwindow.cpp" line="1628"/>
         <source>Stopping...</source>
         <translation>Stöðva...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1507"/>
+        <location filename="../mainwindow.cpp" line="1736"/>
         <source>Updating System Volume...</source>
         <translation>Uppfæri hljóðstyrk kerfis...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1729"/>
+        <location filename="../mainwindow.cpp" line="1752"/>
+        <source>Log Auto Scroll on...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1754"/>
+        <source>Log Auto Scroll off...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2155"/>
         <source>Switching To Headphone Audio Output...</source>
         <translation>Skipti í hljóðúttak fyrir heyrnartól...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1745"/>
+        <location filename="../mainwindow.cpp" line="2171"/>
         <source>Switching To HDMI Audio Output...</source>
         <translation>Skipti í HDMI hljóðúttak...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1760"/>
+        <location filename="../mainwindow.cpp" line="2186"/>
         <source>Switching To Default Audio Output...</source>
         <translation>Skipti í sjálfgefna hljóðúttakið...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1902"/>
+        <location filename="../mainwindow.cpp" line="2337"/>
         <source>Run</source>
         <translation>Keyra</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1903"/>
-        <source>Run the code in the current workspace</source>
-        <translation>Keyra kóðann í núverandi vinnusvæði</translation>
-    </message>
-    <message>
-        <location filename="../mainwindow.cpp" line="1907"/>
+        <location filename="../mainwindow.cpp" line="2343"/>
         <source>Stop</source>
         <translation>Stöðva</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1908"/>
+        <location filename="../mainwindow.cpp" line="2344"/>
         <source>Stop all running code</source>
         <translation>Stöðva allan keyrandi kóða</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1911"/>
+        <location filename="../mainwindow.cpp" line="2347"/>
         <source>Save As...</source>
         <translation>Vista sem...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1912"/>
+        <location filename="../mainwindow.cpp" line="2348"/>
         <source>Save current buffer as an external file</source>
         <translation>Vista virkt rissblað sem ytri skrá</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1915"/>
+        <location filename="../mainwindow.cpp" line="2351"/>
+        <source>Load</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2352"/>
+        <source>Load an external file in the current buffer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2355"/>
         <source>Info</source>
         <translation>Upplýsingar</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1916"/>
+        <location filename="../mainwindow.cpp" line="2356"/>
         <source>See information about Sonic Pi</source>
         <translation>Sjá upplýsingar um Sonic Pi</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1921"/>
+        <location filename="../mainwindow.cpp" line="2361"/>
+        <source>View audio output</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2365"/>
         <source>Toggle help pane</source>
         <translation>Breyta hjálpar flöt</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1924"/>
+        <location filename="../mainwindow.cpp" line="2368"/>
         <source>Prefs</source>
         <translation>Kostir</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1925"/>
+        <location filename="../mainwindow.cpp" line="2369"/>
         <source>Toggle preferences pane</source>
         <translation>Breyta flöt fyrir kosti</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1929"/>
-        <location filename="../mainwindow.cpp" line="2051"/>
-        <location filename="../mainwindow.cpp" line="2052"/>
+        <location filename="../mainwindow.cpp" line="2373"/>
+        <location filename="../mainwindow.cpp" line="2502"/>
+        <location filename="../mainwindow.cpp" line="2503"/>
         <source>Start Recording</source>
         <translation>Hefja upptöku</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1930"/>
+        <location filename="../mainwindow.cpp" line="2374"/>
         <source>Start recording to WAV audio file</source>
         <translation>Hefja upptöku í WAV hljóðskrá</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1934"/>
+        <location filename="../mainwindow.cpp" line="2378"/>
         <source>Auto-Align Text</source>
         <translation>Jafna texta sjálfvirkt</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1935"/>
+        <location filename="../mainwindow.cpp" line="2379"/>
         <source>Improve readability of code</source>
         <translation>Bæta læsileika kóða</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1939"/>
-        <location filename="../mainwindow.cpp" line="1940"/>
+        <location filename="../mainwindow.cpp" line="2385"/>
         <source>Increase Text Size</source>
         <translation>Stækka texta</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1944"/>
-        <location filename="../mainwindow.cpp" line="1945"/>
+        <location filename="../mainwindow.cpp" line="2392"/>
         <source>Decrease Text Size</source>
         <translation>Minnka texta</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1950"/>
+        <location filename="../mainwindow.cpp" line="2397"/>
         <source>Tools</source>
         <translation>Tól</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1997"/>
+        <location filename="../mainwindow.cpp" line="2448"/>
         <source>About</source>
         <translation>Um</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1998"/>
+        <location filename="../mainwindow.cpp" line="2449"/>
         <source>Core Team</source>
         <translation>Kjarnateymi</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1999"/>
+        <location filename="../mainwindow.cpp" line="2450"/>
         <source>Contributors</source>
         <translation>Þáttakendur</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2000"/>
+        <location filename="../mainwindow.cpp" line="2451"/>
         <source>Community</source>
         <translation>Samfélag</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2001"/>
+        <location filename="../mainwindow.cpp" line="2452"/>
         <source>License</source>
         <translation>Leyfi</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2002"/>
+        <location filename="../mainwindow.cpp" line="2453"/>
         <source>History</source>
         <translation>Saga</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2023"/>
+        <location filename="../mainwindow.cpp" line="2474"/>
         <source>Sonic Pi - Info</source>
         <translation>Sonic Pi - Upplýsingar</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2043"/>
-        <location filename="../mainwindow.cpp" line="2044"/>
+        <location filename="../mainwindow.cpp" line="2494"/>
+        <location filename="../mainwindow.cpp" line="2495"/>
         <source>Stop Recording</source>
         <translation>Stöðva upptöku</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2057"/>
+        <location filename="../mainwindow.cpp" line="2508"/>
         <source>Save Recording</source>
         <translation>Vista upptöku</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2076"/>
+        <location filename="../mainwindow.cpp" line="2508"/>
+        <source>Wavefile (*.wav)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2527"/>
         <source>Ready...</source>
         <translation>Tilbúin...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2153"/>
+        <location filename="../mainwindow.cpp" line="2608"/>
         <source>Cannot read file %1:
 %2.</source>
         <translation>Get ekki lesið skrá %1: %2.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2163"/>
+        <location filename="../mainwindow.cpp" line="2619"/>
         <source>File loaded...</source>
         <translation>Skrá hlaðið...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2171"/>
+        <location filename="../mainwindow.cpp" line="2628"/>
         <source>Cannot write file %1:
 %2.</source>
         <translation>Get ekki skrifað skrá %1: %2.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2188"/>
+        <location filename="../mainwindow.cpp" line="2646"/>
         <source>File saved...</source>
         <translation>Skrá vistuð...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2413"/>
+        <location filename="../mainwindow.cpp" line="2873"/>
         <source>Last checked %1</source>
         <translation>Síðast athugað %1</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2415"/>
+        <location filename="../mainwindow.cpp" line="2875"/>
         <source>Sonic Pi checks for updates
 every two weeks.</source>
         <translation>Sonic Pi athugar með uppfærslur\naðra hverja viku.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2417"/>
+        <location filename="../mainwindow.cpp" line="2877"/>
         <source>This is Sonic Pi %1</source>
         <translation>Þetta er Sonic Pi %1</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2418"/>
+        <location filename="../mainwindow.cpp" line="2878"/>
         <source>Version %2 is now available!</source>
         <translation>Útgáfa %2 er nú tilbúin!</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2422"/>
+        <location filename="../mainwindow.cpp" line="2882"/>
         <source>New version available!
 Get Sonic Pi %1</source>
         <translation>Ný útgáfa tilbúin!\nSækja Sonic Pi %1</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2448"/>
+        <location filename="../mainwindow.cpp" line="2908"/>
         <source>Welcome back. Now get your live code on...</source>
         <translation>Velkominn aftur. Byrjaðu að kóða í beinni...</translation>
     </message>
     <message>
-        <location filename="../ruby_help.h" line="80"/>
-        <location filename="../ruby_help.h" line="139"/>
-        <location filename="../ruby_help.h" line="199"/>
-        <location filename="../ruby_help.h" line="218"/>
-        <location filename="../ruby_help.h" line="278"/>
-        <location filename="../ruby_help.h" line="338"/>
+        <location filename="../ruby_help.h" line="93"/>
+        <location filename="../ruby_help.h" line="154"/>
+        <location filename="../ruby_help.h" line="215"/>
+        <location filename="../ruby_help.h" line="274"/>
+        <location filename="../ruby_help.h" line="293"/>
+        <location filename="../ruby_help.h" line="367"/>
+        <location filename="../ruby_help.h" line="442"/>
         <source>Tutorial</source>
         <translation>Kennsla</translation>
     </message>
     <message>
-        <location filename="../ruby_help.h" line="370"/>
+        <location filename="../ruby_help.h" line="476"/>
         <source>Examples</source>
         <translation>Dæmi</translation>
     </message>
     <message>
-        <location filename="../ruby_help.h" line="410"/>
+        <location filename="../ruby_help.h" line="522"/>
         <source>Synths</source>
         <translation>Hljóðgervlar</translation>
     </message>
     <message>
-        <location filename="../ruby_help.h" line="446"/>
+        <location filename="../ruby_help.h" line="564"/>
         <source>Fx</source>
         <translation>Fx</translation>
     </message>
     <message>
-        <location filename="../ruby_help.h" line="463"/>
+        <location filename="../ruby_help.h" line="583"/>
         <source>Samples</source>
         <translation>Sömpl</translation>
     </message>
     <message>
-        <location filename="../ruby_help.h" line="629"/>
+        <location filename="../ruby_help.h" line="779"/>
         <source>Lang</source>
         <translation>Mál</translation>
     </message>
@@ -754,11 +869,11 @@ Get Sonic Pi %1</source>
     </message>
 </context>
 <context>
-    <name>SonicPiUDPServer</name>
+    <name>SonicPiUDPOSCServer</name>
     <message>
-        <location filename="../sonicpiudpserver.cpp" line="24"/>
+        <location filename="../sonic_pi_udp_osc_server.cpp" line="38"/>
         <source>Is Sonic Pi already running?  Can&apos;t open UDP port 4558.</source>
-        <translation>Er Sonic Pi þegar keyrandi? Get ekki opnað UDP port 4558.</translation>
+        <translation type="unfinished">Er Sonic Pi þegar keyrandi? Get ekki opnað UDP port 4558.</translation>
     </message>
 </context>
 </TS>

--- a/app/gui/qt/lang/sonic-pi_ja.ts
+++ b/app/gui/qt/lang/sonic-pi_ja.ts
@@ -1,33 +1,32 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0" language="ja_JP">
-<defaultcodec>UTF-8</defaultcodec>
+<TS version="2.1" language="ja_JP">
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../mainwindow.cpp" line="360"/>
+        <location filename="../mainwindow.cpp" line="459"/>
         <source>Preferences</source>
         <translation>環境設定</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="373"/>
+        <location filename="../mainwindow.cpp" line="472"/>
         <source>Log</source>
         <translation>ログ</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="445"/>
-        <location filename="../mainwindow.cpp" line="2152"/>
-        <location filename="../mainwindow.cpp" line="2170"/>
+        <location filename="../mainwindow.cpp" line="184"/>
+        <location filename="../mainwindow.cpp" line="2607"/>
+        <location filename="../mainwindow.cpp" line="2627"/>
         <source>Sonic Pi</source>
         <translation>Sonic Pi</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="803"/>
+        <location filename="../mainwindow.cpp" line="911"/>
         <source>Raspberry Pi System Volume</source>
         <translation>Raspberry Pi システム ボリューム</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="809"/>
+        <location filename="../mainwindow.cpp" line="917"/>
         <source>Toggle stereo inversion.
 If enabled, audio sent to the left speaker will
 be routed to the right speaker and visa versa.</source>
@@ -36,7 +35,7 @@ be routed to the right speaker and visa versa.</source>
 右スピーカーに送られ、逆もまた同様です。</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="812"/>
+        <location filename="../mainwindow.cpp" line="920"/>
         <source>Toggle mono mode.
 If enabled both right and left audio is mixed and
 the same signal is sent to both speakers.
@@ -49,32 +48,32 @@ can only handle mono.</source>
 有用です。</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="828"/>
+        <location filename="../mainwindow.cpp" line="933"/>
         <source>Raspberry Pi Audio Output</source>
         <translation>Raspberry Pi オーディオアウト</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="830"/>
+        <location filename="../mainwindow.cpp" line="935"/>
         <source>&amp;Default</source>
         <translation>&amp;デフォルト</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="831"/>
+        <location filename="../mainwindow.cpp" line="936"/>
         <source>&amp;Headphones</source>
         <translation>&amp;ヘッドフォン</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="832"/>
+        <location filename="../mainwindow.cpp" line="937"/>
         <source>&amp;HDMI</source>
         <translation>&amp;HDMI</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="853"/>
+        <location filename="../mainwindow.cpp" line="958"/>
         <source>Configure debug behaviour</source>
         <translation>デバッグ時の振る舞いを設定します</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="856"/>
+        <location filename="../mainwindow.cpp" line="964"/>
         <source>Toggle log messages.
 If disabled, activity such as synth and sample
 triggering will not be printed to the log by default.</source>
@@ -83,17 +82,17 @@ triggering will not be printed to the log by default.</source>
 デフォルトで出力されなくなります。</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="815"/>
+        <location filename="../mainwindow.cpp" line="976"/>
         <source>Safe mode</source>
         <translation>セーフモード</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="858"/>
+        <location filename="../mainwindow.cpp" line="966"/>
         <source>Clear log on run</source>
         <translation>実行時にログをクリア</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="859"/>
+        <location filename="../mainwindow.cpp" line="967"/>
         <source>Toggle log clearing on run.
 If enabled, the log is cleared each
 time the run button is pressed.</source>
@@ -102,78 +101,73 @@ time the run button is pressed.</source>
 ログがクリアされます。</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="924"/>
+        <location filename="../mainwindow.cpp" line="1054"/>
         <source>Toggle line number visibility.</source>
         <translation>行番号の表示を切り替えます。</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="936"/>
+        <location filename="../mainwindow.cpp" line="1066"/>
         <source>Dark mode</source>
         <translation>ダークモード</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1249"/>
+        <location filename="../mainwindow.cpp" line="1447"/>
         <source>Running Code...</source>
         <oldsource>Running Code....</oldsource>
         <translation>コードを実行します...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1305"/>
+        <location filename="../mainwindow.cpp" line="1510"/>
         <source>Beautifying...</source>
         <oldsource>Beautifying....</oldsource>
         <translation>整形します...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1325"/>
+        <location filename="../mainwindow.cpp" line="1530"/>
         <source>Reloading...</source>
         <oldsource>Reloading....</oldsource>
         <translation>リロードします...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1356"/>
+        <location filename="../mainwindow.cpp" line="1561"/>
         <source>Enabling Mixer HPF...</source>
         <oldsource>Enabling Mixer HPF....</oldsource>
         <translation>ミキサーHPFを有効にしています...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1365"/>
+        <location filename="../mainwindow.cpp" line="1570"/>
         <source>Disabling Mixer HPF...</source>
         <oldsource>Disabling Mixer HPF....</oldsource>
         <translation>ミキサーHPFを無効にしています...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1275"/>
-        <source>Workspace %1</source>
-        <translation>Workspace %1</translation>
-    </message>
-    <message>
-        <location filename="../mainwindow.cpp" line="296"/>
+        <location filename="../mainwindow.cpp" line="387"/>
         <source>Buffer %1</source>
         <translation>Buffer %1</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="459"/>
+        <location filename="../mainwindow.cpp" line="235"/>
         <source>Welcome to Sonic Pi</source>
         <translation>Sonic Piへようこそ</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="601"/>
+        <location filename="../mainwindow.cpp" line="708"/>
         <source>Indenting selection...</source>
         <translation>選択範囲をインデント...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="605"/>
+        <location filename="../mainwindow.cpp" line="712"/>
         <source>Indenting line...</source>
         <translation>行をインデント...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="804"/>
+        <location filename="../mainwindow.cpp" line="912"/>
         <source>Use this slider to change the system volume of your Raspberry Pi.</source>
         <oldsource>Use this slider to change the system volume of your Raspberry Pi</oldsource>
         <translation>Raspberry Piのシステムボリュームを変更するには、このスライダを使用します。</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="807"/>
+        <location filename="../mainwindow.cpp" line="915"/>
         <source>Advanced audio settings for working with
 external PA systems when performing with Sonic Pi.</source>
         <oldsource>Advanced audio settings for working with external PA systems when performing with Sonic Pi.</oldsource>
@@ -181,17 +175,7 @@ external PA systems when performing with Sonic Pi.</source>
 連携するのに必要な高度なオーディオ設定を行います。</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="808"/>
-        <source>Invert Stereo</source>
-        <translation>ステレオ反転</translation>
-    </message>
-    <message>
-        <location filename="../mainwindow.cpp" line="811"/>
-        <source>Force Mono</source>
-        <translation>モノラル設定</translation>
-    </message>
-    <message>
-        <location filename="../mainwindow.cpp" line="829"/>
+        <location filename="../mainwindow.cpp" line="934"/>
         <source>Your Raspberry Pi has two forms of audio output.
 Firstly, there is the headphone jack of the Raspberry Pi itself.
 Secondly, some HDMI monitors/TVs support audio through the HDMI port.
@@ -207,53 +191,38 @@ For example, if you have headphones connected to your Raspberry Pi, choose &apos
 これらのボタンを使用し、あなたが望む出力に設定します。</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="882"/>
-        <location filename="../mainwindow.cpp" line="1004"/>
+        <location filename="../mainwindow.cpp" line="1012"/>
+        <location filename="../mainwindow.cpp" line="1144"/>
         <source>Updates</source>
         <translation>アップデート</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="884"/>
+        <location filename="../mainwindow.cpp" line="1014"/>
         <source>Check for updates</source>
         <translation>アップデートをチェック</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="988"/>
+        <location filename="../mainwindow.cpp" line="1118"/>
         <source>Editor</source>
         <translation>エディタ</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="923"/>
+        <location filename="../mainwindow.cpp" line="1053"/>
         <source>Show line numbers</source>
         <translation>行番号を表示</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="153"/>
+        <location filename="../mainwindow.cpp" line="277"/>
         <source>Sonic Pi update info</source>
         <translation>Sonic Pi アップデート情報</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="634"/>
-        <source>Commenting selection...</source>
-        <translation>選択範囲をコメント...</translation>
-    </message>
-    <message>
-        <location filename="../mainwindow.cpp" line="638"/>
-        <source>Commenting line...</source>
-        <translation>行をコメント...</translation>
-    </message>
-    <message>
-        <location filename="../mainwindow.cpp" line="717"/>
-        <source>Ruby could not be started, is it installed and in your PATH?</source>
-        <translation>rubyを起動できませんでした。rubyがインストールされ、PATHが通っていることを確認ください。</translation>
-    </message>
-    <message>
-        <location filename="../mainwindow.cpp" line="806"/>
+        <location filename="../mainwindow.cpp" line="914"/>
         <source>Advanced Audio</source>
         <translation>高度なオーディオ設定</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="816"/>
+        <location filename="../mainwindow.cpp" line="977"/>
         <source>Toggle synth argument checking functions.
 If disabled, certain synth opt values may
 create unexpectedly loud or uncomfortable sounds.</source>
@@ -262,22 +231,63 @@ create unexpectedly loud or uncomfortable sounds.</source>
 予期せず大きな音が出たり、不快な音が出たりするかもしれません。</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="852"/>
+        <location filename="../mainwindow.cpp" line="957"/>
         <source>Logging</source>
         <translation>ロギング</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="855"/>
+        <location filename="../mainwindow.cpp" line="452"/>
+        <location filename="../mainwindow.cpp" line="2360"/>
+        <source>Scope</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="741"/>
+        <source>Toggle selection comment...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="745"/>
+        <source>Toggle line comment...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="803"/>
+        <source>The Sonic Pi Server could not be started!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="916"/>
+        <source>Invert stereo</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="919"/>
+        <source>Force mono</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="960"/>
+        <source>Synths and FX</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="961"/>
+        <source>Modify behaviour of synths and FX</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="963"/>
         <source>Log synths</source>
         <translation>synthをログ出力</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="861"/>
+        <location filename="../mainwindow.cpp" line="969"/>
         <source>Log cues</source>
         <translation>cueをログ出力</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="862"/>
+        <location filename="../mainwindow.cpp" line="970"/>
         <source>Enable or disable logging of cues.
 If disabled, cues will still trigger.
 However, they will not be visible in the logs.</source>
@@ -286,505 +296,610 @@ However, they will not be visible in the logs.</source>
 ログには出力されません。</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="871"/>
+        <location filename="../mainwindow.cpp" line="972"/>
+        <source>Log auto scroll</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="973"/>
+        <source>Toggle log auto scrolling.
+If enabled the log is scrolled to the bottom after every new message is displayed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="980"/>
+        <source>Enable external synths and FX</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="981"/>
+        <source>When enabled, Sonic Pi will allow
+synths and FX loaded via load_synthdefs
+to be triggered.
+
+When disabled, Sonic Pi will complain
+when you attempt to use a synth or FX
+which isn&apos;t recognised.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="983"/>
+        <source>Enforce timing guarantees</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="984"/>
+        <source>When enabled, Sonic Pi will refuse
+to trigger synths and FX if
+it is too late to do so
+
+When disabled, Sonic Pi will always
+attempt to trigger synths and FX
+even when a little late.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1001"/>
         <source>Transparency</source>
         <translation>透過</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="886"/>
+        <location filename="../mainwindow.cpp" line="1016"/>
         <source>Toggle automatic update checking.
 This check involves sending anonymous information about your platform and version.</source>
         <translation>Sonic Piが起動時に新しいアップデートをチェックするかを切り替えます。
 チェックの際に、プラットフォームとバージョンに関する匿名情報を送信しています。</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="887"/>
+        <location filename="../mainwindow.cpp" line="1017"/>
         <source>Check now</source>
         <translation>今すぐチェック</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="888"/>
+        <location filename="../mainwindow.cpp" line="1018"/>
         <source>Force a check for updates now.
 This check involves sending anonymous information about your platform and version.</source>
         <translation>強制的にアップデートをチェックします。
 チェックの際に、プラットフォームとバージョンに関する匿名情報を送信しています。</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="889"/>
+        <location filename="../mainwindow.cpp" line="1019"/>
         <source>Get update</source>
         <translation>アップデートを取得</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="890"/>
+        <location filename="../mainwindow.cpp" line="1020"/>
         <source>Visit http://sonic-pi.net to download new version</source>
         <translation>新しいバージョンをダウンロードするために、http://sonic-pi.net を表示します</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="895"/>
+        <location filename="../mainwindow.cpp" line="1025"/>
         <source>Update Info</source>
         <translation>アップデート情報</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="914"/>
+        <location filename="../mainwindow.cpp" line="1044"/>
         <source>Show and Hide</source>
         <translation>表示</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="915"/>
+        <location filename="../mainwindow.cpp" line="1045"/>
         <source>Configure editor display options.</source>
         <translation>エディタの表示オプションを設定します。</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="916"/>
+        <location filename="../mainwindow.cpp" line="1046"/>
         <source>Look and Feel</source>
         <translation>ルック・アンド・フィール</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="917"/>
+        <location filename="../mainwindow.cpp" line="1047"/>
         <source>Configure editor look and feel.</source>
         <translation>エディタのルック・アンド・フィールを設定します。</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="918"/>
+        <location filename="../mainwindow.cpp" line="1048"/>
         <source>Automation</source>
         <translation>自動化</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="919"/>
+        <location filename="../mainwindow.cpp" line="1049"/>
         <source>Configure automation features.</source>
         <translation>自動化機能を設定します。</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="920"/>
+        <location filename="../mainwindow.cpp" line="1050"/>
         <source>Auto-align</source>
         <translation>自動整形</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="921"/>
+        <location filename="../mainwindow.cpp" line="1051"/>
         <source>Automatically align code on Run</source>
         <translation>実行時に自動的にコードを整形します</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="925"/>
+        <location filename="../mainwindow.cpp" line="1055"/>
         <source>Show log</source>
         <translation>ログを表示</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="926"/>
+        <location filename="../mainwindow.cpp" line="1056"/>
         <source>Toggle visibility of the log.</source>
         <translation>ログの表示を切り替えます。</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="928"/>
+        <location filename="../mainwindow.cpp" line="1058"/>
         <source>Show buttons</source>
         <translation>ボタンを表示</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="929"/>
+        <location filename="../mainwindow.cpp" line="1059"/>
         <source>Toggle visibility of the control buttons.</source>
         <translation>コントロールボタンの表示を切り替えます。</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="931"/>
+        <location filename="../mainwindow.cpp" line="1061"/>
         <source>Show tabs</source>
         <translation>タブを表示</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="933"/>
+        <location filename="../mainwindow.cpp" line="1063"/>
         <source>Toggle visibility of the buffer selection tabs.</source>
         <translation>buffer選択タブの表示を切り替えます。</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="934"/>
+        <location filename="../mainwindow.cpp" line="1064"/>
         <source>Full screen</source>
         <translation>フルスクリーン</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="935"/>
+        <location filename="../mainwindow.cpp" line="1065"/>
         <source>Toggle full screen mode.</source>
         <translation>フルスクリーンモードを切り替えます。</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="937"/>
+        <location filename="../mainwindow.cpp" line="1067"/>
         <source>Toggle dark mode.</source>
         <translation>ダークモードを切り替えます。</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="937"/>
+        <location filename="../mainwindow.cpp" line="1067"/>
         <source>
 Dark mode is perfect for live coding in night clubs.</source>
         <translation>
 ダークモードは、クラブでのライブコーディングに最適です。</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="976"/>
+        <location filename="../mainwindow.cpp" line="1106"/>
         <source>Audio</source>
         <translation>オーディオ</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="989"/>
+        <location filename="../mainwindow.cpp" line="1119"/>
         <source>Studio</source>
         <translation>スタジオ</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2448"/>
+        <location filename="../mainwindow.cpp" line="1259"/>
+        <source>Sonic Pi Boot Error
+
+Apologies, a critical error occurred during startup</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1361"/>
+        <location filename="../mainwindow.cpp" line="1362"/>
+        <location filename="../mainwindow.cpp" line="1374"/>
+        <location filename="../mainwindow.cpp" line="1375"/>
+        <source>Buffer files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1362"/>
+        <source>Load Sonic Pi Buffer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1362"/>
+        <location filename="../mainwindow.cpp" line="1375"/>
+        <source>Text files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1362"/>
+        <location filename="../mainwindow.cpp" line="1375"/>
+        <source>Ruby files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1362"/>
+        <location filename="../mainwindow.cpp" line="1375"/>
+        <source>All files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1752"/>
+        <source>Log Auto Scroll on...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1754"/>
+        <source>Log Auto Scroll off...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2338"/>
+        <source>Run the code in the current buffer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2351"/>
+        <source>Load</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2352"/>
+        <source>Load an external file in the current buffer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2361"/>
+        <source>View audio output</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2508"/>
+        <source>Wavefile (*.wav)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2908"/>
         <source>Welcome back. Now get your live code on...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1181"/>
+        <location filename="../mainwindow.cpp" line="1375"/>
         <source>Save Current Buffer</source>
         <translation>現在のbufferを保存</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1291"/>
+        <location filename="../mainwindow.cpp" line="1496"/>
         <source>Zooming In...</source>
         <translation>ズームイン...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1298"/>
+        <location filename="../mainwindow.cpp" line="1503"/>
         <source>Zooming Out...</source>
         <translation>ズームアウト...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1332"/>
+        <location filename="../mainwindow.cpp" line="1537"/>
         <source>Checking for updates...</source>
         <translation>アップデートをチェックしています...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1340"/>
+        <location filename="../mainwindow.cpp" line="1545"/>
         <source>Enabling update checking...</source>
         <translation>アップデートのチェックを有効にしています...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1348"/>
+        <location filename="../mainwindow.cpp" line="1553"/>
         <source>Disabling update checking...</source>
         <translation>アップデートのチェックを無効にしています...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1373"/>
+        <location filename="../mainwindow.cpp" line="1578"/>
         <source>Enabling Mixer LPF...</source>
         <oldsource>Enabling Mixer LPF....</oldsource>
         <translation>ミキサーLPFを有効にしています...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1382"/>
+        <location filename="../mainwindow.cpp" line="1587"/>
         <source>Disabling Mixer LPF...</source>
         <oldsource>Disabling Mixer LPF....</oldsource>
         <translation>ミキサーLPFを無効にしています...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1390"/>
+        <location filename="../mainwindow.cpp" line="1595"/>
         <source>Enabling Inverted Stereo...</source>
         <oldsource>Enabling Inverted Stereo....</oldsource>
         <translation>ステレオ反転を有効にしています...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1398"/>
+        <location filename="../mainwindow.cpp" line="1603"/>
         <source>Enabling Standard Stereo...</source>
         <oldsource>Enabling Standard Stereo....</oldsource>
         <translation>標準ステレオを有効にしています...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1406"/>
+        <location filename="../mainwindow.cpp" line="1611"/>
         <source>Mono Mode...</source>
         <oldsource>Mono Mode....</oldsource>
         <translation>モノラルモード...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1414"/>
+        <location filename="../mainwindow.cpp" line="1619"/>
         <source>Stereo Mode...</source>
         <oldsource>Stereo Mode....</oldsource>
         <translation>ステレオモード...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1423"/>
+        <location filename="../mainwindow.cpp" line="1628"/>
         <source>Stopping...</source>
         <translation>停止しています...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1507"/>
+        <location filename="../mainwindow.cpp" line="1736"/>
         <source>Updating System Volume...</source>
         <translation>システムボリュームを更新しています...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1729"/>
+        <location filename="../mainwindow.cpp" line="2155"/>
         <source>Switching To Headphone Audio Output...</source>
         <translation>ヘッドフォンオーディオ出力に切り替えます...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1745"/>
+        <location filename="../mainwindow.cpp" line="2171"/>
         <source>Switching To HDMI Audio Output...</source>
         <translation>HDMIオーディオ出力に切り替えます...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1760"/>
+        <location filename="../mainwindow.cpp" line="2186"/>
         <source>Switching To Default Audio Output...</source>
         <translation>オーディオ出力をデフォルトに切り替えます...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1912"/>
+        <location filename="../mainwindow.cpp" line="2348"/>
         <source>Save current buffer as an external file</source>
         <translation>現在のbufferをファイルに保存</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1930"/>
+        <location filename="../mainwindow.cpp" line="2374"/>
         <source>Start recording to WAV audio file</source>
         <translation>WAVオーディオファイルへ記録を開始</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1935"/>
+        <location filename="../mainwindow.cpp" line="2379"/>
         <source>Improve readability of code</source>
         <translation>コードの可読性を向上</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2076"/>
+        <location filename="../mainwindow.cpp" line="2527"/>
         <source>Ready...</source>
         <translation>Ready...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2163"/>
+        <location filename="../mainwindow.cpp" line="2619"/>
         <source>File loaded...</source>
         <translation>ファイルがロードされました...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2188"/>
+        <location filename="../mainwindow.cpp" line="2646"/>
         <source>File saved...</source>
         <translation>ファイルが保存されました...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2413"/>
+        <location filename="../mainwindow.cpp" line="2873"/>
         <source>Last checked %1</source>
         <translation>前回のチェック日時: %1</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2415"/>
+        <location filename="../mainwindow.cpp" line="2875"/>
         <source>Sonic Pi checks for updates
 every two weeks.</source>
         <translation>アップデートのチェックは
 2週間毎に行われます。</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2417"/>
+        <location filename="../mainwindow.cpp" line="2877"/>
         <source>This is Sonic Pi %1</source>
         <translation>Sonic Pi %1</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2418"/>
+        <location filename="../mainwindow.cpp" line="2878"/>
         <source>Version %2 is now available!</source>
         <translation>バージョン %2 が利用可能です!</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2422"/>
+        <location filename="../mainwindow.cpp" line="2882"/>
         <source>New version available!
 Get Sonic Pi %1</source>
         <translation>新しいバージョンが利用可能です!
 Sonic Pi %1 を入手</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1902"/>
+        <location filename="../mainwindow.cpp" line="2337"/>
         <source>Run</source>
         <translation>実行</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1903"/>
-        <source>Run the code in the current workspace</source>
-        <translation>現在のワークスペースを実行</translation>
-    </message>
-    <message>
-        <location filename="../mainwindow.cpp" line="1907"/>
+        <location filename="../mainwindow.cpp" line="2343"/>
         <source>Stop</source>
         <translation>停止</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1908"/>
+        <location filename="../mainwindow.cpp" line="2344"/>
         <source>Stop all running code</source>
         <translation>実行中のコードを全て停止</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1911"/>
+        <location filename="../mainwindow.cpp" line="2347"/>
         <source>Save As...</source>
         <translation>名前を付けて保存...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1915"/>
+        <location filename="../mainwindow.cpp" line="2355"/>
         <source>Info</source>
         <translation>インフォメーション</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1916"/>
+        <location filename="../mainwindow.cpp" line="2356"/>
         <source>See information about Sonic Pi</source>
         <translation>Sonic Piについての情報を参照</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="414"/>
-        <location filename="../mainwindow.cpp" line="1920"/>
+        <location filename="../mainwindow.cpp" line="513"/>
+        <location filename="../mainwindow.cpp" line="2364"/>
         <source>Help</source>
         <translation>ヘルプ</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="991"/>
-        <location filename="../mainwindow.cpp" line="996"/>
+        <location filename="../mainwindow.cpp" line="1121"/>
+        <location filename="../mainwindow.cpp" line="1131"/>
         <source>Performance</source>
         <translation>パフォーマンス</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="992"/>
+        <location filename="../mainwindow.cpp" line="1122"/>
         <source>Settings useful for performing with Sonic Pi</source>
         <translation>Sonic Piでパフォーマンスする際に有用な設定です</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1087"/>
+        <location filename="../mainwindow.cpp" line="1259"/>
         <source>Server boot error...</source>
         <translation>サーバー起動エラー...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1087"/>
-        <source>Apologies, a critical error occurred during startup</source>
-        <translation>申し訳ありません。起動中に重大なエラーが発生しました。</translation>
-    </message>
-    <message>
-        <location filename="../mainwindow.cpp" line="1087"/>
+        <location filename="../mainwindow.cpp" line="1259"/>
         <source>Please consider reporting a bug at</source>
         <translation>バグの報告をご検討ください。報告先: </translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1921"/>
+        <location filename="../mainwindow.cpp" line="2365"/>
         <source>Toggle help pane</source>
         <translation>ヘルプ画面の表示</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1924"/>
+        <location filename="../mainwindow.cpp" line="2368"/>
         <source>Prefs</source>
         <translation>環境設定</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1925"/>
+        <location filename="../mainwindow.cpp" line="2369"/>
         <source>Toggle preferences pane</source>
         <translation>設定画面を表示</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1929"/>
-        <location filename="../mainwindow.cpp" line="2051"/>
-        <location filename="../mainwindow.cpp" line="2052"/>
+        <location filename="../mainwindow.cpp" line="2373"/>
+        <location filename="../mainwindow.cpp" line="2502"/>
+        <location filename="../mainwindow.cpp" line="2503"/>
         <source>Start Recording</source>
         <translation>録音開始</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1934"/>
+        <location filename="../mainwindow.cpp" line="2378"/>
         <source>Auto-Align Text</source>
         <oldsource>Auto Align Text</oldsource>
         <translation>テキスト自動整形</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1939"/>
-        <location filename="../mainwindow.cpp" line="1940"/>
+        <location filename="../mainwindow.cpp" line="2385"/>
         <source>Increase Text Size</source>
         <translation>文字を大きく</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1944"/>
-        <location filename="../mainwindow.cpp" line="1945"/>
+        <location filename="../mainwindow.cpp" line="2392"/>
         <source>Decrease Text Size</source>
         <translation>文字を小さく</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1950"/>
+        <location filename="../mainwindow.cpp" line="2397"/>
         <source>Tools</source>
         <translation>ツール</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1997"/>
+        <location filename="../mainwindow.cpp" line="2448"/>
         <source>About</source>
         <translation>概要</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1998"/>
+        <location filename="../mainwindow.cpp" line="2449"/>
         <source>Core Team</source>
         <translation>コアチーム</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1999"/>
+        <location filename="../mainwindow.cpp" line="2450"/>
         <source>Contributors</source>
         <translation>協力者</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2000"/>
+        <location filename="../mainwindow.cpp" line="2451"/>
         <source>Community</source>
         <translation>コミュニティ</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2001"/>
+        <location filename="../mainwindow.cpp" line="2452"/>
         <source>License</source>
         <translation>ライセンス</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2002"/>
+        <location filename="../mainwindow.cpp" line="2453"/>
         <source>History</source>
         <translation>ヒストリー</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2023"/>
+        <location filename="../mainwindow.cpp" line="2474"/>
         <source>Sonic Pi - Info</source>
         <translation>Sonic Pi - Info</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2043"/>
-        <location filename="../mainwindow.cpp" line="2044"/>
+        <location filename="../mainwindow.cpp" line="2494"/>
+        <location filename="../mainwindow.cpp" line="2495"/>
         <source>Stop Recording</source>
         <translation>録音停止</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2057"/>
+        <location filename="../mainwindow.cpp" line="2508"/>
         <source>Save Recording</source>
         <translation>録音を保存</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2153"/>
+        <location filename="../mainwindow.cpp" line="2608"/>
         <source>Cannot read file %1:
 %2.</source>
         <translation>%1:ファイルを読み取ることができません。
 %2.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2171"/>
+        <location filename="../mainwindow.cpp" line="2628"/>
         <source>Cannot write file %1:
 %2.</source>
         <translation>%1:ファイルを書き込むことができません。
 %2.</translation>
     </message>
     <message>
-        <location filename="../ruby_help.h" line="80"/>
-        <location filename="../ruby_help.h" line="139"/>
-        <location filename="../ruby_help.h" line="199"/>
-        <location filename="../ruby_help.h" line="218"/>
-        <location filename="../ruby_help.h" line="278"/>
-        <location filename="../ruby_help.h" line="338"/>
+        <location filename="../ruby_help.h" line="93"/>
+        <location filename="../ruby_help.h" line="154"/>
+        <location filename="../ruby_help.h" line="215"/>
+        <location filename="../ruby_help.h" line="274"/>
+        <location filename="../ruby_help.h" line="293"/>
+        <location filename="../ruby_help.h" line="367"/>
+        <location filename="../ruby_help.h" line="442"/>
         <source>Tutorial</source>
         <translation>チュートリアル</translation>
     </message>
     <message>
-        <location filename="../ruby_help.h" line="370"/>
+        <location filename="../ruby_help.h" line="476"/>
         <source>Examples</source>
         <translation>例</translation>
     </message>
     <message>
-        <location filename="../ruby_help.h" line="410"/>
+        <location filename="../ruby_help.h" line="522"/>
         <source>Synths</source>
         <translation>シンセ</translation>
     </message>
     <message>
-        <location filename="../ruby_help.h" line="446"/>
+        <location filename="../ruby_help.h" line="564"/>
         <source>Fx</source>
         <translation>効果</translation>
     </message>
     <message>
-        <location filename="../ruby_help.h" line="463"/>
+        <location filename="../ruby_help.h" line="583"/>
         <source>Samples</source>
         <translation>サンプル</translation>
     </message>
     <message>
-        <location filename="../ruby_help.h" line="629"/>
+        <location filename="../ruby_help.h" line="779"/>
         <source>Lang</source>
         <translation>命令</translation>
     </message>
@@ -798,11 +913,11 @@ Sonic Pi %1 を入手</translation>
     </message>
 </context>
 <context>
-    <name>SonicPiUDPServer</name>
+    <name>SonicPiUDPOSCServer</name>
     <message>
-        <location filename="../sonicpiudpserver.cpp" line="24"/>
+        <location filename="../sonic_pi_udp_osc_server.cpp" line="38"/>
         <source>Is Sonic Pi already running?  Can&apos;t open UDP port 4558.</source>
-        <translation>Sonic Piはすでに実行されていませんか？ UDPポート4558を開くことができませんでした。</translation>
+        <translation type="unfinished">Sonic Piはすでに実行されていませんか？ UDPポート4558を開くことができませんでした。</translation>
     </message>
 </context>
 </TS>

--- a/app/gui/qt/lang/sonic-pi_nb.ts
+++ b/app/gui/qt/lang/sonic-pi_nb.ts
@@ -1,101 +1,80 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0" language="nb">
-<defaultcodec>UTF-8</defaultcodec>
+<TS version="2.1" language="nb">
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../mainwindow.cpp" line="153"></location>
+        <location filename="../mainwindow.cpp" line="277"/>
         <source>Sonic Pi update info</source>
         <translation>Oppdateringsopplysninger for Sonic Pi</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="296"></location>
+        <location filename="../mainwindow.cpp" line="387"/>
         <source>Buffer %1</source>
         <translation>Mellomlager %1</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="360"></location>
+        <location filename="../mainwindow.cpp" line="459"/>
         <source>Preferences</source>
         <translation>Innstillinger</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="373"></location>
+        <location filename="../mainwindow.cpp" line="472"/>
         <source>Log</source>
         <translation>Logg</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="414"></location>
-        <location filename="../mainwindow.cpp" line="1920"></location>
+        <location filename="../mainwindow.cpp" line="513"/>
+        <location filename="../mainwindow.cpp" line="2364"/>
         <source>Help</source>
         <translation>Hjelp</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="445"></location>
-        <location filename="../mainwindow.cpp" line="2152"></location>
-        <location filename="../mainwindow.cpp" line="2170"></location>
+        <location filename="../mainwindow.cpp" line="184"/>
+        <location filename="../mainwindow.cpp" line="2607"/>
+        <location filename="../mainwindow.cpp" line="2627"/>
         <source>Sonic Pi</source>
         <translation>Sonic Pi</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="459"></location>
+        <location filename="../mainwindow.cpp" line="235"/>
         <source>Welcome to Sonic Pi</source>
         <translation>Velkommen til Sonic Pi</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="601"></location>
+        <location filename="../mainwindow.cpp" line="708"/>
         <source>Indenting selection...</source>
         <translation>Innrykksutvalg ...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="605"></location>
+        <location filename="../mainwindow.cpp" line="712"/>
         <source>Indenting line...</source>
         <translation type="unfinished">Rykker inn linje...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="634"></location>
-        <source>Commenting selection...</source>
-        <translation>Kommentarutvalg ...</translation>
-    </message>
-    <message>
-        <location filename="../mainwindow.cpp" line="638"></location>
-        <source>Commenting line...</source>
-        <translation>Kommentarlinje ...</translation>
-    </message>
-    <message>
-        <location filename="../mainwindow.cpp" line="717"></location>
-        <source>Ruby could not be started, is it installed and in your PATH?</source>
-        <translation>Kunne ikke starte ruby.  Er den installert og i din PATH?</translation>
-    </message>
-    <message>
-        <location filename="../mainwindow.cpp" line="803"></location>
+        <location filename="../mainwindow.cpp" line="911"/>
         <source>Raspberry Pi System Volume</source>
         <translation>Systemlydnivå for Raspberry Pi</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="804"></location>
+        <location filename="../mainwindow.cpp" line="912"/>
         <source>Use this slider to change the system volume of your Raspberry Pi.</source>
         <translation>Bruk denne glidebryteren for å endre systemlydnivå på din Raspberry Pi.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="806"></location>
+        <location filename="../mainwindow.cpp" line="914"/>
         <source>Advanced Audio</source>
         <translation>Avansert lydoppsett</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="807"></location>
+        <location filename="../mainwindow.cpp" line="915"/>
         <source>Advanced audio settings for working with
 external PA systems when performing with Sonic Pi.</source>
         <translation>Avanserte lydoppsett for å bruke eksterne
 PA-systemer mens du spiller med Sonic Pi.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="808"></location>
-        <source>Invert Stereo</source>
-        <translation>Inverter stereo</translation>
-    </message>
-    <message>
-        <location filename="../mainwindow.cpp" line="809"></location>
+        <location filename="../mainwindow.cpp" line="917"/>
         <source>Toggle stereo inversion.
 If enabled, audio sent to the left speaker will
 be routed to the right speaker and visa versa.</source>
@@ -104,12 +83,7 @@ Hvis aktiv, så blir lyd sendt til venstre høytaler
 i stedet overført til det høyre høytaleren og visa versa.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="811"></location>
-        <source>Force Mono</source>
-        <translation>Styr mono</translation>
-    </message>
-    <message>
-        <location filename="../mainwindow.cpp" line="812"></location>
+        <location filename="../mainwindow.cpp" line="920"/>
         <source>Toggle mono mode.
 If enabled both right and left audio is mixed and
 the same signal is sent to both speakers.
@@ -122,12 +96,12 @@ Nyttig når en jobber med eksterne systemer
 som kun håndterer mono.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="815"></location>
+        <location filename="../mainwindow.cpp" line="976"/>
         <source>Safe mode</source>
         <translation>Sikker tilstand</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="816"></location>
+        <location filename="../mainwindow.cpp" line="977"/>
         <source>Toggle synth argument checking functions.
 If disabled, certain synth opt values may
 create unexpectedly loud or uncomfortable sounds.</source>
@@ -136,12 +110,43 @@ Hvis avslått, kan noen verdier i synthvalg
 lage uventede høye eller ubehagelige lyder.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="828"></location>
+        <location filename="../mainwindow.cpp" line="933"/>
         <source>Raspberry Pi Audio Output</source>
         <translation>Lyduttak på Raspberry Pi</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="829"></location>
+        <location filename="../mainwindow.cpp" line="452"/>
+        <location filename="../mainwindow.cpp" line="2360"/>
+        <source>Scope</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="741"/>
+        <source>Toggle selection comment...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="745"/>
+        <source>Toggle line comment...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="803"/>
+        <source>The Sonic Pi Server could not be started!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="916"/>
+        <source>Invert stereo</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="919"/>
+        <source>Force mono</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="934"/>
         <source>Your Raspberry Pi has two forms of audio output.
 Firstly, there is the headphone jack of the Raspberry Pi itself.
 Secondly, some HDMI monitors/TVs support audio through the HDMI port.
@@ -152,37 +157,47 @@ Dernest støtter noen HDMI-skjermer/TV-er lyd gjennom HDMI-kontakten.
 Bruk disse knappene for å tvinge bruk av lydutgangen du ønsker.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="830"></location>
+        <location filename="../mainwindow.cpp" line="935"/>
         <source>&amp;Default</source>
         <translation>&amp;Standard</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="831"></location>
+        <location filename="../mainwindow.cpp" line="936"/>
         <source>&amp;Headphones</source>
         <translation>&amp;Hodetelefoner</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="832"></location>
+        <location filename="../mainwindow.cpp" line="937"/>
         <source>&amp;HDMI</source>
         <translation>H&amp;DMI</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="852"></location>
+        <location filename="../mainwindow.cpp" line="957"/>
         <source>Logging</source>
         <translation>Logging</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="853"></location>
+        <location filename="../mainwindow.cpp" line="958"/>
         <source>Configure debug behaviour</source>
         <translation>Sett opp feilsøkingsoppførsel</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="855"></location>
+        <location filename="../mainwindow.cpp" line="960"/>
+        <source>Synths and FX</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="961"/>
+        <source>Modify behaviour of synths and FX</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="963"/>
         <source>Log synths</source>
         <translation>Logg synther</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="856"></location>
+        <location filename="../mainwindow.cpp" line="964"/>
         <source>Toggle log messages.
 If disabled, activity such as synth and sample
 triggering will not be printed to the log by default.</source>
@@ -191,12 +206,12 @@ Hvis avslått, så vil aktiviteter som synth- og
 sampleutløsning som utgangspunkt ikke skrives til loggen.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="858"></location>
+        <location filename="../mainwindow.cpp" line="966"/>
         <source>Clear log on run</source>
         <translation>Nullstill logg ved kjøring</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="859"></location>
+        <location filename="../mainwindow.cpp" line="967"/>
         <source>Toggle log clearing on run.
 If enabled, the log is cleared each
 time the run button is pressed.</source>
@@ -205,12 +220,12 @@ Hvis aktiv, så nullstilles loggen hver
 gang kjør-knappen trykkes.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="861"></location>
+        <location filename="../mainwindow.cpp" line="969"/>
         <source>Log cues</source>
         <translation>Logg vink</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="862"></location>
+        <location filename="../mainwindow.cpp" line="970"/>
         <source>Enable or disable logging of cues.
 If disabled, cues will still trigger.
 However, they will not be visible in the logs.</source>
@@ -219,553 +234,653 @@ Hvis utkoblet, så vil vink fortsatt utløses.
 De vil dermot ikke være synlige i loggene.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="871"></location>
+        <location filename="../mainwindow.cpp" line="972"/>
+        <source>Log auto scroll</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="973"/>
+        <source>Toggle log auto scrolling.
+If enabled the log is scrolled to the bottom after every new message is displayed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="980"/>
+        <source>Enable external synths and FX</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="981"/>
+        <source>When enabled, Sonic Pi will allow
+synths and FX loaded via load_synthdefs
+to be triggered.
+
+When disabled, Sonic Pi will complain
+when you attempt to use a synth or FX
+which isn&apos;t recognised.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="983"/>
+        <source>Enforce timing guarantees</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="984"/>
+        <source>When enabled, Sonic Pi will refuse
+to trigger synths and FX if
+it is too late to do so
+
+When disabled, Sonic Pi will always
+attempt to trigger synths and FX
+even when a little late.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1001"/>
         <source>Transparency</source>
         <translation>Gjennomsiktighet</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="882"></location>
-        <location filename="../mainwindow.cpp" line="1004"></location>
+        <location filename="../mainwindow.cpp" line="1012"/>
+        <location filename="../mainwindow.cpp" line="1144"/>
         <source>Updates</source>
         <translation>Oppdateringer</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="884"></location>
+        <location filename="../mainwindow.cpp" line="1014"/>
         <source>Check for updates</source>
         <translation>Sjekk etter oppdateringer</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="886"></location>
+        <location filename="../mainwindow.cpp" line="1016"/>
         <source>Toggle automatic update checking.
 This check involves sending anonymous information about your platform and version.</source>
         <translation>Styr automatisk oppdateringsjekk.
 Denne sjekken innebærer å sende anonym informasjon om din platform og versjon.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="887"></location>
+        <location filename="../mainwindow.cpp" line="1017"/>
         <source>Check now</source>
         <translation>Sjekk nå</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="888"></location>
+        <location filename="../mainwindow.cpp" line="1018"/>
         <source>Force a check for updates now.
 This check involves sending anonymous information about your platform and version.</source>
         <translation>Tving igjennom en sjekk etter oppdateringer nå.
 Denne sjekken innebærer å sende anonym informasjon om din platform og versjon.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="889"></location>
+        <location filename="../mainwindow.cpp" line="1019"/>
         <source>Get update</source>
         <translation>Hent oppdatering</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="890"></location>
+        <location filename="../mainwindow.cpp" line="1020"/>
         <source>Visit http://sonic-pi.net to download new version</source>
         <translation>Besøk http://sonic-pi.net for å laste ned ny versjon</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="895"></location>
+        <location filename="../mainwindow.cpp" line="1025"/>
         <source>Update Info</source>
         <translation>Oppdateringsopplysninger</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="914"></location>
+        <location filename="../mainwindow.cpp" line="1044"/>
         <source>Show and Hide</source>
         <translation>Vis og skjul</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="915"></location>
+        <location filename="../mainwindow.cpp" line="1045"/>
         <source>Configure editor display options.</source>
         <translation>Still inn skriveprogrammets fremvisningsvalg.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="916"></location>
+        <location filename="../mainwindow.cpp" line="1046"/>
         <source>Look and Feel</source>
         <translation>Utseende og oppførsel</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="917"></location>
+        <location filename="../mainwindow.cpp" line="1047"/>
         <source>Configure editor look and feel.</source>
         <translation>Oppsett av utseende og oppførsel for skrivefeltet.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="918"></location>
+        <location filename="../mainwindow.cpp" line="1048"/>
         <source>Automation</source>
         <translation>Automatisering</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="919"></location>
+        <location filename="../mainwindow.cpp" line="1049"/>
         <source>Configure automation features.</source>
         <translation>Sett opp automatiseringsegenskaper.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="920"></location>
+        <location filename="../mainwindow.cpp" line="1050"/>
         <source>Auto-align</source>
         <translation>Auto-innrykk</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="921"></location>
+        <location filename="../mainwindow.cpp" line="1051"/>
         <source>Automatically align code on Run</source>
         <translation>Fiks innrykk automatisk ved kjøring</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="923"></location>
+        <location filename="../mainwindow.cpp" line="1053"/>
         <source>Show line numbers</source>
         <translation>Vis linjenummer</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="924"></location>
+        <location filename="../mainwindow.cpp" line="1054"/>
         <source>Toggle line number visibility.</source>
         <translation>Styr synlighet for linjenummer.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="925"></location>
+        <location filename="../mainwindow.cpp" line="1055"/>
         <source>Show log</source>
         <translation>Vis logg</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="926"></location>
+        <location filename="../mainwindow.cpp" line="1056"/>
         <source>Toggle visibility of the log.</source>
         <translation>Styr synligheten for loggen.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="928"></location>
+        <location filename="../mainwindow.cpp" line="1058"/>
         <source>Show buttons</source>
         <translation>Vis knapper</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="929"></location>
+        <location filename="../mainwindow.cpp" line="1059"/>
         <source>Toggle visibility of the control buttons.</source>
         <translation>Styr synlighet for kontrollknappene.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="931"></location>
+        <location filename="../mainwindow.cpp" line="1061"/>
         <source>Show tabs</source>
         <translation>Vis faner</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="933"></location>
+        <location filename="../mainwindow.cpp" line="1063"/>
         <source>Toggle visibility of the buffer selection tabs.</source>
         <translation>Styr synligheten for mellomlagerets merkelappvelgere.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="934"></location>
+        <location filename="../mainwindow.cpp" line="1064"/>
         <source>Full screen</source>
         <translation>Fullskjerm</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="935"></location>
+        <location filename="../mainwindow.cpp" line="1065"/>
         <source>Toggle full screen mode.</source>
         <translation>Styr fullskjermtilstand.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="936"></location>
+        <location filename="../mainwindow.cpp" line="1066"/>
         <source>Dark mode</source>
         <translation>Mørk fremtoning</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="937"></location>
+        <location filename="../mainwindow.cpp" line="1067"/>
         <source>Toggle dark mode.</source>
         <translation>Styr mørk fremtoning.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="937"></location>
+        <location filename="../mainwindow.cpp" line="1067"/>
         <source>
 Dark mode is perfect for live coding in night clubs.</source>
         <translation>
 Mørk fremtoning er perfekt for koding på direkten i nattklubber.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="976"></location>
+        <location filename="../mainwindow.cpp" line="1106"/>
         <source>Audio</source>
         <translation>Lyd</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="988"></location>
+        <location filename="../mainwindow.cpp" line="1118"/>
         <source>Editor</source>
         <translation>Skrivefelt</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="989"></location>
+        <location filename="../mainwindow.cpp" line="1119"/>
         <source>Studio</source>
         <translation>Studio</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="991"></location>
-        <location filename="../mainwindow.cpp" line="996"></location>
+        <location filename="../mainwindow.cpp" line="1121"/>
+        <location filename="../mainwindow.cpp" line="1131"/>
         <source>Performance</source>
         <translation>Fremføring</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="992"></location>
+        <location filename="../mainwindow.cpp" line="1122"/>
         <source>Settings useful for performing with Sonic Pi</source>
         <translation>Oppsett nyttig ved fremføring med Sonic Pi</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1087"></location>
+        <location filename="../mainwindow.cpp" line="1259"/>
         <source>Server boot error...</source>
         <translation>Feil ved tjeneroppstart...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1087"></location>
-        <source>Apologies, a critical error occurred during startup</source>
-        <translation>Beklager, en kritisk feil skjedde under oppstart</translation>
+        <location filename="../mainwindow.cpp" line="2338"/>
+        <source>Run the code in the current buffer</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1087"></location>
+        <location filename="../mainwindow.cpp" line="1259"/>
         <source>Please consider reporting a bug at</source>
         <translation>Veldig fint om du vurderer å rapportere feil til</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1181"></location>
+        <location filename="../mainwindow.cpp" line="1259"/>
+        <source>Sonic Pi Boot Error
+
+Apologies, a critical error occurred during startup</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1361"/>
+        <location filename="../mainwindow.cpp" line="1362"/>
+        <location filename="../mainwindow.cpp" line="1374"/>
+        <location filename="../mainwindow.cpp" line="1375"/>
+        <source>Buffer files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1362"/>
+        <source>Load Sonic Pi Buffer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1362"/>
+        <location filename="../mainwindow.cpp" line="1375"/>
+        <source>Text files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1362"/>
+        <location filename="../mainwindow.cpp" line="1375"/>
+        <source>Ruby files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1362"/>
+        <location filename="../mainwindow.cpp" line="1375"/>
+        <source>All files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1375"/>
         <source>Save Current Buffer</source>
         <translation>Lagre aktive mellomlager</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1249"></location>
+        <location filename="../mainwindow.cpp" line="1447"/>
         <source>Running Code...</source>
         <translation>Kjørende kode...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1275"></location>
-        <source>Workspace %1</source>
-        <translation>Arbeidsområde %1</translation>
-    </message>
-    <message>
-        <location filename="../mainwindow.cpp" line="1291"></location>
+        <location filename="../mainwindow.cpp" line="1496"/>
         <source>Zooming In...</source>
         <translation>Forstørre ...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1298"></location>
+        <location filename="../mainwindow.cpp" line="1503"/>
         <source>Zooming Out...</source>
         <translation>Forminske ...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1305"></location>
+        <location filename="../mainwindow.cpp" line="1510"/>
         <source>Beautifying...</source>
         <translation>Gjør vakrere...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1325"></location>
+        <location filename="../mainwindow.cpp" line="1530"/>
         <source>Reloading...</source>
         <translation>Laster på nytt...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1332"></location>
+        <location filename="../mainwindow.cpp" line="1537"/>
         <source>Checking for updates...</source>
         <translation>Ser etter oppdateringer...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1340"></location>
+        <location filename="../mainwindow.cpp" line="1545"/>
         <source>Enabling update checking...</source>
         <translation>Aktiverer oppdaterings-sjekking...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1348"></location>
+        <location filename="../mainwindow.cpp" line="1553"/>
         <source>Disabling update checking...</source>
         <translation>Kobler ut oppdaterings-sjekking...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1356"></location>
+        <location filename="../mainwindow.cpp" line="1561"/>
         <source>Enabling Mixer HPF...</source>
         <translation>Aktivering Mixer HPF ...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1365"></location>
+        <location filename="../mainwindow.cpp" line="1570"/>
         <source>Disabling Mixer HPF...</source>
         <translation>Deaktivering Mixer HPF ...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1373"></location>
+        <location filename="../mainwindow.cpp" line="1578"/>
         <source>Enabling Mixer LPF...</source>
         <translation>Aktivering Mixer HPF ...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1382"></location>
+        <location filename="../mainwindow.cpp" line="1587"/>
         <source>Disabling Mixer LPF...</source>
         <translation>Deaktivering Mixer HPF ...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1390"></location>
+        <location filename="../mainwindow.cpp" line="1595"/>
         <source>Enabling Inverted Stereo...</source>
         <translation>Aktiver invertert stereo...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1398"></location>
+        <location filename="../mainwindow.cpp" line="1603"/>
         <source>Enabling Standard Stereo...</source>
         <translation>Aktiverer standard stereo...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1406"></location>
+        <location filename="../mainwindow.cpp" line="1611"/>
         <source>Mono Mode...</source>
         <translation>Monotilstand...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1414"></location>
+        <location filename="../mainwindow.cpp" line="1619"/>
         <source>Stereo Mode...</source>
         <translation>Stereotilstand ...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1423"></location>
+        <location filename="../mainwindow.cpp" line="1628"/>
         <source>Stopping...</source>
         <translation>Stopper...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1507"></location>
+        <location filename="../mainwindow.cpp" line="1736"/>
         <source>Updating System Volume...</source>
         <translation>Oppdaterer systemlydnivået...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1729"></location>
+        <location filename="../mainwindow.cpp" line="1752"/>
+        <source>Log Auto Scroll on...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1754"/>
+        <source>Log Auto Scroll off...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2155"/>
         <source>Switching To Headphone Audio Output...</source>
         <translation>Bytter til hodetelefonlyduttak...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1745"></location>
+        <location filename="../mainwindow.cpp" line="2171"/>
         <source>Switching To HDMI Audio Output...</source>
         <translation>Bytter til HDMI-lyduttak...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1760"></location>
+        <location filename="../mainwindow.cpp" line="2186"/>
         <source>Switching To Default Audio Output...</source>
         <translation>Endrer til default-lyduttak...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1902"></location>
+        <location filename="../mainwindow.cpp" line="2337"/>
         <source>Run</source>
         <translation>Kjør</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1903"></location>
-        <source>Run the code in the current workspace</source>
-        <translation>Kjør koden i det aktive arbeidsområdet</translation>
-    </message>
-    <message>
-        <location filename="../mainwindow.cpp" line="1907"></location>
+        <location filename="../mainwindow.cpp" line="2343"/>
         <source>Stop</source>
         <translation>Stopp</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1908"></location>
+        <location filename="../mainwindow.cpp" line="2344"/>
         <source>Stop all running code</source>
         <translation>Stopp all kjørende kode</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1911"></location>
+        <location filename="../mainwindow.cpp" line="2347"/>
         <source>Save As...</source>
         <translation>Lagre som ...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1912"></location>
+        <location filename="../mainwindow.cpp" line="2348"/>
         <source>Save current buffer as an external file</source>
         <translation>Lagre gjeldende mellomlager som en ekstern fil</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1915"></location>
+        <location filename="../mainwindow.cpp" line="2351"/>
+        <source>Load</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2352"/>
+        <source>Load an external file in the current buffer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2355"/>
         <source>Info</source>
         <translation>Opplysninger</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1916"></location>
+        <location filename="../mainwindow.cpp" line="2356"/>
         <source>See information about Sonic Pi</source>
         <translation>Se opplysninger om Sonic Pi</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1921"></location>
+        <location filename="../mainwindow.cpp" line="2361"/>
+        <source>View audio output</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2365"/>
         <source>Toggle help pane</source>
         <translation>Styr hjelpepanel</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1924"></location>
+        <location filename="../mainwindow.cpp" line="2368"/>
         <source>Prefs</source>
         <translation>Innstillinger</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1925"></location>
+        <location filename="../mainwindow.cpp" line="2369"/>
         <source>Toggle preferences pane</source>
         <translation>Styr innstillingspanel</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1929"></location>
-        <location filename="../mainwindow.cpp" line="2051"></location>
-        <location filename="../mainwindow.cpp" line="2052"></location>
+        <location filename="../mainwindow.cpp" line="2373"/>
+        <location filename="../mainwindow.cpp" line="2502"/>
+        <location filename="../mainwindow.cpp" line="2503"/>
         <source>Start Recording</source>
         <translation>Start opptak</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1930"></location>
+        <location filename="../mainwindow.cpp" line="2374"/>
         <source>Start recording to WAV audio file</source>
         <translation>Start opptak av WAV-lydfil</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1934"></location>
+        <location filename="../mainwindow.cpp" line="2378"/>
         <source>Auto-Align Text</source>
         <translation>Autoinnrykk på tekst</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1935"></location>
+        <location filename="../mainwindow.cpp" line="2379"/>
         <source>Improve readability of code</source>
         <translation>Gjør koden mer lesbar</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1939"></location>
-        <location filename="../mainwindow.cpp" line="1940"></location>
+        <location filename="../mainwindow.cpp" line="2385"/>
         <source>Increase Text Size</source>
         <translation>Øk skriftstørrelsen</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1944"></location>
-        <location filename="../mainwindow.cpp" line="1945"></location>
+        <location filename="../mainwindow.cpp" line="2392"/>
         <source>Decrease Text Size</source>
         <translation>Reduser skriftstørrelsen</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1950"></location>
+        <location filename="../mainwindow.cpp" line="2397"/>
         <source>Tools</source>
         <translation>Verktøy</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1997"></location>
+        <location filename="../mainwindow.cpp" line="2448"/>
         <source>About</source>
         <translation>Om</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1998"></location>
+        <location filename="../mainwindow.cpp" line="2449"/>
         <source>Core Team</source>
         <translation>Kjernegruppen</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1999"></location>
+        <location filename="../mainwindow.cpp" line="2450"/>
         <source>Contributors</source>
         <translation>Bidragsytere</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2000"></location>
+        <location filename="../mainwindow.cpp" line="2451"/>
         <source>Community</source>
         <translation>Fellesskap</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2001"></location>
+        <location filename="../mainwindow.cpp" line="2452"/>
         <source>License</source>
         <translation>Lisens</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2002"></location>
+        <location filename="../mainwindow.cpp" line="2453"/>
         <source>History</source>
         <translation>Historie</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2023"></location>
+        <location filename="../mainwindow.cpp" line="2474"/>
         <source>Sonic Pi - Info</source>
         <translation>Sonic Pi - Opplysninger</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2043"></location>
-        <location filename="../mainwindow.cpp" line="2044"></location>
+        <location filename="../mainwindow.cpp" line="2494"/>
+        <location filename="../mainwindow.cpp" line="2495"/>
         <source>Stop Recording</source>
         <translation>Stop opptak</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2057"></location>
+        <location filename="../mainwindow.cpp" line="2508"/>
         <source>Save Recording</source>
         <translation>Lagre opptak</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2076"></location>
+        <location filename="../mainwindow.cpp" line="2508"/>
+        <source>Wavefile (*.wav)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2527"/>
         <source>Ready...</source>
         <translation>Klar...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2153"></location>
+        <location filename="../mainwindow.cpp" line="2608"/>
         <source>Cannot read file %1:
 %2.</source>
         <translation>Kan ikke lese fil %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2163"></location>
+        <location filename="../mainwindow.cpp" line="2619"/>
         <source>File loaded...</source>
         <translation>Lastet fil...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2171"></location>
+        <location filename="../mainwindow.cpp" line="2628"/>
         <source>Cannot write file %1:
 %2.</source>
         <translation>Kan ikke skrive filen %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2188"></location>
+        <location filename="../mainwindow.cpp" line="2646"/>
         <source>File saved...</source>
         <translation>Lagret filen...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2413"></location>
+        <location filename="../mainwindow.cpp" line="2873"/>
         <source>Last checked %1</source>
         <translation>Sist sjekket %1</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2415"></location>
+        <location filename="../mainwindow.cpp" line="2875"/>
         <source>Sonic Pi checks for updates
 every two weeks.</source>
         <translation>Sonic Pi sjekker etter oppdateringer
 hver andre uke.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2417"></location>
+        <location filename="../mainwindow.cpp" line="2877"/>
         <source>This is Sonic Pi %1</source>
         <translation>Dette er Sonic Pi %1</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2418"></location>
+        <location filename="../mainwindow.cpp" line="2878"/>
         <source>Version %2 is now available!</source>
         <translation>Utgave %2 er nå tilgjengelig!</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2422"></location>
+        <location filename="../mainwindow.cpp" line="2882"/>
         <source>New version available!
 Get Sonic Pi %1</source>
         <translation>Ny utgave er tilgjengelig!
 Skaff Sonic Pi %1</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2448"></location>
+        <location filename="../mainwindow.cpp" line="2908"/>
         <source>Welcome back. Now get your live code on...</source>
         <translation>Velkommen tilbake. Nå kan du direkte-kode på...</translation>
     </message>
     <message>
-        <location filename="../ruby_help.h" line="80"></location>
-        <location filename="../ruby_help.h" line="139"></location>
-        <location filename="../ruby_help.h" line="199"></location>
-        <location filename="../ruby_help.h" line="218"></location>
-        <location filename="../ruby_help.h" line="278"></location>
-        <location filename="../ruby_help.h" line="338"></location>
+        <location filename="../ruby_help.h" line="93"/>
+        <location filename="../ruby_help.h" line="154"/>
+        <location filename="../ruby_help.h" line="215"/>
+        <location filename="../ruby_help.h" line="274"/>
+        <location filename="../ruby_help.h" line="293"/>
+        <location filename="../ruby_help.h" line="367"/>
+        <location filename="../ruby_help.h" line="442"/>
         <source>Tutorial</source>
         <translation>Innføring</translation>
     </message>
     <message>
-        <location filename="../ruby_help.h" line="370"></location>
+        <location filename="../ruby_help.h" line="476"/>
         <source>Examples</source>
         <translation>Eksempler</translation>
     </message>
     <message>
-        <location filename="../ruby_help.h" line="410"></location>
+        <location filename="../ruby_help.h" line="522"/>
         <source>Synths</source>
         <translation>Synth-er</translation>
     </message>
     <message>
-        <location filename="../ruby_help.h" line="446"></location>
+        <location filename="../ruby_help.h" line="564"/>
         <source>Fx</source>
         <translation>Fx</translation>
     </message>
     <message>
-        <location filename="../ruby_help.h" line="463"></location>
+        <location filename="../ruby_help.h" line="583"/>
         <source>Samples</source>
         <translation>Prøver</translation>
     </message>
     <message>
-        <location filename="../ruby_help.h" line="629"></location>
+        <location filename="../ruby_help.h" line="779"/>
         <source>Lang</source>
         <translation>Språk</translation>
     </message>
@@ -773,17 +888,17 @@ Skaff Sonic Pi %1</translation>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../main.cpp" line="43"></location>
+        <location filename="../main.cpp" line="43"/>
         <source>Sonic Pi</source>
         <translation>Sonic Pi</translation>
     </message>
 </context>
 <context>
-    <name>SonicPiUDPServer</name>
+    <name>SonicPiUDPOSCServer</name>
     <message>
-        <location filename="../sonicpiudpserver.cpp" line="24"/>
-        <source>Is Sonic Pi already running?  Can't open UDP port 4558.</source>
-        <translation>Kjører Sonic Pi allerede? Klarer ikke åpne UDP port 4558.</translation>
+        <location filename="../sonic_pi_udp_osc_server.cpp" line="38"/>
+        <source>Is Sonic Pi already running?  Can&apos;t open UDP port 4558.</source>
+        <translation type="unfinished">Kjører Sonic Pi allerede? Klarer ikke åpne UDP port 4558.</translation>
     </message>
 </context>
 </TS>

--- a/app/gui/qt/lang/sonic-pi_pl.ts
+++ b/app/gui/qt/lang/sonic-pi_pl.ts
@@ -1,100 +1,79 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0" language="pl_PL">
-<defaultcodec>UTF-8</defaultcodec>
+<TS version="2.1" language="pl_PL">
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../mainwindow.cpp" line="153"/>
+        <location filename="../mainwindow.cpp" line="277"/>
         <source>Sonic Pi update info</source>
         <translation>Sonic PI informacje o aktualizacjach</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="296"/>
+        <location filename="../mainwindow.cpp" line="387"/>
         <source>Buffer %1</source>
         <translation>Bufor %1</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="360"/>
+        <location filename="../mainwindow.cpp" line="459"/>
         <source>Preferences</source>
         <translation>Ustawienia</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="373"/>
+        <location filename="../mainwindow.cpp" line="472"/>
         <source>Log</source>
         <translation>Log</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="414"/>
-        <location filename="../mainwindow.cpp" line="1920"/>
+        <location filename="../mainwindow.cpp" line="513"/>
+        <location filename="../mainwindow.cpp" line="2364"/>
         <source>Help</source>
         <translation>Pomoc</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="445"/>
-        <location filename="../mainwindow.cpp" line="2152"/>
-        <location filename="../mainwindow.cpp" line="2170"/>
+        <location filename="../mainwindow.cpp" line="184"/>
+        <location filename="../mainwindow.cpp" line="2607"/>
+        <location filename="../mainwindow.cpp" line="2627"/>
         <source>Sonic Pi</source>
         <translation>Sonic Pi</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="459"/>
+        <location filename="../mainwindow.cpp" line="235"/>
         <source>Welcome to Sonic Pi</source>
         <translation>Witaj w Sonic Pi</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="601"/>
+        <location filename="../mainwindow.cpp" line="708"/>
         <source>Indenting selection...</source>
         <translation>Formatowanie zaznaczenia...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="605"/>
+        <location filename="../mainwindow.cpp" line="712"/>
         <source>Indenting line...</source>
         <translation>Formatowanie linii...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="634"/>
-        <source>Commenting selection...</source>
-        <translation>Komentowanie zaznaczenia...</translation>
-    </message>
-    <message>
-        <location filename="../mainwindow.cpp" line="638"/>
-        <source>Commenting line...</source>
-        <translation>Komentowanie linii...</translation>
-    </message>
-    <message>
-        <location filename="../mainwindow.cpp" line="717"/>
-        <source>Ruby could not be started, is it installed and in your PATH?</source>
-        <translation>Ruby nie mógł zostać uruchomiony, czy został on dodany do twojej ścieżki PATH?</translation>
-    </message>
-    <message>
-        <location filename="../mainwindow.cpp" line="803"/>
+        <location filename="../mainwindow.cpp" line="911"/>
         <source>Raspberry Pi System Volume</source>
         <translation>Raspberry Pi Głośność Systemu</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="804"/>
+        <location filename="../mainwindow.cpp" line="912"/>
         <source>Use this slider to change the system volume of your Raspberry Pi.</source>
         <translation>Użyj tego suwaka aby zmienić poziom głośności w twoim Raspberry Pi.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="806"/>
+        <location filename="../mainwindow.cpp" line="914"/>
         <source>Advanced Audio</source>
         <translation>Zaawansowane Ustawienia Dźwięku</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="807"/>
+        <location filename="../mainwindow.cpp" line="915"/>
         <source>Advanced audio settings for working with
 external PA systems when performing with Sonic Pi.</source>
         <translation>Zaawansowane ustawienia audio pozwalające na pracę z zewnętrznymi profesjonalnymi sytemami audio używanymi podczas występów na scenie z Sonic Pi. </translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="808"/>
-        <source>Invert Stereo</source>
-        <translation>Odwrócone Stereo</translation>
-    </message>
-    <message>
-        <location filename="../mainwindow.cpp" line="809"/>
+        <location filename="../mainwindow.cpp" line="917"/>
         <source>Toggle stereo inversion.
 If enabled, audio sent to the left speaker will
 be routed to the right speaker and visa versa.</source>
@@ -103,12 +82,7 @@ Jeśli jest włączone, dźwięĸ wysyłany do lewego głośnika
 zostanie wysłany do prawego i vice versa.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="811"/>
-        <source>Force Mono</source>
-        <translation>Wymuś Mono</translation>
-    </message>
-    <message>
-        <location filename="../mainwindow.cpp" line="812"/>
+        <location filename="../mainwindow.cpp" line="920"/>
         <source>Toggle mono mode.
 If enabled both right and left audio is mixed and
 the same signal is sent to both speakers.
@@ -121,12 +95,12 @@ Bardzo przydatne podczas pracy z zewnętrznymi systemami
 audio, które potrafią obsługiwać tylko dźwięk mono.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="815"/>
+        <location filename="../mainwindow.cpp" line="976"/>
         <source>Safe mode</source>
         <translation>Tryb bezpieczny</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="816"/>
+        <location filename="../mainwindow.cpp" line="977"/>
         <source>Toggle synth argument checking functions.
 If disabled, certain synth opt values may
 create unexpectedly loud or uncomfortable sounds.</source>
@@ -135,12 +109,43 @@ Jeśłi nie jest włączona, pewne opcje syntezatorów mogą
 spowodować dźwięki o nieoczekiwanej głośności lub nieprzyjemnym brzmieniu. </translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="828"/>
+        <location filename="../mainwindow.cpp" line="933"/>
         <source>Raspberry Pi Audio Output</source>
         <translation>Raspberry Pi Wyjście Audio</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="829"/>
+        <location filename="../mainwindow.cpp" line="452"/>
+        <location filename="../mainwindow.cpp" line="2360"/>
+        <source>Scope</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="741"/>
+        <source>Toggle selection comment...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="745"/>
+        <source>Toggle line comment...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="803"/>
+        <source>The Sonic Pi Server could not be started!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="916"/>
+        <source>Invert stereo</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="919"/>
+        <source>Force mono</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="934"/>
         <source>Your Raspberry Pi has two forms of audio output.
 Firstly, there is the headphone jack of the Raspberry Pi itself.
 Secondly, some HDMI monitors/TVs support audio through the HDMI port.
@@ -152,37 +157,47 @@ dźwięĸu przez port HDMI.
 Użyj tych przycisków aby wymusić wyjście na takie urządzenie, które chesz.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="830"/>
+        <location filename="../mainwindow.cpp" line="935"/>
         <source>&amp;Default</source>
         <translation>&amp;Domyślnie</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="831"/>
+        <location filename="../mainwindow.cpp" line="936"/>
         <source>&amp;Headphones</source>
         <translation>&amp;Słuchawki</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="832"/>
+        <location filename="../mainwindow.cpp" line="937"/>
         <source>&amp;HDMI</source>
         <translation>&amp;HDMI</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="852"/>
+        <location filename="../mainwindow.cpp" line="957"/>
         <source>Logging</source>
         <translation>Logowanie</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="853"/>
+        <location filename="../mainwindow.cpp" line="958"/>
         <source>Configure debug behaviour</source>
         <translation>Konfiguracja zachowania debugowanych informacji</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="855"/>
+        <location filename="../mainwindow.cpp" line="960"/>
+        <source>Synths and FX</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="961"/>
+        <source>Modify behaviour of synths and FX</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="963"/>
         <source>Log synths</source>
         <translation>Logowanie syntezatorów</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="856"/>
+        <location filename="../mainwindow.cpp" line="964"/>
         <source>Toggle log messages.
 If disabled, activity such as synth and sample
 triggering will not be printed to the log by default.</source>
@@ -192,12 +207,12 @@ i samplerów nie będą domyślnie powodowały prezentowania informacji
 w oknie logowania.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="858"/>
+        <location filename="../mainwindow.cpp" line="966"/>
         <source>Clear log on run</source>
         <translation>Wyczyść okno logowania przy uruchomieniu</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="859"/>
+        <location filename="../mainwindow.cpp" line="967"/>
         <source>Toggle log clearing on run.
 If enabled, the log is cleared each
 time the run button is pressed.</source>
@@ -208,12 +223,12 @@ jest czyszczone przy każdym naciśnięciu
 przycisku Run.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="861"/>
+        <location filename="../mainwindow.cpp" line="969"/>
         <source>Log cues</source>
         <translation>Loguj punkty cue</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="862"/>
+        <location filename="../mainwindow.cpp" line="970"/>
         <source>Enable or disable logging of cues.
 If disabled, cues will still trigger.
 However, they will not be visible in the logs.</source>
@@ -222,23 +237,66 @@ Jeśłi jest wyłączone, punkty cue wciąż będą uruchamiane.
 Jednakżę, nie będą one widoczne panelu logowania.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="871"/>
+        <location filename="../mainwindow.cpp" line="972"/>
+        <source>Log auto scroll</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="973"/>
+        <source>Toggle log auto scrolling.
+If enabled the log is scrolled to the bottom after every new message is displayed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="980"/>
+        <source>Enable external synths and FX</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="981"/>
+        <source>When enabled, Sonic Pi will allow
+synths and FX loaded via load_synthdefs
+to be triggered.
+
+When disabled, Sonic Pi will complain
+when you attempt to use a synth or FX
+which isn&apos;t recognised.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="983"/>
+        <source>Enforce timing guarantees</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="984"/>
+        <source>When enabled, Sonic Pi will refuse
+to trigger synths and FX if
+it is too late to do so
+
+When disabled, Sonic Pi will always
+attempt to trigger synths and FX
+even when a little late.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1001"/>
         <source>Transparency</source>
         <translation>Przezroczystość</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="882"/>
-        <location filename="../mainwindow.cpp" line="1004"/>
+        <location filename="../mainwindow.cpp" line="1012"/>
+        <location filename="../mainwindow.cpp" line="1144"/>
         <source>Updates</source>
         <translation>Aktualizacje</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="884"/>
+        <location filename="../mainwindow.cpp" line="1014"/>
         <source>Check for updates</source>
         <translation>Sprawdź dostępność aktualizacji</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="886"/>
+        <location filename="../mainwindow.cpp" line="1016"/>
         <source>Toggle automatic update checking.
 This check involves sending anonymous information about your platform and version.</source>
         <translation>Włącza lub wyłącza automatyczne sprawdzanie aktualizacji.
@@ -246,528 +304,585 @@ Włączenie spowoduje wysyłanie anonimowych informacji o plaftormie
 i wersji z której korzystasz.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="887"/>
+        <location filename="../mainwindow.cpp" line="1017"/>
         <source>Check now</source>
         <translation>Sprawdź teraz</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="888"/>
+        <location filename="../mainwindow.cpp" line="1018"/>
         <source>Force a check for updates now.
 This check involves sending anonymous information about your platform and version.</source>
         <translation>Wymusza sprawdzenie aktualizacji w tej chwili.
 Zaznaczenie powoduje wysłanie anonimowych informacji o twojej platformie i wersji.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="889"/>
+        <location filename="../mainwindow.cpp" line="1019"/>
         <source>Get update</source>
         <translation>Pobierz aktualizację</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="890"/>
+        <location filename="../mainwindow.cpp" line="1020"/>
         <source>Visit http://sonic-pi.net to download new version</source>
         <translation>Wejdź na stronę http://sonic-pi.net aby pobrać nową wersję</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="895"/>
+        <location filename="../mainwindow.cpp" line="1025"/>
         <source>Update Info</source>
         <translation>Informacje dot. Aktualizacji</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="914"/>
+        <location filename="../mainwindow.cpp" line="1044"/>
         <source>Show and Hide</source>
         <translation>Pokaż i Ukryj</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="915"/>
+        <location filename="../mainwindow.cpp" line="1045"/>
         <source>Configure editor display options.</source>
         <translation>Skonfiguruj opcje dot. wyświetlania edytora.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="916"/>
+        <location filename="../mainwindow.cpp" line="1046"/>
         <source>Look and Feel</source>
         <translation>Wygląd i Wrażenia</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="917"/>
+        <location filename="../mainwindow.cpp" line="1047"/>
         <source>Configure editor look and feel.</source>
         <translation>Konfiguracja wyglądu i wrażeń dot. edytora.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="918"/>
+        <location filename="../mainwindow.cpp" line="1048"/>
         <source>Automation</source>
         <translation>Automatyzacja</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="919"/>
+        <location filename="../mainwindow.cpp" line="1049"/>
         <source>Configure automation features.</source>
         <translation>Konfiguracja opcji dot. automatyzacji.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="920"/>
+        <location filename="../mainwindow.cpp" line="1050"/>
         <source>Auto-align</source>
         <translation>Auto wyrównanie</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="921"/>
+        <location filename="../mainwindow.cpp" line="1051"/>
         <source>Automatically align code on Run</source>
         <translation>Automatycznie wyrównanie (formatowanie) przy uruchomieniu kodu (Run)</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="923"/>
+        <location filename="../mainwindow.cpp" line="1053"/>
         <source>Show line numbers</source>
         <translation>Pokaż numery linii</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="924"/>
+        <location filename="../mainwindow.cpp" line="1054"/>
         <source>Toggle line number visibility.</source>
         <translation>Włącza i wyłącza widoczność numerów linii.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="925"/>
+        <location filename="../mainwindow.cpp" line="1055"/>
         <source>Show log</source>
         <translation>Pokaż log</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="926"/>
+        <location filename="../mainwindow.cpp" line="1056"/>
         <source>Toggle visibility of the log.</source>
         <translation>Włącza i wyłącza widoczność panelu logowania (log).</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="928"/>
+        <location filename="../mainwindow.cpp" line="1058"/>
         <source>Show buttons</source>
         <translation>Pokaż przyciski</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="929"/>
+        <location filename="../mainwindow.cpp" line="1059"/>
         <source>Toggle visibility of the control buttons.</source>
         <translation>Włącza i wyłącza widoczność przycisków.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="931"/>
+        <location filename="../mainwindow.cpp" line="1061"/>
         <source>Show tabs</source>
         <translation>Pokazuj zakładki</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="933"/>
+        <location filename="../mainwindow.cpp" line="1063"/>
         <source>Toggle visibility of the buffer selection tabs.</source>
         <translation>Włącza i wyłącza widoczność zakładek prezentujących bufory.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="934"/>
+        <location filename="../mainwindow.cpp" line="1064"/>
         <source>Full screen</source>
         <translation>Pełny ekran</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="935"/>
+        <location filename="../mainwindow.cpp" line="1065"/>
         <source>Toggle full screen mode.</source>
         <translation>Włącza i wyłącza tryb pełnoekranowy.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="936"/>
+        <location filename="../mainwindow.cpp" line="1066"/>
         <source>Dark mode</source>
         <translation>Tryb nocny</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="937"/>
+        <location filename="../mainwindow.cpp" line="1067"/>
         <source>Toggle dark mode.</source>
         <translation>Włącza i wyłącza tryb nocny.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="937"/>
+        <location filename="../mainwindow.cpp" line="1067"/>
         <source>
 Dark mode is perfect for live coding in night clubs.</source>
         <translation>
 Tryb nocny jest idealny do kodowania na żywo w klubach.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="976"/>
+        <location filename="../mainwindow.cpp" line="1106"/>
         <source>Audio</source>
         <translation>Audio</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="988"/>
+        <location filename="../mainwindow.cpp" line="1118"/>
         <source>Editor</source>
         <translation>Edytor</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="989"/>
+        <location filename="../mainwindow.cpp" line="1119"/>
         <source>Studio</source>
         <translation>Studio</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="991"/>
-        <location filename="../mainwindow.cpp" line="996"/>
+        <location filename="../mainwindow.cpp" line="1121"/>
+        <location filename="../mainwindow.cpp" line="1131"/>
         <source>Performance</source>
         <translation>Koncert</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="992"/>
+        <location filename="../mainwindow.cpp" line="1122"/>
         <source>Settings useful for performing with Sonic Pi</source>
         <translation>Ustawienia przydatne gdy korzystasz z Sonic Pi na koncertach/podczas występów</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1087"/>
+        <location filename="../mainwindow.cpp" line="1259"/>
         <source>Server boot error...</source>
         <translation>Błąd przy uruchamianiu serwera...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1087"/>
-        <source>Apologies, a critical error occurred during startup</source>
-        <translation>Przepraszamy, wystąpił krytyczny błąd podczas uruchamiania</translation>
+        <location filename="../mainwindow.cpp" line="2338"/>
+        <source>Run the code in the current buffer</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1087"/>
+        <location filename="../mainwindow.cpp" line="1259"/>
         <source>Please consider reporting a bug at</source>
         <translation>Proszę, spróbuj zgłosić ten błąd na stronie</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1181"/>
+        <location filename="../mainwindow.cpp" line="1259"/>
+        <source>Sonic Pi Boot Error
+
+Apologies, a critical error occurred during startup</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1361"/>
+        <location filename="../mainwindow.cpp" line="1362"/>
+        <location filename="../mainwindow.cpp" line="1374"/>
+        <location filename="../mainwindow.cpp" line="1375"/>
+        <source>Buffer files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1362"/>
+        <source>Load Sonic Pi Buffer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1362"/>
+        <location filename="../mainwindow.cpp" line="1375"/>
+        <source>Text files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1362"/>
+        <location filename="../mainwindow.cpp" line="1375"/>
+        <source>Ruby files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1362"/>
+        <location filename="../mainwindow.cpp" line="1375"/>
+        <source>All files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1375"/>
         <source>Save Current Buffer</source>
         <translation>Zapisz Aktualny Bufor</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1249"/>
+        <location filename="../mainwindow.cpp" line="1447"/>
         <source>Running Code...</source>
         <translation>Uruchamianie Kodu...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1275"/>
-        <source>Workspace %1</source>
-        <translation>Bufor %1</translation>
-    </message>
-    <message>
-        <location filename="../mainwindow.cpp" line="1291"/>
+        <location filename="../mainwindow.cpp" line="1496"/>
         <source>Zooming In...</source>
         <translation>Powiększanie...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1298"/>
+        <location filename="../mainwindow.cpp" line="1503"/>
         <source>Zooming Out...</source>
         <translation>Zmniejszanie...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1305"/>
+        <location filename="../mainwindow.cpp" line="1510"/>
         <source>Beautifying...</source>
         <translation>Upiększanie...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1325"/>
+        <location filename="../mainwindow.cpp" line="1530"/>
         <source>Reloading...</source>
         <translation>Trwa Przeładowanie...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1332"/>
+        <location filename="../mainwindow.cpp" line="1537"/>
         <source>Checking for updates...</source>
         <translation>Sprawdzam aktualizacje...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1340"/>
+        <location filename="../mainwindow.cpp" line="1545"/>
         <source>Enabling update checking...</source>
         <translation>Włączam sprawdzanie aktualizacji...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1348"/>
+        <location filename="../mainwindow.cpp" line="1553"/>
         <source>Disabling update checking...</source>
         <translation>Wyłączam sprawdzanie aktualizacji...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1356"/>
+        <location filename="../mainwindow.cpp" line="1561"/>
         <source>Enabling Mixer HPF...</source>
         <translatorcomment>HPF - High Pass Filter (Filtr górnoprzepustowy)</translatorcomment>
         <translation>Włączanie Miksera HPF...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1365"/>
+        <location filename="../mainwindow.cpp" line="1570"/>
         <source>Disabling Mixer HPF...</source>
         <translation>Wyłączam Mikser HPF...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1373"/>
+        <location filename="../mainwindow.cpp" line="1578"/>
         <source>Enabling Mixer LPF...</source>
         <translation>Włączam Mikser LPF...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1382"/>
+        <location filename="../mainwindow.cpp" line="1587"/>
         <source>Disabling Mixer LPF...</source>
         <translation>Wyłączam Mikser LPF...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1390"/>
+        <location filename="../mainwindow.cpp" line="1595"/>
         <source>Enabling Inverted Stereo...</source>
         <translation>Włączam Odwrócone Stereo...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1398"/>
+        <location filename="../mainwindow.cpp" line="1603"/>
         <source>Enabling Standard Stereo...</source>
         <translation>Włączam Standardowe Stereo...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1406"/>
+        <location filename="../mainwindow.cpp" line="1611"/>
         <source>Mono Mode...</source>
         <translation>Tryb Mono...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1414"/>
+        <location filename="../mainwindow.cpp" line="1619"/>
         <source>Stereo Mode...</source>
         <translation>Tryb Stereo...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1423"/>
+        <location filename="../mainwindow.cpp" line="1628"/>
         <source>Stopping...</source>
         <translation>Zatrzymuję...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1507"/>
+        <location filename="../mainwindow.cpp" line="1736"/>
         <source>Updating System Volume...</source>
         <translation>Aktualizuję Głośność Systemu...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1729"/>
+        <location filename="../mainwindow.cpp" line="1752"/>
+        <source>Log Auto Scroll on...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1754"/>
+        <source>Log Auto Scroll off...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2155"/>
         <source>Switching To Headphone Audio Output...</source>
         <translation>Zmieniam Wyjśćie Na Słuchawkowe...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1745"/>
+        <location filename="../mainwindow.cpp" line="2171"/>
         <source>Switching To HDMI Audio Output...</source>
         <translation>Zmieniam Wyjśćie na HDMI...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1760"/>
+        <location filename="../mainwindow.cpp" line="2186"/>
         <source>Switching To Default Audio Output...</source>
         <translation>Zmieniam Wyjście Na Domyślne Wyjście Audio...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1902"/>
+        <location filename="../mainwindow.cpp" line="2337"/>
         <source>Run</source>
         <translation>Run (Uruchom)</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1903"/>
-        <source>Run the code in the current workspace</source>
-        <translation>Uruchom kod znajdujący się aktualnym buforze</translation>
-    </message>
-    <message>
-        <location filename="../mainwindow.cpp" line="1907"/>
+        <location filename="../mainwindow.cpp" line="2343"/>
         <source>Stop</source>
         <translation>Stop</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1908"/>
+        <location filename="../mainwindow.cpp" line="2344"/>
         <source>Stop all running code</source>
         <translation>Zatrzymuje jakikolwiek kod, który jest aktualnie uruchomiony</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1911"/>
+        <location filename="../mainwindow.cpp" line="2347"/>
         <source>Save As...</source>
         <translation>Zapisz jako...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1912"/>
+        <location filename="../mainwindow.cpp" line="2348"/>
         <source>Save current buffer as an external file</source>
         <translation>Zapisz aktualny bufor jako zewnętrzny plik</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1915"/>
+        <location filename="../mainwindow.cpp" line="2351"/>
+        <source>Load</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2352"/>
+        <source>Load an external file in the current buffer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2355"/>
         <source>Info</source>
         <translation>Info</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1916"/>
+        <location filename="../mainwindow.cpp" line="2356"/>
         <source>See information about Sonic Pi</source>
         <translation>Zobacz informacje o Sonic Pi</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1921"/>
+        <location filename="../mainwindow.cpp" line="2361"/>
+        <source>View audio output</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2365"/>
         <source>Toggle help pane</source>
         <translation>Włącza i wyłącza panel pomocy</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1924"/>
+        <location filename="../mainwindow.cpp" line="2368"/>
         <source>Prefs</source>
         <translation>Ustawienia</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1925"/>
+        <location filename="../mainwindow.cpp" line="2369"/>
         <source>Toggle preferences pane</source>
         <translation>Włącza i wyłącza panel ustawień</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1929"/>
-        <location filename="../mainwindow.cpp" line="2051"/>
-        <location filename="../mainwindow.cpp" line="2052"/>
+        <location filename="../mainwindow.cpp" line="2373"/>
+        <location filename="../mainwindow.cpp" line="2502"/>
+        <location filename="../mainwindow.cpp" line="2503"/>
         <source>Start Recording</source>
         <translation>Uruchom Nagrywanie</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1930"/>
+        <location filename="../mainwindow.cpp" line="2374"/>
         <source>Start recording to WAV audio file</source>
         <translation>Uruchamiana nagrywanie dźwięku do pliku WAV</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1934"/>
+        <location filename="../mainwindow.cpp" line="2378"/>
         <source>Auto-Align Text</source>
         <translation>Automatyczne Wyrównanie Tekstu</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1935"/>
+        <location filename="../mainwindow.cpp" line="2379"/>
         <source>Improve readability of code</source>
         <translation>Poprawia czytelność kodu</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1939"/>
-        <location filename="../mainwindow.cpp" line="1940"/>
+        <location filename="../mainwindow.cpp" line="2385"/>
         <source>Increase Text Size</source>
         <translation>Zwiększa Wielkość Tekstu</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1944"/>
-        <location filename="../mainwindow.cpp" line="1945"/>
+        <location filename="../mainwindow.cpp" line="2392"/>
         <source>Decrease Text Size</source>
         <translation>Zmniejsza Wielkość Tekstu</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1950"/>
+        <location filename="../mainwindow.cpp" line="2397"/>
         <source>Tools</source>
         <translation>Narzędzia</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1997"/>
+        <location filename="../mainwindow.cpp" line="2448"/>
         <source>About</source>
         <translation>Informacje</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1998"/>
+        <location filename="../mainwindow.cpp" line="2449"/>
         <source>Core Team</source>
         <translation>Zespół Podstawowy</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1999"/>
+        <location filename="../mainwindow.cpp" line="2450"/>
         <source>Contributors</source>
         <translation>Osoby, które wniosły wkład</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2000"/>
+        <location filename="../mainwindow.cpp" line="2451"/>
         <source>Community</source>
         <translation>Społeczność</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2001"/>
+        <location filename="../mainwindow.cpp" line="2452"/>
         <source>License</source>
         <translation>Licencja</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2002"/>
+        <location filename="../mainwindow.cpp" line="2453"/>
         <source>History</source>
         <translation>HIstoria</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2023"/>
+        <location filename="../mainwindow.cpp" line="2474"/>
         <source>Sonic Pi - Info</source>
         <translation>Sonic Pi - Info</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2043"/>
-        <location filename="../mainwindow.cpp" line="2044"/>
+        <location filename="../mainwindow.cpp" line="2494"/>
+        <location filename="../mainwindow.cpp" line="2495"/>
         <source>Stop Recording</source>
         <translation>Zakończ Nagrywanie</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2057"/>
+        <location filename="../mainwindow.cpp" line="2508"/>
         <source>Save Recording</source>
         <translation>Zapisz Nagranie</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2076"/>
+        <location filename="../mainwindow.cpp" line="2508"/>
+        <source>Wavefile (*.wav)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2527"/>
         <source>Ready...</source>
         <translation>Gotowy....</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2153"/>
+        <location filename="../mainwindow.cpp" line="2608"/>
         <source>Cannot read file %1:
 %2.</source>
         <translation>NIe można odczytać pliku %1: %2.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2163"/>
+        <location filename="../mainwindow.cpp" line="2619"/>
         <source>File loaded...</source>
         <translation>Plik wczytany....</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2171"/>
+        <location filename="../mainwindow.cpp" line="2628"/>
         <source>Cannot write file %1:
 %2.</source>
         <translation>Nie można zapisać pliku %1: %2.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2188"/>
+        <location filename="../mainwindow.cpp" line="2646"/>
         <source>File saved...</source>
         <translation>Plik zapisany....</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2413"/>
+        <location filename="../mainwindow.cpp" line="2873"/>
         <source>Last checked %1</source>
         <translation>Ostatnio sprawdzono %1</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2415"/>
+        <location filename="../mainwindow.cpp" line="2875"/>
         <source>Sonic Pi checks for updates
 every two weeks.</source>
         <translation>Sonic Pi sprawdza aktualizacje
 co dwa tygodnie.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2417"/>
+        <location filename="../mainwindow.cpp" line="2877"/>
         <source>This is Sonic Pi %1</source>
         <translation>To jest Sonic Pi %1</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2418"/>
+        <location filename="../mainwindow.cpp" line="2878"/>
         <source>Version %2 is now available!</source>
         <translation>Wersja %2 jest dostępna!</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2422"/>
+        <location filename="../mainwindow.cpp" line="2882"/>
         <source>New version available!
 Get Sonic Pi %1</source>
         <translation>Nowa wersja jest już dostępna! Pobierz Sonic Pi %1</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2448"/>
+        <location filename="../mainwindow.cpp" line="2908"/>
         <source>Welcome back. Now get your live code on...</source>
         <translation>Witaj ponownie. A teraz spraw aby twój kod ożył...</translation>
     </message>
     <message>
-        <location filename="../ruby_help.h" line="80"/>
-        <location filename="../ruby_help.h" line="139"/>
-        <location filename="../ruby_help.h" line="199"/>
-        <location filename="../ruby_help.h" line="218"/>
-        <location filename="../ruby_help.h" line="278"/>
-        <location filename="../ruby_help.h" line="338"/>
+        <location filename="../ruby_help.h" line="93"/>
+        <location filename="../ruby_help.h" line="154"/>
+        <location filename="../ruby_help.h" line="215"/>
+        <location filename="../ruby_help.h" line="274"/>
+        <location filename="../ruby_help.h" line="293"/>
+        <location filename="../ruby_help.h" line="367"/>
+        <location filename="../ruby_help.h" line="442"/>
         <source>Tutorial</source>
         <translation>Samouczek</translation>
     </message>
     <message>
-        <location filename="../ruby_help.h" line="370"/>
+        <location filename="../ruby_help.h" line="476"/>
         <source>Examples</source>
         <translation>Przykłady</translation>
     </message>
     <message>
-        <location filename="../ruby_help.h" line="410"/>
+        <location filename="../ruby_help.h" line="522"/>
         <source>Synths</source>
         <translation>Syntezatory</translation>
     </message>
     <message>
-        <location filename="../ruby_help.h" line="446"/>
+        <location filename="../ruby_help.h" line="564"/>
         <source>Fx</source>
         <translation>Efekty</translation>
     </message>
     <message>
-        <location filename="../ruby_help.h" line="463"/>
+        <location filename="../ruby_help.h" line="583"/>
         <source>Samples</source>
         <translation>Sample</translation>
     </message>
     <message>
-        <location filename="../ruby_help.h" line="629"/>
+        <location filename="../ruby_help.h" line="779"/>
         <source>Lang</source>
         <translation>Język</translation>
     </message>
@@ -781,11 +896,11 @@ Get Sonic Pi %1</source>
     </message>
 </context>
 <context>
-    <name>SonicPiUDPServer</name>
+    <name>SonicPiUDPOSCServer</name>
     <message>
-        <location filename="../sonicpiudpserver.cpp" line="24"/>
+        <location filename="../sonic_pi_udp_osc_server.cpp" line="38"/>
         <source>Is Sonic Pi already running?  Can&apos;t open UDP port 4558.</source>
-        <translation>Czy Sonic Pi nie jest już uruchoiony? Nie można otworzyć portu UDP o numerze 4558.</translation>
+        <translation type="unfinished">Czy Sonic Pi nie jest już uruchoiony? Nie można otworzyć portu UDP o numerze 4558.</translation>
     </message>
 </context>
 </TS>

--- a/app/gui/qt/lang/sonic-pi_zh-Hans.ts
+++ b/app/gui/qt/lang/sonic-pi_zh-Hans.ts
@@ -4,108 +4,93 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../mainwindow.cpp" line="201"/>
-        <location filename="../mainwindow.cpp" line="2336"/>
-        <location filename="../mainwindow.cpp" line="2356"/>
+        <location filename="../mainwindow.cpp" line="184"/>
+        <location filename="../mainwindow.cpp" line="2607"/>
+        <location filename="../mainwindow.cpp" line="2627"/>
         <source>Sonic Pi</source>
         <translation>Sonic Pi</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="254"/>
+        <location filename="../mainwindow.cpp" line="235"/>
         <source>Welcome to Sonic Pi</source>
         <translation>欢迎进入Sonic Pi的世界</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="296"/>
+        <location filename="../mainwindow.cpp" line="277"/>
         <source>Sonic Pi update info</source>
         <translation>Sonic Pi更新</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="400"/>
+        <location filename="../mainwindow.cpp" line="387"/>
         <source>Buffer %1</source>
         <translation>编辑器窗口 %1</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="464"/>
+        <location filename="../mainwindow.cpp" line="459"/>
         <source>Preferences</source>
         <translation>偏好设置</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="477"/>
+        <location filename="../mainwindow.cpp" line="472"/>
         <source>Log</source>
         <translation>日志</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="518"/>
-        <location filename="../mainwindow.cpp" line="2097"/>
+        <location filename="../mainwindow.cpp" line="513"/>
+        <location filename="../mainwindow.cpp" line="2364"/>
         <source>Help</source>
         <translation>帮助</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="670"/>
+        <location filename="../mainwindow.cpp" line="708"/>
         <source>Indenting selection...</source>
         <translation>缩进选中区域</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="674"/>
+        <location filename="../mainwindow.cpp" line="712"/>
         <source>Indenting line...</source>
         <translation>缩进当前行</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="703"/>
+        <location filename="../mainwindow.cpp" line="741"/>
         <source>Toggle selection comment...</source>
         <translation>注释/取消注释选中区域</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="707"/>
+        <location filename="../mainwindow.cpp" line="745"/>
         <source>Toggle line comment...</source>
         <translation>注释/取消注释当前行</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="765"/>
-        <source>The Sonic Pi server could not be started!</source>
-        <translation>Sonic Pi服务器无法启动。</translation>
-    </message>
-    <message>
-        <location filename="../mainwindow.cpp" line="872"/>
+        <location filename="../mainwindow.cpp" line="911"/>
         <source>Raspberry Pi System Volume</source>
         <translation>Raspberry Pi系统音量</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="873"/>
+        <location filename="../mainwindow.cpp" line="912"/>
         <source>Use this slider to change the system volume of your Raspberry Pi.</source>
         <translation>请用这个滑块调整Raspberry Pi的系统音量</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="875"/>
+        <location filename="../mainwindow.cpp" line="914"/>
         <source>Advanced Audio</source>
         <translation>高级音量选项</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="876"/>
+        <location filename="../mainwindow.cpp" line="915"/>
         <source>Advanced audio settings for working with
 external PA systems when performing with Sonic Pi.</source>
         <translation>外接PA系统的高级音量选项</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="877"/>
-        <source>Invert Stereo</source>
-        <translation>反转立体声声道</translation>
-    </message>
-    <message>
-        <location filename="../mainwindow.cpp" line="878"/>
+        <location filename="../mainwindow.cpp" line="917"/>
         <source>Toggle stereo inversion.
 If enabled, audio sent to the left speaker will
 be routed to the right speaker and visa versa.</source>
         <translation>打开/关闭立体声声道反转</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="880"/>
-        <source>Force Mono</source>
-        <translation>强制单声道</translation>
-    </message>
-    <message>
-        <location filename="../mainwindow.cpp" line="881"/>
+        <location filename="../mainwindow.cpp" line="920"/>
         <source>Toggle mono mode.
 If enabled both right and left audio is mixed and
 the same signal is sent to both speakers.
@@ -114,24 +99,56 @@ can only handle mono.</source>
         <translation>打开/关闭强制单声道</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="884"/>
+        <location filename="../mainwindow.cpp" line="972"/>
+        <source>Log auto scroll</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="973"/>
+        <source>Toggle log auto scrolling.
+If enabled the log is scrolled to the bottom after every new message is displayed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="976"/>
         <source>Safe mode</source>
         <translation>安全模式</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="885"/>
+        <location filename="../mainwindow.cpp" line="977"/>
         <source>Toggle synth argument checking functions.
 If disabled, certain synth opt values may
 create unexpectedly loud or uncomfortable sounds.</source>
         <translation>打开/关闭合成器参数检查</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="897"/>
+        <location filename="../mainwindow.cpp" line="933"/>
         <source>Raspberry Pi Audio Output</source>
         <translation>Raspberry Pi音频输出</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="898"/>
+        <location filename="../mainwindow.cpp" line="452"/>
+        <location filename="../mainwindow.cpp" line="2360"/>
+        <source>Scope</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="803"/>
+        <source>The Sonic Pi Server could not be started!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="916"/>
+        <source>Invert stereo</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="919"/>
+        <source>Force mono</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="934"/>
         <source>Your Raspberry Pi has two forms of audio output.
 Firstly, there is the headphone jack of the Raspberry Pi itself.
 Secondly, some HDMI monitors/TVs support audio through the HDMI port.
@@ -140,264 +157,263 @@ Use these buttons to force the output to the one you want.</source>
             第二种是通过HDMI接口。你可以通过以下按钮来选择你希望使用的音频输出方式</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="899"/>
+        <location filename="../mainwindow.cpp" line="935"/>
         <source>&amp;Default</source>
         <translation>&amp;默认</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="900"/>
+        <location filename="../mainwindow.cpp" line="936"/>
         <source>&amp;Headphones</source>
         <translation>&amp;耳机接口</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="901"/>
+        <location filename="../mainwindow.cpp" line="937"/>
         <source>&amp;HDMI</source>
         <translation>&amp;HDMI接口</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="921"/>
+        <location filename="../mainwindow.cpp" line="957"/>
         <source>Logging</source>
         <translation>日志选项</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="922"/>
+        <location filename="../mainwindow.cpp" line="958"/>
         <source>Configure debug behaviour</source>
         <translation>配置调试模式</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="924"/>
+        <location filename="../mainwindow.cpp" line="960"/>
+        <source>Synths and FX</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="961"/>
+        <source>Modify behaviour of synths and FX</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="963"/>
         <source>Log synths</source>
         <translation>记录声音合成</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="925"/>
+        <location filename="../mainwindow.cpp" line="964"/>
         <source>Toggle log messages.
 If disabled, activity such as synth and sample
 triggering will not be printed to the log by default.</source>
         <translation>是否记录日志</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="927"/>
+        <location filename="../mainwindow.cpp" line="966"/>
         <source>Clear log on run</source>
         <translation>重新运行时清空日志</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="928"/>
+        <location filename="../mainwindow.cpp" line="967"/>
         <source>Toggle log clearing on run.
 If enabled, the log is cleared each
 time the run button is pressed.</source>
         <translation>是否在运行时自动清空日志</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="930"/>
+        <location filename="../mainwindow.cpp" line="969"/>
         <source>Log cues</source>
         <translation>记录提示</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="931"/>
+        <location filename="../mainwindow.cpp" line="970"/>
         <source>Enable or disable logging of cues.
 If disabled, cues will still trigger.
 However, they will not be visible in the logs.</source>
         <translation>是否记录提示到日志</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="933"/>
-        <source>Log Auto Scroll</source>
-        <translation>日志自动滚动</translation>
-    </message>
-    <message>
-        <location filename="../mainwindow.cpp" line="934"/>
-        <source>Toggle log auto scrolling.
-If enabled the log is scrolled to the botton after every new message is displayed.</source>
-        <translation>是否自动滚动日志</translation>
-    </message>
-    <message>
-        <location filename="../mainwindow.cpp" line="944"/>
+        <location filename="../mainwindow.cpp" line="1001"/>
         <source>Transparency</source>
         <translation>透明度</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="955"/>
-        <location filename="../mainwindow.cpp" line="1087"/>
+        <location filename="../mainwindow.cpp" line="1012"/>
+        <location filename="../mainwindow.cpp" line="1144"/>
         <source>Updates</source>
         <translation>更新</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="957"/>
+        <location filename="../mainwindow.cpp" line="1014"/>
         <source>Check for updates</source>
         <translation>检查更新</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="959"/>
+        <location filename="../mainwindow.cpp" line="1016"/>
         <source>Toggle automatic update checking.
 This check involves sending anonymous information about your platform and version.</source>
         <translation>打开/关闭自动更新（以及上传匿名版本信息）</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="960"/>
+        <location filename="../mainwindow.cpp" line="1017"/>
         <source>Check now</source>
         <translation>立即检查更新</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="961"/>
+        <location filename="../mainwindow.cpp" line="1018"/>
         <source>Force a check for updates now.
 This check involves sending anonymous information about your platform and version.</source>
         <translation>立即检查更新（并上传匿名版本信息）</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="962"/>
+        <location filename="../mainwindow.cpp" line="1019"/>
         <source>Get update</source>
         <translation>获取更新</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="963"/>
+        <location filename="../mainwindow.cpp" line="1020"/>
         <source>Visit http://sonic-pi.net to download new version</source>
         <translation>访问http://sonic-pi.net下载新版本</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="968"/>
+        <location filename="../mainwindow.cpp" line="1025"/>
         <source>Update Info</source>
         <translation>更新信息</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="987"/>
+        <location filename="../mainwindow.cpp" line="1044"/>
         <source>Show and Hide</source>
         <translation>显示/隐藏</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="988"/>
+        <location filename="../mainwindow.cpp" line="1045"/>
         <source>Configure editor display options.</source>
         <translation>代码编辑器选项</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="989"/>
+        <location filename="../mainwindow.cpp" line="1046"/>
         <source>Look and Feel</source>
         <translation>外观</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="990"/>
+        <location filename="../mainwindow.cpp" line="1047"/>
         <source>Configure editor look and feel.</source>
         <translation>设置代码编辑器外观</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="991"/>
+        <location filename="../mainwindow.cpp" line="1048"/>
         <source>Automation</source>
         <translation>自动化</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="992"/>
+        <location filename="../mainwindow.cpp" line="1049"/>
         <source>Configure automation features.</source>
         <translation>设置自动化选项</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="993"/>
+        <location filename="../mainwindow.cpp" line="1050"/>
         <source>Auto-align</source>
         <translation>自动对齐</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="994"/>
+        <location filename="../mainwindow.cpp" line="1051"/>
         <source>Automatically align code on Run</source>
         <translation>运行时自动对齐代码</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="996"/>
+        <location filename="../mainwindow.cpp" line="1053"/>
         <source>Show line numbers</source>
         <translation>显示行号</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="997"/>
+        <location filename="../mainwindow.cpp" line="1054"/>
         <source>Toggle line number visibility.</source>
         <translation>是否显示行号</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="998"/>
+        <location filename="../mainwindow.cpp" line="1055"/>
         <source>Show log</source>
         <translation>显示日志</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="999"/>
+        <location filename="../mainwindow.cpp" line="1056"/>
         <source>Toggle visibility of the log.</source>
         <translation>是否显示日志</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1001"/>
+        <location filename="../mainwindow.cpp" line="1058"/>
         <source>Show buttons</source>
         <translation>显示控制按钮</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1002"/>
+        <location filename="../mainwindow.cpp" line="1059"/>
         <source>Toggle visibility of the control buttons.</source>
         <translation>是否显示控制按钮</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1004"/>
+        <location filename="../mainwindow.cpp" line="1061"/>
         <source>Show tabs</source>
         <translation>显示编辑器窗口选择栏</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1006"/>
+        <location filename="../mainwindow.cpp" line="1063"/>
         <source>Toggle visibility of the buffer selection tabs.</source>
         <translation>是否显示编辑器窗口选择栏</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1007"/>
+        <location filename="../mainwindow.cpp" line="1064"/>
         <source>Full screen</source>
         <translation>全屏模式</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1008"/>
+        <location filename="../mainwindow.cpp" line="1065"/>
         <source>Toggle full screen mode.</source>
         <translation>打开/关闭全屏模式</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1009"/>
+        <location filename="../mainwindow.cpp" line="1066"/>
         <source>Dark mode</source>
         <translation>夜灯模式</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1010"/>
+        <location filename="../mainwindow.cpp" line="1067"/>
         <source>Toggle dark mode.</source>
         <translation>打开/关闭夜灯模式</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1010"/>
+        <location filename="../mainwindow.cpp" line="1067"/>
         <source>
 Dark mode is perfect for live coding in night clubs.</source>
         <translation>夜灯模式适用于在灯光教案的场所使用</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1049"/>
+        <location filename="../mainwindow.cpp" line="1106"/>
         <source>Audio</source>
         <translation>音频</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1061"/>
+        <location filename="../mainwindow.cpp" line="1118"/>
         <source>Editor</source>
         <translation>编辑器</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1062"/>
+        <location filename="../mainwindow.cpp" line="1119"/>
         <source>Studio</source>
         <translation>工作室</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1064"/>
-        <location filename="../mainwindow.cpp" line="1074"/>
+        <location filename="../mainwindow.cpp" line="1121"/>
+        <location filename="../mainwindow.cpp" line="1131"/>
         <source>Performance</source>
         <translation>性能</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1065"/>
+        <location filename="../mainwindow.cpp" line="1122"/>
         <source>Settings useful for performing with Sonic Pi</source>
         <translation>表演用设置</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1200"/>
+        <location filename="../mainwindow.cpp" line="1259"/>
         <source>Server boot error...</source>
         <translation>服务器启动错误...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1200"/>
+        <location filename="../mainwindow.cpp" line="1259"/>
         <source>Sonic Pi Boot Error
 
 Apologies, a critical error occurred during startup</source>
@@ -407,361 +423,448 @@ Apologies, a critical error occurred during startup</source>
         </translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1200"/>
+        <location filename="../mainwindow.cpp" line="1259"/>
         <source>Please consider reporting a bug at</source>
         <translation>你可以报告这个bug</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1305"/>
-        <location filename="../mainwindow.cpp" line="1318"/>
-        <source>Buffer files(*.rb *.txt)</source>
-        <translation>Sonic-Pi代码文件 (*.rb *.txt)</translation>
+        <location filename="../mainwindow.cpp" line="980"/>
+        <source>Enable external synths and FX</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1306"/>
-        <source>Load Sonic-Pi Buffer</source>
-        <translation>加载Sonic-Pi代码</translation>
+        <location filename="../mainwindow.cpp" line="981"/>
+        <source>When enabled, Sonic Pi will allow
+synths and FX loaded via load_synthdefs
+to be triggered.
+
+When disabled, Sonic Pi will complain
+when you attempt to use a synth or FX
+which isn&apos;t recognised.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1306"/>
-        <location filename="../mainwindow.cpp" line="1319"/>
-        <source>Buffer files(*.rb *.txt);;Text files (*.txt);;Ruby (*.rb);;All files (*.*)</source>
-        <translation>Sonic-Pi代码文件 (*.rb *.txt);;Text files (*.txt);;Ruby (*.rb);;所有文件 (*.*)</translation>
+        <location filename="../mainwindow.cpp" line="983"/>
+        <source>Enforce timing guarantees</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1319"/>
+        <location filename="../mainwindow.cpp" line="984"/>
+        <source>When enabled, Sonic Pi will refuse
+to trigger synths and FX if
+it is too late to do so
+
+When disabled, Sonic Pi will always
+attempt to trigger synths and FX
+even when a little late.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1361"/>
+        <location filename="../mainwindow.cpp" line="1362"/>
+        <location filename="../mainwindow.cpp" line="1374"/>
+        <location filename="../mainwindow.cpp" line="1375"/>
+        <source>Buffer files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1362"/>
+        <source>Load Sonic Pi Buffer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1362"/>
+        <location filename="../mainwindow.cpp" line="1375"/>
+        <source>Text files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1362"/>
+        <location filename="../mainwindow.cpp" line="1375"/>
+        <source>Ruby files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1362"/>
+        <location filename="../mainwindow.cpp" line="1375"/>
+        <source>All files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1375"/>
         <source>Save Current Buffer</source>
         <translation>保存当前编辑器窗口代码</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1390"/>
+        <location filename="../mainwindow.cpp" line="1447"/>
         <source>Running Code...</source>
         <translation>运行代码</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1432"/>
+        <location filename="../mainwindow.cpp" line="1496"/>
         <source>Zooming In...</source>
         <translation>放大...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1439"/>
+        <location filename="../mainwindow.cpp" line="1503"/>
         <source>Zooming Out...</source>
         <translation>缩小...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1446"/>
+        <location filename="../mainwindow.cpp" line="1510"/>
         <source>Beautifying...</source>
         <translation>美化...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1466"/>
+        <location filename="../mainwindow.cpp" line="1530"/>
         <source>Reloading...</source>
         <translation>重新载入...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1473"/>
+        <location filename="../mainwindow.cpp" line="1537"/>
         <source>Checking for updates...</source>
         <translation>检查更新...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1481"/>
+        <location filename="../mainwindow.cpp" line="1545"/>
         <source>Enabling update checking...</source>
         <translation>开启更新检查...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1489"/>
+        <location filename="../mainwindow.cpp" line="1553"/>
         <source>Disabling update checking...</source>
         <translation>关闭更新检查...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1497"/>
+        <location filename="../mainwindow.cpp" line="1561"/>
         <source>Enabling Mixer HPF...</source>
         <translation>启用高通滤波器...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1506"/>
+        <location filename="../mainwindow.cpp" line="1570"/>
         <source>Disabling Mixer HPF...</source>
         <translation>禁用高通滤波器...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1514"/>
+        <location filename="../mainwindow.cpp" line="1578"/>
         <source>Enabling Mixer LPF...</source>
         <translation>启用低通滤波器...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1523"/>
+        <location filename="../mainwindow.cpp" line="1587"/>
         <source>Disabling Mixer LPF...</source>
         <translation>禁用低通滤波器...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1531"/>
+        <location filename="../mainwindow.cpp" line="1595"/>
         <source>Enabling Inverted Stereo...</source>
         <translation>启用反转立体声...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1539"/>
+        <location filename="../mainwindow.cpp" line="1603"/>
         <source>Enabling Standard Stereo...</source>
         <translation>启用标准立体声...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1547"/>
+        <location filename="../mainwindow.cpp" line="1611"/>
         <source>Mono Mode...</source>
         <translation>单声道模式...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1555"/>
+        <location filename="../mainwindow.cpp" line="1619"/>
         <source>Stereo Mode...</source>
         <translation>立体声模式...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1564"/>
+        <location filename="../mainwindow.cpp" line="1628"/>
         <source>Stopping...</source>
         <translation>终止当前任务...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1660"/>
+        <location filename="../mainwindow.cpp" line="1736"/>
         <source>Updating System Volume...</source>
         <translation>更新系统音量...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1676"/>
+        <location filename="../mainwindow.cpp" line="1752"/>
         <source>Log Auto Scroll on...</source>
         <translation>日志窗口自动滚动开启...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1678"/>
+        <location filename="../mainwindow.cpp" line="1754"/>
         <source>Log Auto Scroll off...</source>
         <translation>日志窗口自动滚动关闭...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1892"/>
+        <location filename="../mainwindow.cpp" line="2155"/>
         <source>Switching To Headphone Audio Output...</source>
         <translation>切换到耳机音频输出...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1908"/>
+        <location filename="../mainwindow.cpp" line="2171"/>
         <source>Switching To HDMI Audio Output...</source>
         <translation>切换到HDMI音频输出...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1923"/>
+        <location filename="../mainwindow.cpp" line="2186"/>
         <source>Switching To Default Audio Output...</source>
         <translation>切换到默认音频输出...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2074"/>
+        <location filename="../mainwindow.cpp" line="2337"/>
         <source>Run</source>
         <translation>运行</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2075"/>
+        <location filename="../mainwindow.cpp" line="2338"/>
         <source>Run the code in the current buffer</source>
         <translation>运行当前编辑器窗口内的代码</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2080"/>
+        <location filename="../mainwindow.cpp" line="2343"/>
         <source>Stop</source>
         <translation>停止</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2081"/>
+        <location filename="../mainwindow.cpp" line="2344"/>
         <source>Stop all running code</source>
         <translation>停止所有代码运行</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2084"/>
+        <location filename="../mainwindow.cpp" line="2347"/>
         <source>Save As...</source>
         <translation>另存为...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2085"/>
+        <location filename="../mainwindow.cpp" line="2348"/>
         <source>Save current buffer as an external file</source>
         <translation>保存当前编辑器窗口为外部文件</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2088"/>
+        <location filename="../mainwindow.cpp" line="2351"/>
         <source>Load</source>
         <translation>载入</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2089"/>
+        <location filename="../mainwindow.cpp" line="2352"/>
         <source>Load an external file in the current buffer</source>
         <translation>载入外部文件到当前编辑器窗口</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2092"/>
+        <location filename="../mainwindow.cpp" line="2355"/>
         <source>Info</source>
         <translation>信息</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2093"/>
+        <location filename="../mainwindow.cpp" line="2356"/>
         <source>See information about Sonic Pi</source>
         <translation>查看Sonic Pi相关信息</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2098"/>
+        <location filename="../mainwindow.cpp" line="2361"/>
+        <source>View audio output</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2365"/>
         <source>Toggle help pane</source>
         <translation>打开/关闭帮助栏</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2101"/>
+        <location filename="../mainwindow.cpp" line="2368"/>
         <source>Prefs</source>
         <translation>偏好选项</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2102"/>
+        <location filename="../mainwindow.cpp" line="2369"/>
         <source>Toggle preferences pane</source>
         <translation>打开/关闭偏好选项栏</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2106"/>
-        <location filename="../mainwindow.cpp" line="2234"/>
-        <location filename="../mainwindow.cpp" line="2235"/>
+        <location filename="../mainwindow.cpp" line="2373"/>
+        <location filename="../mainwindow.cpp" line="2502"/>
+        <location filename="../mainwindow.cpp" line="2503"/>
         <source>Start Recording</source>
         <translation>开始录制</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2107"/>
+        <location filename="../mainwindow.cpp" line="2374"/>
         <source>Start recording to WAV audio file</source>
         <translation>开始录制到wav文件</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2111"/>
+        <location filename="../mainwindow.cpp" line="2378"/>
         <source>Auto-Align Text</source>
         <translation>自动对齐</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2112"/>
+        <location filename="../mainwindow.cpp" line="2379"/>
         <source>Improve readability of code</source>
         <translation>提高代码可读性</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2118"/>
+        <location filename="../mainwindow.cpp" line="2385"/>
         <source>Increase Text Size</source>
         <translation>增大字体</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2125"/>
+        <location filename="../mainwindow.cpp" line="2392"/>
         <source>Decrease Text Size</source>
         <translation>减小字体</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2130"/>
+        <location filename="../mainwindow.cpp" line="2397"/>
         <source>Tools</source>
         <translation>工具</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2180"/>
+        <location filename="../mainwindow.cpp" line="2448"/>
         <source>About</source>
         <translation>关于</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2181"/>
+        <location filename="../mainwindow.cpp" line="2449"/>
         <source>Core Team</source>
         <translation>核心团队</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2182"/>
+        <location filename="../mainwindow.cpp" line="2450"/>
         <source>Contributors</source>
         <translation>项目参与者</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2183"/>
+        <location filename="../mainwindow.cpp" line="2451"/>
         <source>Community</source>
         <translation>社区</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2184"/>
+        <location filename="../mainwindow.cpp" line="2452"/>
         <source>License</source>
         <translation>License</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2185"/>
+        <location filename="../mainwindow.cpp" line="2453"/>
         <source>History</source>
         <translation>历史</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2206"/>
+        <location filename="../mainwindow.cpp" line="2474"/>
         <source>Sonic Pi - Info</source>
         <translation>Sonic Pi - 信息</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2226"/>
-        <location filename="../mainwindow.cpp" line="2227"/>
+        <location filename="../mainwindow.cpp" line="2494"/>
+        <location filename="../mainwindow.cpp" line="2495"/>
         <source>Stop Recording</source>
         <translation>停止录制</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2240"/>
+        <location filename="../mainwindow.cpp" line="2508"/>
         <source>Save Recording</source>
         <translation>保存录音</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2240"/>
+        <location filename="../mainwindow.cpp" line="2508"/>
         <source>Wavefile (*.wav)</source>
         <translation>波形文件 (*.wav)</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2259"/>
+        <location filename="../mainwindow.cpp" line="2527"/>
         <source>Ready...</source>
         <translation>就绪...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2337"/>
+        <location filename="../mainwindow.cpp" line="2608"/>
         <source>Cannot read file %1:
 %2.</source>
         <translation>无法读取文件 %1:
         %2.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2348"/>
+        <location filename="../mainwindow.cpp" line="2619"/>
         <source>File loaded...</source>
         <translation>文件已加载...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2357"/>
+        <location filename="../mainwindow.cpp" line="2628"/>
         <source>Cannot write file %1:
 %2.</source>
         <translation>无法写入文件 %1:
         %2.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2375"/>
+        <location filename="../mainwindow.cpp" line="2646"/>
         <source>File saved...</source>
         <translation>文件已保存...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2601"/>
+        <location filename="../mainwindow.cpp" line="2873"/>
         <source>Last checked %1</source>
         <translation>上次检查 %1</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2603"/>
+        <location filename="../mainwindow.cpp" line="2875"/>
         <source>Sonic Pi checks for updates
 every two weeks.</source>
         <translation>Sonic Pi每两周检查一次更新</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2605"/>
+        <location filename="../mainwindow.cpp" line="2877"/>
         <source>This is Sonic Pi %1</source>
         <translation>这是Sonic Pi %1</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2606"/>
+        <location filename="../mainwindow.cpp" line="2878"/>
         <source>Version %2 is now available!</source>
         <translation>新版本 %2 已经就绪，可供下载。</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2610"/>
+        <location filename="../mainwindow.cpp" line="2882"/>
         <source>New version available!
 Get Sonic Pi %1</source>
         <translation>发现新版本！
         获取Sonic Pi %1</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2636"/>
+        <location filename="../mainwindow.cpp" line="2908"/>
         <source>Welcome back. Now get your live code on...</source>
         <translation>欢迎回来。现在加载你的代码...</translation>
+    </message>
+    <message>
+        <location filename="../ruby_help.h" line="93"/>
+        <location filename="../ruby_help.h" line="154"/>
+        <location filename="../ruby_help.h" line="215"/>
+        <location filename="../ruby_help.h" line="274"/>
+        <location filename="../ruby_help.h" line="293"/>
+        <location filename="../ruby_help.h" line="367"/>
+        <location filename="../ruby_help.h" line="442"/>
+        <source>Tutorial</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ruby_help.h" line="476"/>
+        <source>Examples</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ruby_help.h" line="522"/>
+        <source>Synths</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ruby_help.h" line="564"/>
+        <source>Fx</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ruby_help.h" line="583"/>
+        <source>Samples</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ruby_help.h" line="779"/>
+        <source>Lang</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -775,7 +878,7 @@ Get Sonic Pi %1</source>
 <context>
     <name>SonicPiUDPOSCServer</name>
     <message>
-        <location filename="../sonic_pi_udp_osc_server.cpp" line="37"/>
+        <location filename="../sonic_pi_udp_osc_server.cpp" line="38"/>
         <source>Is Sonic Pi already running?  Can&apos;t open UDP port 4558.</source>
         <translation>无法打开UDP端口4558。请确定Sonic Pi是否已在运行。</translation>
     </message>

--- a/app/gui/qt/lang/sonic-pi_zh-Hant.ts
+++ b/app/gui/qt/lang/sonic-pi_zh-Hant.ts
@@ -4,108 +4,93 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../mainwindow.cpp" line="201"/>
-        <location filename="../mainwindow.cpp" line="2336"/>
-        <location filename="../mainwindow.cpp" line="2356"/>
+        <location filename="../mainwindow.cpp" line="184"/>
+        <location filename="../mainwindow.cpp" line="2607"/>
+        <location filename="../mainwindow.cpp" line="2627"/>
         <source>Sonic Pi</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="254"/>
+        <location filename="../mainwindow.cpp" line="235"/>
         <source>Welcome to Sonic Pi</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="296"/>
+        <location filename="../mainwindow.cpp" line="277"/>
         <source>Sonic Pi update info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="400"/>
+        <location filename="../mainwindow.cpp" line="387"/>
         <source>Buffer %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="464"/>
+        <location filename="../mainwindow.cpp" line="459"/>
         <source>Preferences</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="477"/>
+        <location filename="../mainwindow.cpp" line="472"/>
         <source>Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="518"/>
-        <location filename="../mainwindow.cpp" line="2097"/>
+        <location filename="../mainwindow.cpp" line="513"/>
+        <location filename="../mainwindow.cpp" line="2364"/>
         <source>Help</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="670"/>
+        <location filename="../mainwindow.cpp" line="708"/>
         <source>Indenting selection...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="674"/>
+        <location filename="../mainwindow.cpp" line="712"/>
         <source>Indenting line...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="703"/>
+        <location filename="../mainwindow.cpp" line="741"/>
         <source>Toggle selection comment...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="707"/>
+        <location filename="../mainwindow.cpp" line="745"/>
         <source>Toggle line comment...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="765"/>
-        <source>The Sonic Pi server could not be started!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../mainwindow.cpp" line="872"/>
+        <location filename="../mainwindow.cpp" line="911"/>
         <source>Raspberry Pi System Volume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="873"/>
+        <location filename="../mainwindow.cpp" line="912"/>
         <source>Use this slider to change the system volume of your Raspberry Pi.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="875"/>
+        <location filename="../mainwindow.cpp" line="914"/>
         <source>Advanced Audio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="876"/>
+        <location filename="../mainwindow.cpp" line="915"/>
         <source>Advanced audio settings for working with
 external PA systems when performing with Sonic Pi.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="877"/>
-        <source>Invert Stereo</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../mainwindow.cpp" line="878"/>
+        <location filename="../mainwindow.cpp" line="917"/>
         <source>Toggle stereo inversion.
 If enabled, audio sent to the left speaker will
 be routed to the right speaker and visa versa.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="880"/>
-        <source>Force Mono</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../mainwindow.cpp" line="881"/>
+        <location filename="../mainwindow.cpp" line="920"/>
         <source>Toggle mono mode.
 If enabled both right and left audio is mixed and
 the same signal is sent to both speakers.
@@ -114,24 +99,56 @@ can only handle mono.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="884"/>
+        <location filename="../mainwindow.cpp" line="972"/>
+        <source>Log auto scroll</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="973"/>
+        <source>Toggle log auto scrolling.
+If enabled the log is scrolled to the bottom after every new message is displayed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="976"/>
         <source>Safe mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="885"/>
+        <location filename="../mainwindow.cpp" line="977"/>
         <source>Toggle synth argument checking functions.
 If disabled, certain synth opt values may
 create unexpectedly loud or uncomfortable sounds.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="897"/>
+        <location filename="../mainwindow.cpp" line="933"/>
         <source>Raspberry Pi Audio Output</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="898"/>
+        <location filename="../mainwindow.cpp" line="452"/>
+        <location filename="../mainwindow.cpp" line="2360"/>
+        <source>Scope</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="803"/>
+        <source>The Sonic Pi Server could not be started!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="916"/>
+        <source>Invert stereo</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="919"/>
+        <source>Force mono</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="934"/>
         <source>Your Raspberry Pi has two forms of audio output.
 Firstly, there is the headphone jack of the Raspberry Pi itself.
 Secondly, some HDMI monitors/TVs support audio through the HDMI port.
@@ -139,621 +156,707 @@ Use these buttons to force the output to the one you want.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="899"/>
+        <location filename="../mainwindow.cpp" line="935"/>
         <source>&amp;Default</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="900"/>
+        <location filename="../mainwindow.cpp" line="936"/>
         <source>&amp;Headphones</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="901"/>
+        <location filename="../mainwindow.cpp" line="937"/>
         <source>&amp;HDMI</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="921"/>
+        <location filename="../mainwindow.cpp" line="957"/>
         <source>Logging</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="922"/>
+        <location filename="../mainwindow.cpp" line="958"/>
         <source>Configure debug behaviour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="924"/>
+        <location filename="../mainwindow.cpp" line="960"/>
+        <source>Synths and FX</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="961"/>
+        <source>Modify behaviour of synths and FX</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="963"/>
         <source>Log synths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="925"/>
+        <location filename="../mainwindow.cpp" line="964"/>
         <source>Toggle log messages.
 If disabled, activity such as synth and sample
 triggering will not be printed to the log by default.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="927"/>
+        <location filename="../mainwindow.cpp" line="966"/>
         <source>Clear log on run</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="928"/>
+        <location filename="../mainwindow.cpp" line="967"/>
         <source>Toggle log clearing on run.
 If enabled, the log is cleared each
 time the run button is pressed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="930"/>
+        <location filename="../mainwindow.cpp" line="969"/>
         <source>Log cues</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="931"/>
+        <location filename="../mainwindow.cpp" line="970"/>
         <source>Enable or disable logging of cues.
 If disabled, cues will still trigger.
 However, they will not be visible in the logs.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="933"/>
-        <source>Log Auto Scroll</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../mainwindow.cpp" line="934"/>
-        <source>Toggle log auto scrolling.
-If enabled the log is scrolled to the botton after every new message is displayed.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../mainwindow.cpp" line="944"/>
+        <location filename="../mainwindow.cpp" line="1001"/>
         <source>Transparency</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="955"/>
-        <location filename="../mainwindow.cpp" line="1087"/>
+        <location filename="../mainwindow.cpp" line="1012"/>
+        <location filename="../mainwindow.cpp" line="1144"/>
         <source>Updates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="957"/>
+        <location filename="../mainwindow.cpp" line="1014"/>
         <source>Check for updates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="959"/>
+        <location filename="../mainwindow.cpp" line="1016"/>
         <source>Toggle automatic update checking.
 This check involves sending anonymous information about your platform and version.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="960"/>
+        <location filename="../mainwindow.cpp" line="1017"/>
         <source>Check now</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="961"/>
+        <location filename="../mainwindow.cpp" line="1018"/>
         <source>Force a check for updates now.
 This check involves sending anonymous information about your platform and version.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="962"/>
+        <location filename="../mainwindow.cpp" line="1019"/>
         <source>Get update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="963"/>
+        <location filename="../mainwindow.cpp" line="1020"/>
         <source>Visit http://sonic-pi.net to download new version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="968"/>
+        <location filename="../mainwindow.cpp" line="1025"/>
         <source>Update Info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="987"/>
+        <location filename="../mainwindow.cpp" line="1044"/>
         <source>Show and Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="988"/>
+        <location filename="../mainwindow.cpp" line="1045"/>
         <source>Configure editor display options.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="989"/>
+        <location filename="../mainwindow.cpp" line="1046"/>
         <source>Look and Feel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="990"/>
+        <location filename="../mainwindow.cpp" line="1047"/>
         <source>Configure editor look and feel.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="991"/>
+        <location filename="../mainwindow.cpp" line="1048"/>
         <source>Automation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="992"/>
+        <location filename="../mainwindow.cpp" line="1049"/>
         <source>Configure automation features.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="993"/>
+        <location filename="../mainwindow.cpp" line="1050"/>
         <source>Auto-align</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="994"/>
+        <location filename="../mainwindow.cpp" line="1051"/>
         <source>Automatically align code on Run</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="996"/>
+        <location filename="../mainwindow.cpp" line="1053"/>
         <source>Show line numbers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="997"/>
+        <location filename="../mainwindow.cpp" line="1054"/>
         <source>Toggle line number visibility.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="998"/>
+        <location filename="../mainwindow.cpp" line="1055"/>
         <source>Show log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="999"/>
+        <location filename="../mainwindow.cpp" line="1056"/>
         <source>Toggle visibility of the log.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1001"/>
+        <location filename="../mainwindow.cpp" line="1058"/>
         <source>Show buttons</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1002"/>
+        <location filename="../mainwindow.cpp" line="1059"/>
         <source>Toggle visibility of the control buttons.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1004"/>
+        <location filename="../mainwindow.cpp" line="1061"/>
         <source>Show tabs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1006"/>
+        <location filename="../mainwindow.cpp" line="1063"/>
         <source>Toggle visibility of the buffer selection tabs.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1007"/>
+        <location filename="../mainwindow.cpp" line="1064"/>
         <source>Full screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1008"/>
+        <location filename="../mainwindow.cpp" line="1065"/>
         <source>Toggle full screen mode.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1009"/>
+        <location filename="../mainwindow.cpp" line="1066"/>
         <source>Dark mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1010"/>
+        <location filename="../mainwindow.cpp" line="1067"/>
         <source>Toggle dark mode.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1010"/>
+        <location filename="../mainwindow.cpp" line="1067"/>
         <source>
 Dark mode is perfect for live coding in night clubs.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1049"/>
+        <location filename="../mainwindow.cpp" line="1106"/>
         <source>Audio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1061"/>
+        <location filename="../mainwindow.cpp" line="1118"/>
         <source>Editor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1062"/>
+        <location filename="../mainwindow.cpp" line="1119"/>
         <source>Studio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1064"/>
-        <location filename="../mainwindow.cpp" line="1074"/>
+        <location filename="../mainwindow.cpp" line="1121"/>
+        <location filename="../mainwindow.cpp" line="1131"/>
         <source>Performance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1065"/>
+        <location filename="../mainwindow.cpp" line="1122"/>
         <source>Settings useful for performing with Sonic Pi</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1200"/>
+        <location filename="../mainwindow.cpp" line="1259"/>
         <source>Server boot error...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1200"/>
+        <location filename="../mainwindow.cpp" line="1259"/>
         <source>Sonic Pi Boot Error
 
 Apologies, a critical error occurred during startup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1200"/>
+        <location filename="../mainwindow.cpp" line="1259"/>
         <source>Please consider reporting a bug at</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1305"/>
-        <location filename="../mainwindow.cpp" line="1318"/>
-        <source>Buffer files(*.rb *.txt)</source>
+        <location filename="../mainwindow.cpp" line="980"/>
+        <source>Enable external synths and FX</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1306"/>
-        <source>Load Sonic-Pi Buffer</source>
+        <location filename="../mainwindow.cpp" line="981"/>
+        <source>When enabled, Sonic Pi will allow
+synths and FX loaded via load_synthdefs
+to be triggered.
+
+When disabled, Sonic Pi will complain
+when you attempt to use a synth or FX
+which isn&apos;t recognised.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1306"/>
-        <location filename="../mainwindow.cpp" line="1319"/>
-        <source>Buffer files(*.rb *.txt);;Text files (*.txt);;Ruby (*.rb);;All files (*.*)</source>
+        <location filename="../mainwindow.cpp" line="983"/>
+        <source>Enforce timing guarantees</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1319"/>
+        <location filename="../mainwindow.cpp" line="984"/>
+        <source>When enabled, Sonic Pi will refuse
+to trigger synths and FX if
+it is too late to do so
+
+When disabled, Sonic Pi will always
+attempt to trigger synths and FX
+even when a little late.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1361"/>
+        <location filename="../mainwindow.cpp" line="1362"/>
+        <location filename="../mainwindow.cpp" line="1374"/>
+        <location filename="../mainwindow.cpp" line="1375"/>
+        <source>Buffer files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1362"/>
+        <source>Load Sonic Pi Buffer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1362"/>
+        <location filename="../mainwindow.cpp" line="1375"/>
+        <source>Text files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1362"/>
+        <location filename="../mainwindow.cpp" line="1375"/>
+        <source>Ruby files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1362"/>
+        <location filename="../mainwindow.cpp" line="1375"/>
+        <source>All files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1375"/>
         <source>Save Current Buffer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1390"/>
+        <location filename="../mainwindow.cpp" line="1447"/>
         <source>Running Code...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1432"/>
+        <location filename="../mainwindow.cpp" line="1496"/>
         <source>Zooming In...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1439"/>
+        <location filename="../mainwindow.cpp" line="1503"/>
         <source>Zooming Out...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1446"/>
+        <location filename="../mainwindow.cpp" line="1510"/>
         <source>Beautifying...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1466"/>
+        <location filename="../mainwindow.cpp" line="1530"/>
         <source>Reloading...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1473"/>
+        <location filename="../mainwindow.cpp" line="1537"/>
         <source>Checking for updates...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1481"/>
+        <location filename="../mainwindow.cpp" line="1545"/>
         <source>Enabling update checking...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1489"/>
+        <location filename="../mainwindow.cpp" line="1553"/>
         <source>Disabling update checking...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1497"/>
+        <location filename="../mainwindow.cpp" line="1561"/>
         <source>Enabling Mixer HPF...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1506"/>
+        <location filename="../mainwindow.cpp" line="1570"/>
         <source>Disabling Mixer HPF...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1514"/>
+        <location filename="../mainwindow.cpp" line="1578"/>
         <source>Enabling Mixer LPF...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1523"/>
+        <location filename="../mainwindow.cpp" line="1587"/>
         <source>Disabling Mixer LPF...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1531"/>
+        <location filename="../mainwindow.cpp" line="1595"/>
         <source>Enabling Inverted Stereo...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1539"/>
+        <location filename="../mainwindow.cpp" line="1603"/>
         <source>Enabling Standard Stereo...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1547"/>
+        <location filename="../mainwindow.cpp" line="1611"/>
         <source>Mono Mode...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1555"/>
+        <location filename="../mainwindow.cpp" line="1619"/>
         <source>Stereo Mode...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1564"/>
+        <location filename="../mainwindow.cpp" line="1628"/>
         <source>Stopping...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1660"/>
+        <location filename="../mainwindow.cpp" line="1736"/>
         <source>Updating System Volume...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1676"/>
+        <location filename="../mainwindow.cpp" line="1752"/>
         <source>Log Auto Scroll on...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1678"/>
+        <location filename="../mainwindow.cpp" line="1754"/>
         <source>Log Auto Scroll off...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1892"/>
+        <location filename="../mainwindow.cpp" line="2155"/>
         <source>Switching To Headphone Audio Output...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1908"/>
+        <location filename="../mainwindow.cpp" line="2171"/>
         <source>Switching To HDMI Audio Output...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1923"/>
+        <location filename="../mainwindow.cpp" line="2186"/>
         <source>Switching To Default Audio Output...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2074"/>
+        <location filename="../mainwindow.cpp" line="2337"/>
         <source>Run</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2075"/>
+        <location filename="../mainwindow.cpp" line="2338"/>
         <source>Run the code in the current buffer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2080"/>
+        <location filename="../mainwindow.cpp" line="2343"/>
         <source>Stop</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2081"/>
+        <location filename="../mainwindow.cpp" line="2344"/>
         <source>Stop all running code</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2084"/>
+        <location filename="../mainwindow.cpp" line="2347"/>
         <source>Save As...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2085"/>
+        <location filename="../mainwindow.cpp" line="2348"/>
         <source>Save current buffer as an external file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2088"/>
+        <location filename="../mainwindow.cpp" line="2351"/>
         <source>Load</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2089"/>
+        <location filename="../mainwindow.cpp" line="2352"/>
         <source>Load an external file in the current buffer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2092"/>
+        <location filename="../mainwindow.cpp" line="2355"/>
         <source>Info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2093"/>
+        <location filename="../mainwindow.cpp" line="2356"/>
         <source>See information about Sonic Pi</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2098"/>
+        <location filename="../mainwindow.cpp" line="2361"/>
+        <source>View audio output</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2365"/>
         <source>Toggle help pane</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2101"/>
+        <location filename="../mainwindow.cpp" line="2368"/>
         <source>Prefs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2102"/>
+        <location filename="../mainwindow.cpp" line="2369"/>
         <source>Toggle preferences pane</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2106"/>
-        <location filename="../mainwindow.cpp" line="2234"/>
-        <location filename="../mainwindow.cpp" line="2235"/>
+        <location filename="../mainwindow.cpp" line="2373"/>
+        <location filename="../mainwindow.cpp" line="2502"/>
+        <location filename="../mainwindow.cpp" line="2503"/>
         <source>Start Recording</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2107"/>
+        <location filename="../mainwindow.cpp" line="2374"/>
         <source>Start recording to WAV audio file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2111"/>
+        <location filename="../mainwindow.cpp" line="2378"/>
         <source>Auto-Align Text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2112"/>
+        <location filename="../mainwindow.cpp" line="2379"/>
         <source>Improve readability of code</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2118"/>
+        <location filename="../mainwindow.cpp" line="2385"/>
         <source>Increase Text Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2125"/>
+        <location filename="../mainwindow.cpp" line="2392"/>
         <source>Decrease Text Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2130"/>
+        <location filename="../mainwindow.cpp" line="2397"/>
         <source>Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2180"/>
+        <location filename="../mainwindow.cpp" line="2448"/>
         <source>About</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2181"/>
+        <location filename="../mainwindow.cpp" line="2449"/>
         <source>Core Team</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2182"/>
+        <location filename="../mainwindow.cpp" line="2450"/>
         <source>Contributors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2183"/>
+        <location filename="../mainwindow.cpp" line="2451"/>
         <source>Community</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2184"/>
+        <location filename="../mainwindow.cpp" line="2452"/>
         <source>License</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2185"/>
+        <location filename="../mainwindow.cpp" line="2453"/>
         <source>History</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2206"/>
+        <location filename="../mainwindow.cpp" line="2474"/>
         <source>Sonic Pi - Info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2226"/>
-        <location filename="../mainwindow.cpp" line="2227"/>
+        <location filename="../mainwindow.cpp" line="2494"/>
+        <location filename="../mainwindow.cpp" line="2495"/>
         <source>Stop Recording</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2240"/>
+        <location filename="../mainwindow.cpp" line="2508"/>
         <source>Save Recording</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2240"/>
+        <location filename="../mainwindow.cpp" line="2508"/>
         <source>Wavefile (*.wav)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2259"/>
+        <location filename="../mainwindow.cpp" line="2527"/>
         <source>Ready...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2337"/>
+        <location filename="../mainwindow.cpp" line="2608"/>
         <source>Cannot read file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2348"/>
+        <location filename="../mainwindow.cpp" line="2619"/>
         <source>File loaded...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2357"/>
+        <location filename="../mainwindow.cpp" line="2628"/>
         <source>Cannot write file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2375"/>
+        <location filename="../mainwindow.cpp" line="2646"/>
         <source>File saved...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2601"/>
+        <location filename="../mainwindow.cpp" line="2873"/>
         <source>Last checked %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2603"/>
+        <location filename="../mainwindow.cpp" line="2875"/>
         <source>Sonic Pi checks for updates
 every two weeks.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2605"/>
+        <location filename="../mainwindow.cpp" line="2877"/>
         <source>This is Sonic Pi %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2606"/>
+        <location filename="../mainwindow.cpp" line="2878"/>
         <source>Version %2 is now available!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2610"/>
+        <location filename="../mainwindow.cpp" line="2882"/>
         <source>New version available!
 Get Sonic Pi %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2636"/>
+        <location filename="../mainwindow.cpp" line="2908"/>
         <source>Welcome back. Now get your live code on...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ruby_help.h" line="93"/>
+        <location filename="../ruby_help.h" line="154"/>
+        <location filename="../ruby_help.h" line="215"/>
+        <location filename="../ruby_help.h" line="274"/>
+        <location filename="../ruby_help.h" line="293"/>
+        <location filename="../ruby_help.h" line="367"/>
+        <location filename="../ruby_help.h" line="442"/>
+        <source>Tutorial</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ruby_help.h" line="476"/>
+        <source>Examples</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ruby_help.h" line="522"/>
+        <source>Synths</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ruby_help.h" line="564"/>
+        <source>Fx</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ruby_help.h" line="583"/>
+        <source>Samples</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ruby_help.h" line="779"/>
+        <source>Lang</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -768,7 +871,7 @@ Get Sonic Pi %1</source>
 <context>
     <name>SonicPiUDPOSCServer</name>
     <message>
-        <location filename="../sonic_pi_udp_osc_server.cpp" line="37"/>
+        <location filename="../sonic_pi_udp_osc_server.cpp" line="38"/>
         <source>Is Sonic Pi already running?  Can&apos;t open UDP port 4558.</source>
         <translation type="unfinished"></translation>
     </message>


### PR DESCRIPTION
Hi @samaaron,

this makes Weblate the translation editor for the Qt GUI.

Before merging this pull request, please follow the three steps described in "Setup" in `TRANSLATION-WORKFLOW.md`.

After that one-time setup, weblate will sync from the master repo here, I can make you the owner of the Weblate Project on hosted.weblate.org and I can then ask @nijel to activate the weblate sync to push translations back to the master repo here.

I know that you would have preferred a solution with pull requests instead of direct commits, but @nijel told me that automated PRs were less reliable. Since the commits from the @weblate user only go to the translation files (which from now on should not be touched by anyone except you during the Qt linguist file update), I see no danger of a merge conflict in that workflow.

That workflow document is also meant as a cheatsheet for you.

The only manual step you need to do after this is update the Qt linguist files every now and then as described in the workflow document.

But what is "every now and then"? Whenever you think the translators should be notified of new strings to translate, e.g.
- when a new major feature was added to the Qt codebase
- when you fixed a spelling mistake in the English strings
- when a new release of Sonic Pi is coming soon

Again, this is the Qt GUI only. For the tutorial, there will later be a similar, slightly more complicated `po4a` call to update the translation files in the workflow. I'm still working on that.

Thanks @petterreinholdtsen and @nijel!