### PR TITLE
Remove incongruous performance widget label

### DIFF
--- a/app/gui/qt/mainwindow.cpp
+++ b/app/gui/qt/mainwindow.cpp
@@ -1119,7 +1119,7 @@ void MainWindow::initPrefsWindow() {
   prefTabs->addTab(editor_box, tr("Editor"));
   prefTabs->addTab(studio_prefs_box, tr("Studio"));
 
-  QGroupBox *performance_box = new QGroupBox(tr("Performance"));
+  QGroupBox *performance_box = new QGroupBox();
   performance_box->setToolTip(tr("Settings useful for performing with Sonic Pi"));
 
 


### PR DESCRIPTION
The performance preferences pane on OS X was the only one that had a top level widget label in its top left corner. To be consistent with the other preference panes, it is being removed.