### PR TITLE
Fix for scope vertical size fix, docking change, corrected memory leak

### DIFF
--- a/app/gui/qt/mainwindow.cpp
+++ b/app/gui/qt/mainwindow.cpp
@@ -451,7 +451,7 @@ void MainWindow::setupWindowStructure() {
 
   scopeWidget = new QDockWidget(tr("Scope"),this);
   scopeWidget->setFocusPolicy(Qt::NoFocus);
-  scopeWidget->setAllowedAreas(Qt::RightDockWidgetArea | Qt::BottomDockWidgetArea | Qt::LeftDockWidgetArea | Qt::TopDockWidgetArea);
+  scopeWidget->setAllowedAreas(Qt::RightDockWidgetArea | Qt::BottomDockWidgetArea | Qt::TopDockWidgetArea);
   scopeWidget->setFeatures(QDockWidget::DockWidgetClosable | QDockWidget::DockWidgetMovable | QDockWidget::DockWidgetFloatable);
   scopeWidget->setWidget(new Scope);
   scopeWidget->setObjectName("scope");

--- a/app/gui/qt/scope.cpp
+++ b/app/gui/qt/scope.cpp
@@ -32,7 +32,7 @@ ScopePanel::ScopePanel( const std::string& name, QWidget* parent ) : QWidget(par
   plot_curve.setRawSamples( sample_x, sample_y, 4096 );
   plot_curve.setItemAttribute( QwtPlotItem::AutoScale );
   plot_curve.attach(&plot);
-  plot_curve.setPen(* new QPen(QColor("deeppink"), 2));
+  plot_curve.setPen(QPen(QColor("deeppink"), 2));
 #if QWT_VERSION >= 0x60100
   plot_curve.setPaintAttribute( QwtPlotCurve::PaintAttribute::FilterPoints );
 #endif
@@ -40,6 +40,9 @@ ScopePanel::ScopePanel( const std::string& name, QWidget* parent ) : QWidget(par
   plot.setAxisScale(QwtPlot::Axis::yLeft,-1,1);
   plot.setAxisScale(QwtPlot::Axis::xBottom,0,4096);
   plot.enableAxis(QwtPlot::Axis::xBottom, false);
+
+  QSizePolicy sp(QSizePolicy::MinimumExpanding,QSizePolicy::Expanding);
+  plot.setSizePolicy(sp);
 
   QVBoxLayout* layout = new QVBoxLayout();
   layout->addWidget(&plot);

--- a/app/gui/qt/scope.cpp
+++ b/app/gui/qt/scope.cpp
@@ -46,6 +46,8 @@ ScopePanel::ScopePanel( const std::string& name, QWidget* parent ) : QWidget(par
 
   QVBoxLayout* layout = new QVBoxLayout();
   layout->addWidget(&plot);
+  layout->setContentsMargins(0,0,0,0);
+  layout->setSpacing(0);
   setLayout(layout);
 }
 
@@ -103,6 +105,8 @@ Scope::Scope( QWidget* parent ) : QWidget(parent), left("Left",this), right("Rig
   scopeTimer->start(1);
 
   QVBoxLayout* layout = new QVBoxLayout();
+  layout->setSpacing(0);
+  layout->setContentsMargins(0,0,0,0);
   layout->addWidget(&left);
   layout->addWidget(&right);
   setLayout(layout);


### PR DESCRIPTION
* This seems to get the scope sizing to be better behaved on OSX, not tested yet on other platforms.
* Scope plotter setPen changed to not use a heap allocation, which was probably a memory leak.
* Removed "left side" docking for scope window to conform to desire that code window always be left most.