### PR TITLE
Scope pr

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,6 +77,7 @@ app/server/native/
 app/server/vendor/ffi/ext/
 app/server/vendor/ffi-1.9.10/ext/ffi_c/Makefile
 app/server/vendor/ffi-1.9.10/ext/ffi_c/extconf.h
+app/server/vendor/*/ext
 
 app/server/rb-native/
 

--- a/app/gui/qt/mainwindow.cpp
+++ b/app/gui/qt/mainwindow.cpp
@@ -1122,19 +1122,19 @@ void MainWindow::initPrefsWindow() {
 
   QGroupBox *scope_box = new QGroupBox();
   QGridLayout* scope_box_layout = new QGridLayout();
-  QCheckBox *show_left = new QCheckBox(tr("Left Channel"));
-  show_left->setChecked(true);
-  QCheckBox *show_right = new QCheckBox(tr("Right Channel"));
-  show_right->setChecked(true);
-  QCheckBox *show_axes = new QCheckBox(tr("Show Axes"));
-  show_axes->setChecked(true);
-  scope_box_layout->addWidget(show_left);
-  scope_box_layout->addWidget(show_right);
-  scope_box_layout->addWidget(show_axes);
+  show_left_scope = new QCheckBox(tr("Left Channel"));
+  show_left_scope->setChecked(true);
+  show_right_scope = new QCheckBox(tr("Right Channel"));
+  show_right_scope->setChecked(true);
+  show_scope_axes = new QCheckBox(tr("Show Axes"));
+  show_scope_axes->setChecked(true);
+  scope_box_layout->addWidget(show_left_scope);
+  scope_box_layout->addWidget(show_right_scope);
+  scope_box_layout->addWidget(show_scope_axes);
   scope_box->setLayout(scope_box_layout);
-  connect(show_left, SIGNAL(clicked()), this, SLOT(toggleLeftScope()));
-  connect(show_right, SIGNAL(clicked()), this, SLOT(toggleRightScope()));
-  connect(show_axes, SIGNAL(clicked()), this, SLOT(toggleScopeAxes()));
+  connect(show_left_scope, SIGNAL(clicked()), this, SLOT(toggleLeftScope()));
+  connect(show_right_scope, SIGNAL(clicked()), this, SLOT(toggleRightScope()));
+  connect(show_scope_axes, SIGNAL(clicked()), this, SLOT(toggleScopeAxes()));
   prefTabs->addTab(scope_box, tr("Scope"));
 
 
@@ -1207,6 +1207,10 @@ void MainWindow::initPrefsWindow() {
 
   int stored_vol = settings.value("prefs/rp/system-vol", 50).toInt();
   rp_system_vol->setValue(stored_vol);
+
+  show_left_scope->setChecked( scopeInterface->setLeftScope( settings.value("prefs/scope/show-left", true).toBool() ) );
+  show_right_scope->setChecked( scopeInterface->setRightScope( settings.value("prefs/scope/show-right", true).toBool() ) );
+  show_scope_axes->setChecked( scopeInterface->setScopeAxes( settings.value("prefs/scope/show-axes", true).toBool() ) );
 
   // Ensure prefs are honoured on boot
   update_mixer_invert_stereo();
@@ -1758,17 +1762,17 @@ void MainWindow::changeRPSystemVol(int)
 
 void MainWindow::toggleLeftScope() 
 {
-  scopeInterface->toggleLeftScope();
+  scopeInterface->setLeftScope(show_left_scope->isChecked());
 }
 
 void MainWindow::toggleRightScope()
 {
-  scopeInterface->toggleRightScope();
+  scopeInterface->setRightScope(show_right_scope->isChecked());
 }
 
 void MainWindow::toggleScopeAxes()
 {
-  scopeInterface->toggleScopeAxes();
+  scopeInterface->setScopeAxes(show_scope_axes->isChecked());
 }
 
 void MainWindow::toggleDarkMode() {
@@ -2628,6 +2632,10 @@ void MainWindow::writeSettings()
   settings.setValue("docsplitState", docsplit->saveState());
   settings.setValue("windowState", saveState());
   settings.setValue("windowGeom", saveGeometry());
+
+  settings.setValue("prefs/scope/show-left", show_left_scope->isChecked() );
+  settings.setValue("prefs/scope/show-right", show_right_scope->isChecked() );
+  settings.setValue("prefs/scope/show-axes", show_scope_axes->isChecked() );
 }
 
 void MainWindow::loadFile(const QString &fileName, SonicPiScintilla* &text)

--- a/app/gui/qt/mainwindow.cpp
+++ b/app/gui/qt/mainwindow.cpp
@@ -453,7 +453,8 @@ void MainWindow::setupWindowStructure() {
   scopeWidget->setFocusPolicy(Qt::NoFocus);
   scopeWidget->setAllowedAreas(Qt::RightDockWidgetArea | Qt::BottomDockWidgetArea | Qt::TopDockWidgetArea);
   scopeWidget->setFeatures(QDockWidget::DockWidgetClosable | QDockWidget::DockWidgetMovable | QDockWidget::DockWidgetFloatable);
-  scopeWidget->setWidget(new Scope);
+  scopeInterface = new Scope();
+  scopeWidget->setWidget(scopeInterface);
   scopeWidget->setObjectName("scope");
   addDockWidget(Qt::RightDockWidgetArea, scopeWidget);
 
@@ -1007,9 +1008,6 @@ void MainWindow::initPrefsWindow() {
   transparency_box->setLayout(transparency_box_layout);
 
 
-
-
-
   QGroupBox *update_box = new QGroupBox(tr("Updates"));
   QSizePolicy updatesPrefSizePolicy(QSizePolicy::Minimum, QSizePolicy::Fixed);
   check_updates = new QCheckBox(tr("Check for updates"));
@@ -1121,6 +1119,23 @@ void MainWindow::initPrefsWindow() {
 
   QGroupBox *performance_box = new QGroupBox();
   performance_box->setToolTip(tr("Settings useful for performing with Sonic Pi"));
+
+  QGroupBox *scope_box = new QGroupBox();
+  QGridLayout* scope_box_layout = new QGridLayout();
+  QCheckBox *show_left = new QCheckBox(tr("Left Channel"));
+  show_left->setChecked(true);
+  QCheckBox *show_right = new QCheckBox(tr("Right Channel"));
+  show_right->setChecked(true);
+  QCheckBox *show_axes = new QCheckBox(tr("Show Axes"));
+  show_axes->setChecked(true);
+  scope_box_layout->addWidget(show_left);
+  scope_box_layout->addWidget(show_right);
+  scope_box_layout->addWidget(show_axes);
+  scope_box->setLayout(scope_box_layout);
+  connect(show_left, SIGNAL(clicked()), this, SLOT(toggleLeftScope()));
+  connect(show_right, SIGNAL(clicked()), this, SLOT(toggleRightScope()));
+  connect(show_axes, SIGNAL(clicked()), this, SLOT(toggleScopeAxes()));
+  prefTabs->addTab(scope_box, tr("Scope"));
 
 
 #if defined(Q_OS_WIN)
@@ -1739,6 +1754,21 @@ void MainWindow::changeRPSystemVol(int)
   p->start(prog);
 #endif
 
+}
+
+void MainWindow::toggleLeftScope() 
+{
+  scopeInterface->toggleLeftScope();
+}
+
+void MainWindow::toggleRightScope()
+{
+  scopeInterface->toggleRightScope();
+}
+
+void MainWindow::toggleScopeAxes()
+{
+  scopeInterface->toggleScopeAxes();
 }
 
 void MainWindow::toggleDarkMode() {

--- a/app/gui/qt/mainwindow.h
+++ b/app/gui/qt/mainwindow.h
@@ -292,6 +292,9 @@ private:
     QCheckBox *show_buttons;
     QCheckBox *show_tabs;
     QCheckBox *check_updates;
+    QCheckBox *show_left_scope;
+    QCheckBox *show_right_scope;
+    QCheckBox *show_scope_axes;
     QPushButton *check_updates_now;
     QPushButton *visit_sonic_pi_net;
     QLabel *update_info;

--- a/app/gui/qt/mainwindow.h
+++ b/app/gui/qt/mainwindow.h
@@ -138,6 +138,9 @@ private slots:
     void setRPSystemAudioHeadphones();
     void setRPSystemAudioHDMI();
     void changeShowLineNumbers();
+    void toggleLeftScope();
+    void toggleRightScope();
+    void toggleScopeAxes();
     void toggleDarkMode();
     void updateDarkMode();
     void showPrefsPane();
@@ -321,7 +324,7 @@ private:
     QSplitter *docsplit;
 
     QLabel *versionLabel;
-
+    Scope* scopeInterface;
     QString guiID;
     bool homeDirWritable;
 };

--- a/app/gui/qt/scope.cpp
+++ b/app/gui/qt/scope.cpp
@@ -116,7 +116,7 @@ Scope::Scope( QWidget* parent ) : QWidget(parent), left("Left",this), right("Rig
   right.setChannel(1);
   QTimer *scopeTimer = new QTimer(this);
   connect(scopeTimer, SIGNAL(timeout()), this, SLOT(refreshScope()));
-  scopeTimer->start(1);
+  scopeTimer->start(4096*1000/44100); // sample size (4096)*1000 ms/s / Sample Rate (Hz)
 
   QVBoxLayout* layout = new QVBoxLayout();
   layout->setSpacing(0);

--- a/app/gui/qt/scope.cpp
+++ b/app/gui/qt/scope.cpp
@@ -20,9 +20,10 @@
 #include <QTimer>
 #include <QPainter>
 #include <QDebug>
+#include <qwt_text_label.h>
 #include <cmath>
 
-ScopePanel::ScopePanel( const std::string& name, QWidget* parent ) : QWidget(parent), plot(QwtText(name.c_str()),this), max_y(0), counter(0), channel(0)
+ScopePanel::ScopePanel( const std::string& name, QWidget* parent ) : QWidget(parent), name(name), plot(QwtText(name.c_str()),this), max_y(0), counter(0), channel(0)
 {
   for( unsigned int i = 0; i < 4096; ++i )
   {
@@ -53,6 +54,20 @@ ScopePanel::ScopePanel( const std::string& name, QWidget* parent ) : QWidget(par
 
 ScopePanel::~ScopePanel()
 {
+}
+
+bool ScopePanel::toggleAxes()
+{
+  bool b = !plot.axisEnabled(QwtPlot::Axis::yLeft);
+  plot.enableAxis(QwtPlot::Axis::yLeft,b);
+  if( b )
+  {
+    plot.setTitle(QwtText(name.c_str()));
+  } else
+  {
+    plot.setTitle(QwtText(""));
+  }
+  return b;
 }
 
 void ScopePanel::setChannel( unsigned int i )
@@ -114,6 +129,26 @@ Scope::Scope( QWidget* parent ) : QWidget(parent), left("Left",this), right("Rig
 
 Scope::~Scope()
 {
+}
+
+bool Scope::toggleLeftScope()
+{
+  bool b = !left.isVisible();
+  left.setVisible(b);
+  return b;
+}
+
+bool Scope::toggleRightScope()
+{
+  bool b = !right.isVisible();
+  right.setVisible(b);
+  return b;
+}
+
+bool Scope::toggleScopeAxes()
+{
+  left.toggleAxes();
+  return right.toggleAxes();
 }
 
 void Scope::refreshScope() {

--- a/app/gui/qt/scope.cpp
+++ b/app/gui/qt/scope.cpp
@@ -56,9 +56,8 @@ ScopePanel::~ScopePanel()
 {
 }
 
-bool ScopePanel::toggleAxes()
+bool ScopePanel::setAxes(bool b)
 {
-  bool b = !plot.axisEnabled(QwtPlot::Axis::yLeft);
   plot.enableAxis(QwtPlot::Axis::yLeft,b);
   if( b )
   {
@@ -131,24 +130,23 @@ Scope::~Scope()
 {
 }
 
-bool Scope::toggleLeftScope()
+bool Scope::setLeftScope(bool b)
 {
-  bool b = !left.isVisible();
   left.setVisible(b);
   return b;
 }
 
-bool Scope::toggleRightScope()
+bool Scope::setRightScope(bool b)
 {
-  bool b = !right.isVisible();
   right.setVisible(b);
   return b;
 }
 
-bool Scope::toggleScopeAxes()
+bool Scope::setScopeAxes(bool on)
 {
-  left.toggleAxes();
-  return right.toggleAxes();
+  left.setAxes(on);
+  right.setAxes(on);
+  return on;
 }
 
 void Scope::refreshScope() {

--- a/app/gui/qt/scope.h
+++ b/app/gui/qt/scope.h
@@ -36,8 +36,10 @@ public:
   void setChannel( unsigned int i );
   void setReader( scope_buffer_reader* shmReader );
   void refresh();
+  bool toggleAxes();
 
 private:
+  std::string name;
   scope_buffer_reader* reader;
   QwtPlot plot;
   QwtPlotCurve plot_curve;
@@ -55,6 +57,10 @@ class Scope : public QWidget
 public:
   Scope( QWidget* parent = 0 );
   virtual ~Scope();
+
+  bool toggleLeftScope();
+  bool toggleRightScope();
+  bool toggleScopeAxes();
 
 private slots:
   void refreshScope();

--- a/app/gui/qt/scope.h
+++ b/app/gui/qt/scope.h
@@ -36,7 +36,7 @@ public:
   void setChannel( unsigned int i );
   void setReader( scope_buffer_reader* shmReader );
   void refresh();
-  bool toggleAxes();
+  bool setAxes( bool on );
 
 private:
   std::string name;
@@ -58,9 +58,9 @@ public:
   Scope( QWidget* parent = 0 );
   virtual ~Scope();
 
-  bool toggleLeftScope();
-  bool toggleRightScope();
-  bool toggleScopeAxes();
+  bool setLeftScope(bool on);
+  bool setRightScope(bool on);
+  bool setScopeAxes(bool on);
 
 private slots:
   void refreshScope();


### PR DESCRIPTION


Support for scope tab on preferences screen. Allows users to disable scopes, or hide the label and axis markings. Refresh rate was dropped to ~92ms per frame (~11 fps), which greatly reduces CPU load.

I have to check the SC code to be certain, but I suspect that the buffer only updates whenever there is a new batch of frames to view. So at the default 4096, that's (4096/44100 = 92.8ms) between updates, so repainting faster than that doesn't seem to matter. To get a faster frame rate, like 60fps, we'd need a smaller sample window.

I could not discern a difference in the rendering of the waveform at 100ms per update vs. 10ms.