### PR TITLE
Improved i18n documentation.

### DIFF
--- a/TRANSLATION-WORKFLOW.md
+++ b/TRANSLATION-WORKFLOW.md
@@ -74,24 +74,24 @@ complete the translation.
 
 To initiate a translation update:
 
-- [Lock the Sonic Pi project](https://hosted.weblate.org/projects/sonic-pi/#repository)
-  on Weblate (this will also commit and merge all oustanding 
-  translation updates from Weblate to Github).
+1. [Lock the Sonic Pi project](https://hosted.weblate.org/projects/sonic-pi/#repository)
+   on Weblate (this will also commit and merge all oustanding 
+   translation updates from Weblate to Github).
 
-- Update your local repo to the current HEAD of the master branch from 
-  Github, update the Qt linguist files using `lupdate`, commit the 
-  update and push it back to the master branch.
+2. Update your local repo to the current HEAD of the master branch from 
+   Github, update the Qt linguist files using `lupdate`, commit the 
+   update and push it back to the master branch.
   
-  ```
-    git pull
-    cd app/gui/qt
-    lupdate -pro SonicPi.pro -no-obsolete
-    git commit lang/sonic-pi_*.ts
-    git push
-  ```
+   ```
+     git pull
+     cd app/gui/qt
+     lupdate -pro SonicPi.pro -no-obsolete
+     git commit lang/sonic-pi_*.ts
+     git push
+   ```
 
-- [Unlock the Sonic Pi project](https://hosted.weblate.org/projects/sonic-pi/#repository)
-  on Weblate.
+3. [Unlock the Sonic Pi project](https://hosted.weblate.org/projects/sonic-pi/#repository)
+   on Weblate.
 
 This will update all Qt linguist files in 
 `app/gui/qt/lang/sonic-pi_<LANG>.ts` with the new message strings from 

--- a/TRANSLATION-WORKFLOW.md
+++ b/TRANSLATION-WORKFLOW.md
@@ -6,20 +6,41 @@
 you're a translator who wants to help bring Sonic Pi to your language 
 please read the [Translation Guide Workflow](TRANSLATION.md).)
 
-[Weblate](https://weblate.org) is open-source web-based translation 
+## Making your code translatable
+
+Translations for the Qt GUI are located in the Qt Linguist `.ts` files 
+in [`app/gui/qt/lang/sonic-pi_<LANG>.ts`](./app/gui/qt/lang/). Do not 
+edit these, that's what we use Weblate for.
+
+The translatable message strings are marked in your C++ code using the 
+[`tr()`](https://wiki.qt.io/QtInternationalization#What_is_tr.28.29.3F) 
+macro.
+
+There is an extensive [I18N 
+Tutorial](http://doc.qt.io/qt-5/internationalization.html) for Qt, but 
+the condensed version is: _When you mark a message string with `tr()`, 
+it can be translated._
+
+## Integrating Weblate
+
+The rest of this document is mostly meant as a cheatsheet for @samaaron 
+as the main developer in charge of the master repository.
+
+[Weblate](https://weblate.org) is an open-source web-based translation 
 editor. Their development team runs a hosted version of the tool and 
 they have kindly offered us to use the service for free. (Thanks!)
 
 The Weblate server keeps a copy of Sonic Pi's upstream git repository. 
 Translators commit to the cloned repository on the Weblate server.
 
-Sonic Pi's upstream git repository is tracked by Weblate, it will 
-pull changes from and push updates to us.
+Sonic Pi's upstream git repository [is tracked by 
+Weblate](http://weblate.readthedocs.io/en/latest/admin/continuous.html), 
+it will pull changes from and push updates to us.
 
 ## Setup
 
 This is a one-time setup for the master repository and needs to be done 
-by @samaaron.
+by the main developer.
 
 - [Sign up](https://hosted.weblate.org/accounts/register/),
   preferably using your Github account authorization.
@@ -27,47 +48,55 @@ by @samaaron.
 - To enable Weblate pulling updates from the master repository, add the
   [Weblate service](https://docs.weblate.org/en/latest/admin/continuous.html#github-setup)
   in the repository settings and use the URL
-  `https://hosted.weblate.org` in the Weblate service settings.
+  `https://hosted.weblate.org` for the Weblate service settings.
 
 - To enable Weblate pushing translation updates back to the master 
-  repository, add the [Weblate push user](@weblate) to the 
-  collaborators  in the master branch's repository settings.
+  repository, add the [Weblate push user](https://github.com/weblate) 
+  to the collaborators in the master branch's repository settings.
 
 After this, translations will be synced automatically between Github 
-and Weblate.
+and Weblate, using the [lazy 
+commit](http://weblate.readthedocs.io/en/latest/admin/continuous.html#lazy-commits) 
+strategy.
 
 ## Workflow
 
-Translations for the Qt GUI are located in 
-[`app/gui/qt/lang/sonic-pi_<LANG>.ts`](./app/gui/qt/lang/). Do not edit 
-these, that's what we use Weblate for.
-
-The translatable message strings are marked in your C++ code using the 
-[`tr()`](https://wiki.qt.io/QtInternationalization#What_is_tr.28.29.3F) 
-macro. There is an extensive [I18N 
-Tutorial](http://doc.qt.io/qt-5/internationalization.html) for Qt, but 
-the condensed version is: When you mark a message string with `tr()`, 
-it can be translated.
+The Qt Linguist `.ts` files are created and updated from the source 
+code, using the Qt `lupdate` tool.
 
 Whenever message strings are changed or a major feature introduces new 
 ones, you need to update the `.ts` files.
 
-To initiate a translation update, update your repo to the current HEAD 
-of the master branch, update the Qt linguist files using `lupdate`, 
-commit the update and push it back to the master branch.
+Don't update too often, as we don't want to annoy the volunteer 
+translators with many small work chunks. Remember to do an extra update 
+some time before a major release, to give everybody a chance to 
+complete the translation.
 
-```
-  git pull
-  cd app/gui/qt
-  lupdate -pro SonicPi.pro -no-obsolete
-  git commit lang/sonic-pi_*.ts
-  git push
-```
+To initiate a translation update:
+
+- [Lock the Sonic Pi project](https://hosted.weblate.org/projects/sonic-pi/#repository)
+  on Weblate (this will also commit and merge all oustanding 
+  translation updates from Weblate to Github).
+
+- Update your local repo to the current HEAD of the master branch from 
+  Github, update the Qt linguist files using `lupdate`, commit the 
+  update and push it back to the master branch.
+  
+  ```
+    git pull
+    cd app/gui/qt
+    lupdate -pro SonicPi.pro -no-obsolete
+    git commit lang/sonic-pi_*.ts
+    git push
+  ```
+
+- [Unlock the Sonic Pi project](https://hosted.weblate.org/projects/sonic-pi/#repository)
+  on Weblate.
 
 This will update all Qt linguist files in 
 `app/gui/qt/lang/sonic-pi_<LANG>.ts` with the new message strings from 
 your code and remove obsolete entries.
 
-Weblate will then fetch them automatically, translators will update 
-them and the finished translations will flow back into the master 
-repository.
+Weblate will then fetch the changes automatically, translators can 
+update them and the finished translations will flow back into the 
+master repository.

--- a/TRANSLATION.md
+++ b/TRANSLATION.md
@@ -3,16 +3,15 @@
 [![Weblate](https://hosted.weblate.org/widgets/sonic-pi/-/svg-badge.svg)](https://hosted.weblate.org/engage/sonic-pi/)
 
 (This document is meant for translators who want to help bring Sonic Pi 
-to their language. If you're contributing code to Sonic Pi and want to 
-make sure that your feature is translatable and the translation always 
-up-to-date, please read the primer to the [Translation 
-Workflow](TRANSLATION-WORKFLOW.md) for coders.)
+to their language. If you're contributing code to Sonic Pi, please read 
+the primer to the [Translation Workflow](TRANSLATION-WORKFLOW.md) to 
+learn about the inner workings of i18n in your code.)
 
 Sonic Pi is designed to be used by school kids as early as primary 
 school. We want to make sure that it's usable outside the 
-English-speaking world and if you want to help kids in your country to 
-be able to play with it, please consider translating Sonic Pi to your 
-language.
+English-speaking world and if you want to help kids in your community 
+to be able to play with it, please consider translating Sonic Pi to 
+your language.
 
 A number of awesome contributors have already translated much of Sonic 
 Pi to their language. We always appreciate help by those willing to 
@@ -26,21 +25,20 @@ these changes, _we are currently moving to
 *[Weblate](https://hosted.weblate.org/engage/sonic-pi/)*_, an 
 open-source web-based translation editor.
 
-The nice thing about Weblate is that from now on, you don't need to be 
-a developer to help translate Sonic Pi (and you don't need to know 
-anything about github or the other tools we use during development).
+The nice thing about Weblate is that you don't need to be a developer 
+to help translate Sonic Pi.
 
 ## What you can translate
 
-The Sonic Pi Qt GUI is the application you use on your desktop screen.
-It contains few screen strings and translating it is fairly easy.
+* The *Sonic Pi Qt GUI* is the application you use on your desktop
+  screen. It contains few message strings and translating it is fairly 
+  easy.
 
-The tutorial is a fairly long document. Translating it takes 
-significantly longer, but it's very rewarding as it is the best way to 
-introduce new users to Sonic Pi.
+* The *Tutorial* is a fairly long document. Translating it requires
+  significantly more effort, but it's very rewarding as it is a 
+  step-by-step introduction for new users to Sonic Pi.
 
-It is planned to make the language reference translatable in the 
-future, too.
+* (The *Reference* cannot be translated - yet. We're working on that.)
 
 ## How to fix or contribute a translation
 
@@ -48,7 +46,7 @@ So if you want to...
 
 - proofread an existing translation
 - correct a mistake in a translation
-- translate Sonic Pi to a whole new language
+- translate to a whole new language
 
 ...all you need to do is visit [Sonic Pi on 
 Weblate](https://hosted.weblate.org/engage/sonic-pi/), sign up and 
@@ -59,10 +57,19 @@ You can already translate the Qt GUI there, but the tutorial will
 follow soon.
 
 Weblate gives you a number of helpful tools, e.g. it spots common 
-mistakes, you can keep a glossary of recurring terms and be notified 
-when a new string needs to be translated.
+mistakes and you can keep a glossary of recurring terms that you can 
+share with other translators.
 
-By the way, if you spot a spelling mistake in the English texts, please 
-[file an issue](https://github.com/samaaron/sonic-pi/issues) or correct 
-it with a pull request here on github, as you cannot change those via 
-Weblate.
+We can't thank you enough for putting up with the inconvenience of 
+translating Sonic Pi, but allow me to ask you for one more giant 
+favour: If you want to help keep the translation up-to-date in the 
+future, please consider [subscribing to the Sonic Pi project on 
+Weblate](https://hosted.weblate.org/accounts/profile/#subscriptions) so 
+that you will be informed of new or changed strings.
+
+## How to fix the original English texts
+
+You cannot change the original English strings with Weblate. If you 
+spot a mistake in the English texts, please [file an 
+issue](https://github.com/samaaron/sonic-pi/issues) or correct it with 
+a pull request here on github. Thanks!


### PR DESCRIPTION
This updates and improves the i18n documentation. Feel free to rewrite it as necessary.

Hey @samaaron, after this merge, please do the three steps (Lock, Update, Unlock) as described in the workflow cheatsheet. The temporary Lock/Unlock in Weblate around the Update step is necessary to avoid merge conflicts.

After that, the Russian translation should also be ready with the new strings like the others.

In the future, you'll need to the these three steps whenever you want to notify the translators of new/changed strings.

