### PR TITLE
No indent in tutorial codeblocks

### DIFF
--- a/etc/doc/tutorial/en/01.1-Live-Coding.md
+++ b/etc/doc/tutorial/en/01.1-Live-Coding.md
@@ -19,10 +19,10 @@ this. Just try to hold onto your seats and enjoy...
 Let's get started, copy the following code into an empty buffer above:
 
 ```
-  live_loop :flibble do
-    sample :bd_haus, rate: 1
-    sleep 0.5
-  end
+live_loop :flibble do
+  sample :bd_haus, rate: 1
+  sleep 0.5
+end
 ```
 
 Now, press the `Run` button and you'll hear a nice fast bass drum
@@ -41,11 +41,11 @@ Ok, that was simple enough. Let's add something else into the mix. Above
 code should look like this:
 
 ```
-  live_loop :flibble do
-    sample :ambi_choir, rate: 0.3
-    sample :bd_haus, rate: 1
-    sleep 1
-  end
+live_loop :flibble do
+  sample :ambi_choir, rate: 0.3
+  sample :bd_haus, rate: 1
+  sleep 1
+end
 ```
 
 Now, play around. Change the rates - what happens when you use high
@@ -60,11 +60,11 @@ Try commenting one of the `sample` lines out by adding a `#` to the
 beginning:
 
 ```
-  live_loop :flibble do
-    sample :ambi_choir, rate: 0.3
-  #  sample :bd_haus, rate: 1
-    sleep 1
-  end
+live_loop :flibble do
+  sample :ambi_choir, rate: 0.3
+#  sample :bd_haus, rate: 1
+  sleep 1
+end
 ```
 
 Notice how it tells the computer to ignore it, so we don't hear it. This
@@ -92,20 +92,20 @@ jam again. Making mistakes is how you'll learn the quickest...
 
 
 ```
-  live_loop :guit do
-    with_fx :echo, mix: 0.3, phase: 0.25 do
-      sample :guit_em9, rate: 0.5
-    end
-  #  sample :guit_em9, rate: -0.5
-    sleep 8
+live_loop :guit do
+  with_fx :echo, mix: 0.3, phase: 0.25 do
+    sample :guit_em9, rate: 0.5
   end
-  
-  live_loop :boom do
-    with_fx :reverb, room: 1 do
-      sample :bd_boom, amp: 10, rate: 1
-    end
-    sleep 8
+#  sample :guit_em9, rate: -0.5
+  sleep 8
+end
+
+live_loop :boom do
+  with_fx :reverb, room: 1 do
+    sample :bd_boom, amp: 10, rate: 1
   end
+  sleep 8
+end
 ```
 
 Now, keep playing and experimenting until your curiosity about how this

--- a/etc/doc/tutorial/en/02.1-Your-First-Beeps.md
+++ b/etc/doc/tutorial/en/02.1-Your-First-Beeps.md
@@ -5,7 +5,7 @@
 Take a look at the following code:
 
 ```
-  play 70
+play 70
 ```
 
 This is where it all starts. Go ahead, copy and paste it into the code
@@ -21,13 +21,13 @@ before you lose yourself in an infinite stream of beeps, try changing
 the number:
 
 ```
-  play 75
+play 75
 ```
 
 Can you hear the difference? Try a lower number:
 
 ```
-  play 60
+play 60
 ```
 
 So, lower numbers make lower pitched beeps and higher numbers make
@@ -49,9 +49,9 @@ Playing a note is quite fun, but playing many at the same time can be
 even better. Try it:
 
 ```
-  play 72
-  play 75
-  play 79
+play 72
+play 75
+play 79
 ```
 
 Jazzy! So, when you write multiple `play`s, they all play at the same
@@ -65,11 +65,11 @@ you wanted to play one note after another and not at the same time?
 Well, that's easy, you just need to `sleep` between the notes:
 
 ```
-  play 72
-  sleep 1
-  play 75
-  sleep 1
-  play 79
+play 72
+sleep 1
+play 75
+sleep 1
+play 79
 ```
 
 How lovely, a little arpeggio. So what does the `1` mean in `sleep 1`?
@@ -79,11 +79,11 @@ second. So, what if we wanted to make our arpeggio a little faster?
 Well, we need to use shorter sleep values. What about a half i.e. `0.5`:
 
 ```
-  play 72
-  sleep 0.5
-  play 75
-  sleep 0.5
-  play 79
+play 72
+sleep 0.5
+play 75
+sleep 0.5
+play 79
 ```
 
 Notice how it plays faster. Now, try for yourself, change the times -
@@ -102,11 +102,11 @@ melody using note names such as C and F# rather than numbers. Sonic Pi
 has you covered. You can do the following:
 
 ```
-  play :C
-  sleep 0.5
-  play :D
-  sleep 0.5
-  play :E
+play :C
+sleep 0.5
+play :D
+sleep 0.5
+play :E
 ```
 
 Remember to put the colon `:` in front of your note name so that it
@@ -114,11 +114,11 @@ goes pink. Also, you can specify the octave by adding a number after
 the note name:
 
 ```
-  play :C3
-  sleep 0.5
-  play :D3
-  sleep 0.5
-  play :E4
+play :C3
+sleep 0.5
+play :D3
+sleep 0.5
+play :E4
 ```
 
 If you want to make a note sharp, add an `s` after the note name such as

--- a/etc/doc/tutorial/en/02.1-Your-First-Beeps.md
+++ b/etc/doc/tutorial/en/02.1-Your-First-Beeps.md
@@ -40,8 +40,8 @@ is one note up (the next note to the right). It just so happens that
 the 4th octave C is number 60. Go ahead and play it: `play 60`.
 
 *Don't worry* if this means nothing to you - it didn't to me when I
- first started. All that matters right now is that you know that *low
- numbers make lower beeps* and *high numbers make higher beeps*.
+first started. All that matters right now is that you know that *low
+numbers make lower beeps* and *high numbers make higher beeps*.
 
 ## Chords
 

--- a/etc/doc/tutorial/en/02.2-Synth-Params.md
+++ b/etc/doc/tutorial/en/02.2-Synth-Params.md
@@ -29,7 +29,7 @@ Opts are passed to calls to `play` by using a comma
 colon `:`) and then a space and the value of the opt. For example:
 
 ```
-  play 50, cheese: 1
+play 50, cheese: 1
 ```
 
 (Note that `cheese:` isn't a valid opt, we're just using it as an example).
@@ -37,13 +37,13 @@ colon `:`) and then a space and the value of the opt. For example:
 You can pass multiple opts by separating them with a comma:
 
 ```
-  play 50, cheese: 1, beans: 0.5
+play 50, cheese: 1, beans: 0.5
 ```
 
 The order of the opts doesn't matter, so the following is identical:
 
 ```
-  play 50, beans: 0.5, cheese: 1
+play 50, beans: 0.5, cheese: 1
 ```
 
 Opts that aren't recognised by the synth are just ignored (like
@@ -54,7 +54,7 @@ last one wins. For example, `beans:` here will have the value 2 rather
 than 0.5:
 
 ```
-  play 50, beans: 0.5, cheese: 3, eggs: 0.1, beans: 2
+play 50, beans: 0.5, cheese: 3, eggs: 0.1, beans: 2
 ```
 
 Many things in Sonic Pi accept opts, so just spend a little time
@@ -82,13 +82,13 @@ To change the amplitude of a sound, you can use the `amp:`
 opt. For example, to play at half amplitude pass 0.5:
 
 ```
-  play 60, amp: 0.5
+play 60, amp: 0.5
 ```
 
 To play at double amplitude pass 2:
 
 ```
-  play 60, amp: 2
+play 60, amp: 2
 ```
 
 The `amp:` opt only modifies the call to `play` it's associated
@@ -96,21 +96,21 @@ with. So, in this example, the first call to play is at half volume and
 the second is back to the default (1):
 
 ```
-  play 60, amp: 0.5
-  sleep 0.5
-  play 65
+play 60, amp: 0.5
+sleep 0.5
+play 65
 ```
 
 Of course, you can use different `amp:` values for each call to play:
 
 ```
-  play 50, amp: 0.1
-  sleep 0.25
-  play 55, amp: 0.2
-  sleep 0.25
-  play 57, amp: 0.4
-  sleep 0.25
-  play 62, amp: 1
+play 50, amp: 0.1
+sleep 0.25
+play 55, amp: 0.2
+sleep 0.25
+play 57, amp: 0.4
+sleep 0.25
+play 62, amp: 1
 ```
 
 ## Panning
@@ -126,20 +126,20 @@ control the exact positioning of our sound.
 Let's play a beep out of the left speaker:
 
 ```
-  play 60, pan: -1
+play 60, pan: -1
 ```
 
 Now, let's play it out of the right speaker:
 
 ```
-  play 60, pan: 1
+play 60, pan: 1
 ```
 
 Finally let's play it back out of the center of both (the default
 position):
 
 ```
-  play 60, pan: 0
+play 60, pan: 0
 ```
 
 Now, go and have fun changing the amplitude and panning of your sounds!

--- a/etc/doc/tutorial/en/02.3-Switching-Synths.md
+++ b/etc/doc/tutorial/en/02.3-Switching-Synths.md
@@ -23,52 +23,52 @@ use.
 A fun sound is the *saw wave* - let's give it a try:
 
 ```
-  use_synth :saw
-  play 38
-  sleep 0.25
-  play 50
-  sleep 0.25
-  play 62
-  sleep 0.25
+use_synth :saw
+play 38
+sleep 0.25
+play 50
+sleep 0.25
+play 62
+sleep 0.25
 ```
 
 Let's try another sound - the *prophet*:
 
 ```
-  use_synth :prophet
-  play 38
-  sleep 0.25
-  play 50
-  sleep 0.25
-  play 62
-  sleep 0.25
+use_synth :prophet
+play 38
+sleep 0.25
+play 50
+sleep 0.25
+play 62
+sleep 0.25
 ```
 
 How about combining two sounds. First one after another:
 
 ```
-  use_synth :saw
-  play 38
-  sleep 0.25
-  play 50
-  sleep 0.25
-  use_synth :prophet
-  play 57
-  sleep 0.25
+use_synth :saw
+play 38
+sleep 0.25
+play 50
+sleep 0.25
+use_synth :prophet
+play 57
+sleep 0.25
 ```
 
 Now at the same time:
 
 ```
-  use_synth :tb303
-  play 38
-  sleep 0.25
-  use_synth :dsaw
-  play 50
-  sleep 0.25
-  use_synth :prophet
-  play 57
-  sleep 0.25
+use_synth :tb303
+play 38
+sleep 0.25
+use_synth :dsaw
+play 50
+sleep 0.25
+use_synth :prophet
+play 57
+sleep 0.25
 ```
 
 Notice that the `use_synth` command only affects the following calls to

--- a/etc/doc/tutorial/en/02.4-Durations-with-Envelopes.md
+++ b/etc/doc/tutorial/en/02.4-Durations-with-Envelopes.md
@@ -47,14 +47,14 @@ synths have a release time of 1 which means that by default they have a
 duration of 1 beat (which at the default BPM of 60 is 1 second):
 
 ```
-  play 70
+play 70
 ```
 
 The note will be audible for 1 second.  Go ahead and time it :-) This is
 short hand for the longer more explicit version:
 
 ```
-  play 70, release: 1
+play 70, release: 1
 ```
 
 Notice how this sounds exactly the same (the sound lasts for one
@@ -62,14 +62,14 @@ second). However, it's now very easy to change the duration by modifying
 the value of the `release:` opt:
 
 ```
-  play 60, release: 2
+play 60, release: 2
 ```
 
 We can make the synth sound for a very short amount of time by using a
 very small release time:
 
 ```
-  play 60, release: 0.2
+play 60, release: 0.2
 ```
 
 The duration of the release of the sound is called the *release phase*
@@ -96,16 +96,16 @@ percussive sound. However, you may wish to fade your sound in. This can
 be achieved with the `attack:` opt. Try fading in some sounds:
 
 ```
-  play 60, attack: 2
-  sleep 3
-  play 65, attack: 0.5
+play 60, attack: 2
+sleep 3
+play 65, attack: 0.5
 ```
 
 You may use multiple opts at the same time. For example for a short
 attack and a long release try:
 
 ```
-  play 60, attack: 0.7, release: 4
+play 60, attack: 0.7, release: 4
 ```
 
 This short attack and long release envelope is illustrated in the
@@ -117,7 +117,7 @@ Of course, you may switch things around. Try a long attack and a short
 release:
 
 ```
-  play 60, attack: 4, release: 0.7
+play 60, attack: 4, release: 0.7
 ```
 
 ![long attack short release envelope](../images/tutorial/env-long-attack-short-release.png)
@@ -126,7 +126,7 @@ Finally, you can also have both short attack and release times for
 shorter sounds.
 
 ```
-  play 60, attack: 0.5, release: 0.5
+play 60, attack: 0.5, release: 0.5
 ```
 
 ![short attack short release envelope](../images/tutorial/env-short-attack-short-release.png)
@@ -139,7 +139,7 @@ which the sound is maintained at full amplitude between the attack and
 release phases.
 
 ```
-  play 60, attack: 0.3, sustain: 1, release: 1
+play 60, attack: 0.3, sustain: 1, release: 1
 ```
 
 ![ASR envelope](../images/tutorial/env-attack-sustain-release.png)
@@ -162,7 +162,7 @@ it will be set to the `sustain_level:`). By default, the `decay:` opt is
 them for the decay time to have any effect:
 
 ```
-  play 60, attack: 0.1, attack_level: 1, decay: 0.2, sustain_level: 0.4, sustain: 1, release: 0.5
+play 60, attack: 0.1, attack_level: 1, decay: 0.2, sustain_level: 0.4, sustain: 1, release: 0.5
 ```
 
 ![ADSR envelope](../images/tutorial/env-attack-decay-sustain-release.png)
@@ -175,7 +175,7 @@ different values for full control over the envelope. This allows you to
 to create envelopes such as the following:
 
 ```
-  play 60, attack: 0.1, attack_level: 1, decay: 0.2, decay_level: 0.3, sustain: 1, sustain_level: 0.4, release: 0.5
+play 60, attack: 0.1, attack_level: 1, decay: 0.2, decay_level: 0.3, sustain: 1, sustain_level: 0.4, release: 0.5
 ```
 
 ![ASR envelope](../images/tutorial/env-decay-level.png)
@@ -183,7 +183,7 @@ to create envelopes such as the following:
 It's also possible to set the `decay_level:` to be higher than `sustain_level:`:
 
 ```
-  play 60, attack: 0.1, attack_level: 0.1, decay: 0.2, decay_level: 1, sustain: 0.5, sustain_level: 0.8, release: 1.5
+play 60, attack: 0.1, attack_level: 0.1, decay: 0.2, decay_level: 1, sustain: 0.5, sustain_level: 0.8, release: 1.5
 ```
 
 ![ASR envelope](../images/tutorial/env-decay-level-2.png)
@@ -202,7 +202,7 @@ the times of each of these phases. Therefore the following sound will
 have a duration of 0.5 + 1 + 2 + 0.5 = 4 beats:
 
 ```
-  play 60, attack: 0.5, attack_level: 1, decay: 1, sustain_level: 0.4, sustain: 2, release: 0.5
+play 60, attack: 0.5, attack_level: 1, decay: 1, sustain_level: 0.4, sustain: 2, release: 0.5
 ```
 
 Now go and have a play adding envelopes to your sounds...

--- a/etc/doc/tutorial/en/03.1-Triggering-Samples.md
+++ b/etc/doc/tutorial/en/03.1-Triggering-Samples.md
@@ -6,7 +6,7 @@ Playing beeps is only the beginning. Something that's a lot of fun is
 triggering pre-recorded samples. Try it:
 
 ```
-  sample :ambi_lunar_land
+sample :ambi_lunar_land
 ```
 
 Sonic Pi includes many samples for you to play with. You can use them
@@ -14,23 +14,23 @@ just like you use the `play` command. To play multiple samples and notes
 just write them one after another:
 
 ```
-  play 36
-  play 48
-  sample :ambi_lunar_land
-  sample :ambi_drone
+play 36
+play 48
+sample :ambi_lunar_land
+sample :ambi_drone
 ```
 
 If you want to space them out in time, use the `sleep` command:
 
 ```
-  sample :ambi_lunar_land
-  sleep 1
-  play 48
-  sleep 0.5
-  play 36
-  sample :ambi_drone
-  sleep 1
-  play 36
+sample :ambi_lunar_land
+sleep 1
+play 48
+sleep 0.5
+play 36
+sample :ambi_drone
+sleep 1
+play 36
 ```
 
 Notice how Sonic Pi doesn't wait for a sound to finish before starting

--- a/etc/doc/tutorial/en/03.2-Sample-Params.md
+++ b/etc/doc/tutorial/en/03.2-Sample-Params.md
@@ -12,7 +12,7 @@ You can change the amplitude of samples with exactly the same
 approach you used for synths:
 
 ```
-  sample :ambi_lunar_land, amp: 0.5
+sample :ambi_lunar_land, amp: 0.5
 ```
 
 ## Panning samples
@@ -22,9 +22,9 @@ here's how we'd play the amen break in the left ear and then half way
 through play it again through the right ear:
 
 ```
-  sample :loop_amen, pan: -1
-  sleep 0.877
-  sample :loop_amen, pan: 1
+sample :loop_amen, pan: -1
+sleep 0.877
+sample :loop_amen, pan: 1
 ```
 
 Note that 0.877 is half the duration of the `:loop_amen` sample in

--- a/etc/doc/tutorial/en/03.3-Stretching-Samples.md
+++ b/etc/doc/tutorial/en/03.3-Stretching-Samples.md
@@ -26,14 +26,14 @@ Let's play with one of the ambient sounds: `:ambi_choir`. To play it
 with the default rate, you can pass a `rate:` opt to `sample`:
 
 ```
-  sample :ambi_choir, rate: 1
+sample :ambi_choir, rate: 1
 ```
 
 This plays it at normal rate (1), so nothing special yet. However, we're
 free to change that number to something else. How about `0.5`:
 
 ```
-  sample :ambi_choir, rate: 0.5
+sample :ambi_choir, rate: 0.5
 ```
 
 Woah! What's going on here? Well, two things. Firstly, the sample takes
@@ -46,27 +46,27 @@ A sample that's fun to stretch and compress is the Amen Break. At normal
 rate, we might imagine throwing it into a *drum 'n' bass* track:
 
 ```
-  sample :loop_amen
+sample :loop_amen
 ```
 
 However by changing the rate we can switch up genres. Try half speed for
 *old school hip-hop*:
 
 ```
-  sample :loop_amen, rate: 0.5
+sample :loop_amen, rate: 0.5
 ```
 
 If we speed it up, we enter *jungle* territory: 
 
 ```
-  sample :loop_amen, rate: 1.5
+sample :loop_amen, rate: 1.5
 ```
 
 Now for our final party trick - let's see what happens if we use a
 negative rate:
 
 ```
-  sample :loop_amen, rate: -1
+sample :loop_amen, rate: -1
 ```
 
 Woah! It plays it *backwards*! Now try playing with lots of different
@@ -123,7 +123,7 @@ The duration of the sample is affected by the playback rate:
 We can represent this with the formula:
 
 ```
-  new_sample_duration = (1 / rate) * sample_duration 
+new_sample_duration = (1 / rate) * sample_duration 
 ```
 
 Changing the playback rate also affects the pitch of the sample. The

--- a/etc/doc/tutorial/en/03.4-Enveloped-Samples.md
+++ b/etc/doc/tutorial/en/03.4-Enveloped-Samples.md
@@ -15,20 +15,20 @@ long `release:`, it won't extend the duration of the sample.
 Let's return to our trusty friend the Amen Break:
 
 ```
-  sample :loop_amen
+sample :loop_amen
 ```
 
 With no opts, we hear the full sample at full amplitude. If we
 want to fade this in over 1 second we can use the `attack:` param:
 
 ```
-  sample :loop_amen, attack: 1
+sample :loop_amen, attack: 1
 ```
 
 For a shorter fade in, choose a shorter attack value:
 
 ```
-  sample :loop_amen, attack: 0.3
+sample :loop_amen, attack: 0.3
 ```
 
 ## Auto Sustain
@@ -51,7 +51,7 @@ To explore this, let's consider our Amen break in more detail. If we ask
 Sonic Pi how long the sample is:
 
 ```
-  print sample_duration :loop_amen
+print sample_duration :loop_amen
 ```
 
 It will print out `1.753310657596372` which is the length of the sample
@@ -59,7 +59,7 @@ in seconds. Let's just round that to `1.75` for convenience here. Now,
 if we set the release to `0.75`, something surprising will happen:
 
 ```
-  sample :loop_amen, release: 0.75
+sample :loop_amen, release: 0.75
 ```
 
 It will play the first second of the sample at full amplitude before
@@ -76,7 +76,7 @@ We can use both `attack:` and `release:` together with the auto sustain
 behaviour to fade both in and out over the duration of the sample:
 
 ```
-  sample :loop_amen, attack: 0.75, release: 0.75
+sample :loop_amen, attack: 0.75, release: 0.75
 ```
 
 As the full duration of the sample is 1.75s and our attack and release
@@ -89,7 +89,7 @@ We can easily get back to our normal synth ADSR behaviour by manually
 setting `sustain:` to a value such as 0:
 
 ```
-  sample :loop_amen, sustain: 0, release: 0.75
+sample :loop_amen, sustain: 0, release: 0.75
 ```
 
 Now, our sample only plays for 0.75 seconds in total. With the default
@@ -104,21 +104,21 @@ into shorter, more percussive versions. Consider the sample
 `:drum_cymbal_open`:
 
 ```
-  sample :drum_cymbal_open
+sample :drum_cymbal_open
 ```
 
 You can hear the cymbal sound ringing out over a period of
 time. However, we can use our envelope to make it more percussive:
 
 ```
-  sample :drum_cymbal_open, attack: 0.01, sustain: 0, release: 0.1
+sample :drum_cymbal_open, attack: 0.01, sustain: 0, release: 0.1
 ```
 
 You can then emulate hitting the cymbal and then dampening it by
 increasing the sustain period:
 
 ```
-  sample :drum_cymbal_open, attack: 0.01, sustain: 0.3, release: 0.1
+sample :drum_cymbal_open, attack: 0.01, sustain: 0.3, release: 0.1
 ```
 
 Now go and have fun putting envelopes over the samples. Try changing the

--- a/etc/doc/tutorial/en/03.5-Partial-Samples.md
+++ b/etc/doc/tutorial/en/03.5-Partial-Samples.md
@@ -7,21 +7,21 @@ player. Let's do a quick recap. So far we've looked at how we can
 trigger samples:
 
 ```
-  sample :loop_amen
+sample :loop_amen
 ```
 
 We then looked at how we can change the rate of samples such as
 playing them at half speed:
 
 ```
-  sample :loop_amen, rate: 0.5
+sample :loop_amen, rate: 0.5
 ```
 
 Next, we looked at how we could fade a sample in (let's do it at half
 speed):
 
 ```
-  sample :loop_amen, rate: 0.5, attack: 1
+sample :loop_amen, rate: 0.5, attack: 1
 ```
 
 We also looked at how we could use the start of a sample percussively
@@ -29,7 +29,7 @@ by giving `sustain:` an explicit value and setting both the attack and
 release to be short values:
 
 ```
-  sample :loop_amen, rate: 2, attack: 0.01, sustain: 0, release: 0.35
+sample :loop_amen, rate: 2, attack: 0.01, sustain: 0, release: 0.35
 ```
 
 However, wouldn't it be nice if we didn't have to always start at the
@@ -44,13 +44,13 @@ and 0.5 is half way through the sample. Let's try playing only the last
 half of the amen break:
 
 ```
-  sample :loop_amen, start: 0.5
+sample :loop_amen, start: 0.5
 ```
 
 How about the last quarter of the sample:
 
 ```
-  sample :loop_amen, start: 0.75
+sample :loop_amen, start: 0.75
 ```
 
 ## Choosing a finish point
@@ -60,7 +60,7 @@ sample as a value between 0 and 1. Let's finish the amen break half way
 through:
 
 ```
-  sample :loop_amen, finish: 0.5
+sample :loop_amen, finish: 0.5
 ```
 
 ## Specifying start and finish
@@ -69,14 +69,14 @@ Of course, we can combine these two to play arbitrary segments of the
 audio file. How about only a small section in the middle:
 
 ```
-  sample :loop_amen, start: 0.4, finish: 0.6
+sample :loop_amen, start: 0.4, finish: 0.6
 ```
 
 What happens if we choose a start position after the finish position?
 
 
 ```
-  sample :loop_amen, start: 0.6, finish: 0.4
+sample :loop_amen, start: 0.6, finish: 0.4
 ```
 
 Cool! It plays it backwards!
@@ -88,7 +88,7 @@ our friend `rate:`. For example, we can play a very small section of the
 middle of the amen break very slowly:
 
 ```
-  sample :loop_amen, start: 0.5, finish: 0.7, rate: 0.2
+sample :loop_amen, start: 0.5, finish: 0.7, rate: 0.2
 ```
 
 ## Combining with envelopes
@@ -97,7 +97,7 @@ Finally, we can combine all of this with our ADSR envelopes to produce
 interesting results:
 
 ```
-  sample :loop_amen, start: 0.5, finish: 0.8, rate: -0.2, attack: 0.3, release: 1
+sample :loop_amen, start: 0.5, finish: 0.8, rate: -0.2, attack: 0.3, release: 1
 ```
 
 Now go and have a play mashing up samples with all of this fun stuff...

--- a/etc/doc/tutorial/en/03.6-External-Samples.md
+++ b/etc/doc/tutorial/en/03.6-External-Samples.md
@@ -29,19 +29,19 @@ So how do you play any arbitrary WAV, AIFF or FLAC file on your computer?
 All you need to do is pass the path of that file to `sample`:
 
 ```
-  # Raspberry Pi, Mac, Linux
-  sample "/Users/sam/Desktop/my-sound.wav"
-  # Windows
-  sample "C:/Users/sam/Desktop/my-sound.wav"
+# Raspberry Pi, Mac, Linux
+sample "/Users/sam/Desktop/my-sound.wav"
+# Windows
+sample "C:/Users/sam/Desktop/my-sound.wav"
 ```
 
 Sonic Pi will automatically load and play the sample. You can also pass
 all the standard params you're used to passing `sample`:
 
 ```
-  # Raspberry Pi, Mac, Linux
-  sample "/Users/sam/Desktop/my-sound.wav", rate: 0.5, amp: 0.3
-  # Windows
-  sample "C:/Users/sam/Desktop/my-sound.wav", rate: 0.5, amp: 0.3
+# Raspberry Pi, Mac, Linux
+sample "/Users/sam/Desktop/my-sound.wav", rate: 0.5, amp: 0.3
+# Windows
+sample "C:/Users/sam/Desktop/my-sound.wav", rate: 0.5, amp: 0.3
 ```
 

--- a/etc/doc/tutorial/en/03.7-Sample-Packs.md
+++ b/etc/doc/tutorial/en/03.7-Sample-Packs.md
@@ -17,7 +17,7 @@ sample.
 For example, say you have the following folder on your machine:
 
 ```
-  /path/to/my/samples/
+/path/to/my/samples/
 ```
 
 When we look inside that folder we find the following samples:
@@ -32,13 +32,13 @@ When we look inside that folder we find the following samples:
 Typically in order to play the piano sample we can use the full path:
 
 ```
-  sample "/path/to/my/samples/120_Bb_piano1.wav"
+sample "/path/to/my/samples/120_Bb_piano1.wav"
 ```
 
 If we want to then play the guitar sample we can use its full path too:
 
 ```
-  sample "/path/to/my/samples/120_Bb_guit.wav"
+sample "/path/to/my/samples/120_Bb_guit.wav"
 ```
 
 However, both of these calls to sample requires us to *know* the names
@@ -51,22 +51,22 @@ If we want to play the first sample in a directory we just need to pass
 the directory's name to `sample` and the index `0` as follows:
 
 ```
-  sample "/path/to/my/samples/", 0
+sample "/path/to/my/samples/", 0
 ```
 
 We can even make a shortcut to our directory path using a variable:
 
 ```
-  samps = "/path/to/my/samples/"
-  sample samps, 0
+samps = "/path/to/my/samples/"
+sample samps, 0
 ```
 
 Now, if we want to play the second sample in our directory, we just need
 to add 1 to our index:
 
 ```
-  samps = "/path/to/my/samples/"
-  sample samps, 1
+samps = "/path/to/my/samples/"
+sample samps, 1
 ```
 
 Notice that we no longer need to know the names of the samples in the
@@ -105,16 +105,16 @@ example, if we're working at 120 BPM, we can filter down to all the
 samples that contain the string `"120"` with the following:
 
 ```
-  samps = "/path/to/my/samples/"
-  sample samps, "120"
+samps = "/path/to/my/samples/"
+sample samps, "120"
 ```
 
 This will play us the first match. If we want the second match we just
 need to use the index:
 
 ```
-  samps = "/path/to/my/samples/"
-  sample samps, "120", 1
+samps = "/path/to/my/samples/"
+sample samps, "120", 1
 ```
 
 We can even use multiple filters at the same time. For example, if we
@@ -122,15 +122,15 @@ want a sample whose filename contains both the substrings "120" and "A#"
 we can find it easily with the following code:
 
 ```
-  samps = "/path/to/my/samples/"
-  sample samps, "120", "A#"
+samps = "/path/to/my/samples/"
+sample samps, "120", "A#"
 ```
 
 Finally, we're still free to add our usual opts to the call to `sample`:
 
 ```
-  samps = "/path/to/my/samples/"
-  sample samps, "120", "Bb", 1, lpf: 70, amp: 2
+samps = "/path/to/my/samples/"
+sample samps, "120", "Bb", 1, lpf: 70, amp: 2
 ```
 
 ## Sources
@@ -150,11 +150,11 @@ valid paths and then by adding all the valid `.flac`, `.aif`, `.aiff`,
 For example, take a look at the following code:
 
 ```
-  samps = "/path/to/my/samples/"
-  samps2 = "/path/to/my/samples2/"
-  path = "/path/to/my/samples3/foo.wav"
-  
-  sample samps, samps2, path, 0
+samps = "/path/to/my/samples/"
+samps2 = "/path/to/my/samples2/"
+path = "/path/to/my/samples3/foo.wav"
+
+sample samps, samps2, path, 0
 ```
 
 Here, we're combining the contents of the samples within two directories
@@ -169,8 +169,8 @@ recursive search for all samples within all subfolders of a particular
 folder by adding `**` to the end of the path:
 
 ```
-  samps = "/path/to/nested/samples/**"
-  sample samps, 0
+samps = "/path/to/nested/samples/**"
+sample samps, 0
 ```
 
 Take care though as searching through a very large set of folders may
@@ -197,7 +197,7 @@ containing the string `"foo"` and play the first matching sample at half
 speed:
 
 ```
-  sample "/path/to/samples", "foo", rate: 0.5
+sample "/path/to/samples", "foo", rate: 0.5
 ```
 
 See the help for `sample` for many detailed usage examples. Note that
@@ -211,10 +211,10 @@ be treated as regular sources and filters. Therefore the following calls
 to `sample` are semantically equivalent:
 
 ```
-  sample "/path/to/dir", "100", "C#"
-  sample ["/path/to/dir", "100", "C#"]
-  sample "/path/to/dir", ["100", "C#"]
-  sample ["/path/to/dir", ["100", ["C#"]]]
+sample "/path/to/dir", "100", "C#"
+sample ["/path/to/dir", "100", "C#"]
+sample "/path/to/dir", ["100", "C#"]
+sample ["/path/to/dir", ["100", ["C#"]]]
 ```
 
 ## Wrapping Up

--- a/etc/doc/tutorial/en/04-Randomisation.md
+++ b/etc/doc/tutorial/en/04-Randomisation.md
@@ -15,7 +15,7 @@ value between two numbers - a *min* and a *max*. (`rrand` is short for
 ranged random). Let's try playing a random note:
 
 ```
-  play rrand(50, 95)
+play rrand(50, 95)
 ```
 
 Ooh, it played a random note. It played note `83.7527`. A nice random
@@ -34,10 +34,10 @@ every time, then it wouldn't be very interesting. However, it
 doesn't. Try the following:
 
 ```
-  loop do
-    play rrand(50, 95)
-    sleep 0.5
-  end 
+loop do
+  play rrand(50, 95)
+  sleep 0.5
+end 
 ```
 
 Yes! It finally sounds random. Within a given *run* subsequent calls
@@ -54,10 +54,10 @@ example which loops the `:perc_bell` sample with a random rate and sleep
 time between bell sounds:
 
 ```
-  loop do
-    sample :perc_bell, rate: (rrand 0.125, 1.5)
-    sleep rrand(0.2, 2)
-  end
+loop do
+  sample :perc_bell, rate: (rrand 0.125, 1.5)
+  sleep rrand(0.2, 2)
+end
 ```
 
 ## Random cutoff
@@ -67,12 +67,12 @@ synth randomly. A great synth to try this out on is the `:tb303`
 emulator:
 
 ```
-  use_synth :tb303
-  
-  loop do
-    play 50, release: 0.1, cutoff: rrand(60, 120)
-    sleep 0.125
-  end
+use_synth :tb303
+
+loop do
+  play 50, release: 0.1, cutoff: rrand(60, 120)
+  sleep 0.125
+end
 ```
 
 ## Random seeds
@@ -85,21 +85,21 @@ starting point via `use_random_seed`. The default seed happens to be
 Consider the following:
 
 ```
-  5.times do
-    play rrand(50, 100)
-    sleep 0.5
-  end
+5.times do
+  play rrand(50, 100)
+  sleep 0.5
+end
 ```
 
 Every time you run this code, you'll hear the same sequence of 5
 notes. To get a different sequence simply change the seed:
 
 ```
-  use_random_seed 40
-  5.times do
-    play rrand(50, 100)
-    sleep 0.5
-  end
+use_random_seed 40
+5.times do
+  play rrand(50, 100)
+  sleep 0.5
+end
 ```
 
 This will produce a different sequence of 5 notes. By changing the seed
@@ -120,16 +120,16 @@ which is done by wrapping them in square brackets and separating them
 with commas: `[60, 65, 72]`. Next I just need to pass them to `choose`:
 
 ```
-  choose([60, 65, 72])
+choose([60, 65, 72])
 ```
 
 Let's hear what that sounds like:
 
 ```
-  loop do
-    play choose([60, 65, 72])
-    sleep 1
-  end
+loop do
+  play choose([60, 65, 72])
+  sleep 1
+end
 ```
 
 ## rrand
@@ -165,10 +165,10 @@ between 0 and one. It's therefore useful for choosing random `amp:`
 values:
 
 ```
-  loop do
-    play 60, amp: rand
-    sleep 0.25
-  end
+loop do
+  play 60, amp: rand
+  sleep 0.25
+end
 ```
 
 ## rand_i

--- a/etc/doc/tutorial/en/05.1-Blocks.md
+++ b/etc/doc/tutorial/en/05.1-Blocks.md
@@ -11,11 +11,11 @@ reverb to it, to only run it 1 time out of 5, etc. Consider the
 following code:
 
 ```
-  play 50
-  sleep 0.5
-  sample :elec_plip
-  sleep 0.5
-  play 62
+play 50
+sleep 0.5
+sample :elec_plip
+sleep 0.5
+play 62
 ```
 
 To do something with a chunk of code, we need to tell Sonic Pi where
@@ -23,13 +23,13 @@ the code block *starts* and where it *ends*. We use `do` for start and
 `end` for end. For example:
 
 ```
-  do
-    play 50
-    sleep 0.5
-    sample :elec_plip
-    sleep 0.5
-    play 62
-  end
+do
+  play 50
+  sleep 0.5
+  sample :elec_plip
+  sleep 0.5
+  play 62
+end
 ```
 
 However, this isn't yet complete and won't work (try it and you'll get

--- a/etc/doc/tutorial/en/05.2-Iteration-and-Loops.md
+++ b/etc/doc/tutorial/en/05.2-Iteration-and-Loops.md
@@ -18,38 +18,38 @@ Have you written some code you'd like to repeat a few times? For
 example, you might have something like this:
 
 ```
-  play 50
-  sleep 0.5
-  sample :elec_blup
-  sleep 0.5
-  play 62
-  sleep 0.25
+play 50
+sleep 0.5
+sample :elec_blup
+sleep 0.5
+play 62
+sleep 0.25
 ```
 
 What if we wished to repeat this 3 times? Well, we could do something
 simple and just copy and paste it three times:
 
 ```
-  play 50
-  sleep 0.5
-  sample :elec_blup
-  sleep 0.5
-  play 62
-  sleep 0.25
-  
-  play 50
-  sleep 0.5
-  sample :elec_blup
-  sleep 0.5
-  play 62
-  sleep 0.25
-  
-  play 50
-  sleep 0.5
-  sample :elec_blup
-  sleep 0.5
-  play 62
-  sleep 0.25
+play 50
+sleep 0.5
+sample :elec_blup
+sleep 0.5
+play 62
+sleep 0.25
+
+play 50
+sleep 0.5
+sample :elec_blup
+sleep 0.5
+play 62
+sleep 0.25
+
+play 50
+sleep 0.5
+sample :elec_blup
+sleep 0.5
+play 62
+sleep 0.25
 ```
 
 Now that's a lot of code! What happens if you want to change the
@@ -70,34 +70,34 @@ that's not too hard. Just remember to write `end` at the end of the
 code you'd like to repeat:
 
 ```
-  3.times do
-    play 50
-    sleep 0.5
-    sample :elec_blup
-    sleep 0.5
-    play 62
-    sleep 0.25
-  end
+3.times do
+  play 50
+  sleep 0.5
+  sample :elec_blup
+  sleep 0.5
+  play 62
+  sleep 0.25
+end
 ```
 
 Now isn't that much neater than cutting and pasting! We can use this to
 create lots of nice repeating structures:
 
 ```
-  4.times do
-    play 50
-    sleep 0.5
-  end
-  
-  8.times do
-    play 55, release: 0.2
-    sleep 0.25
-  end
-  
-  4.times do
-    play 50
-    sleep 0.5
-  end
+4.times do
+  play 50
+  sleep 0.5
+end
+
+8.times do
+  play 55, release: 0.2
+  sleep 0.25
+end
+
+4.times do
+  play 50
+  sleep 0.5
+end
 ```
 
 ## Nesting Iterations
@@ -106,18 +106,18 @@ We can put iterations inside other iterations to create interesting
 patterns. For example:
 
 ```
-  4.times do
-    sample :drum_heavy_kick
-    2.times do
-      sample :elec_blip2, rate: 2
-      sleep 0.25
-    end
-    sample :elec_snare
-    4.times do
-      sample :drum_tom_mid_soft
-      sleep 0.125
-    end
+4.times do
+  sample :drum_heavy_kick
+  2.times do
+    sample :elec_blip2, rate: 2
+    sleep 0.25
   end
+  sample :elec_snare
+  4.times do
+    sample :drum_tom_mid_soft
+    sleep 0.125
+  end
+end
 ```
 
 ## Looping
@@ -128,10 +128,10 @@ probably better off asking Sonic Pi to repeat forever (at least until
 you press the stop button!). Let's loop the amen break forever:
 
 ```
-  loop do
-    sample :loop_amen
-    sleep sample_duration :loop_amen
-  end
+loop do
+  sample :loop_amen
+  sleep sample_duration :loop_amen
+end
 ```
 
 The important thing to know about loops is that they act like black
@@ -141,12 +141,12 @@ means if you have code after the loop you will *never* hear it. For
 example, the cymbal after this loop will never play:
 
 ```
-  loop do
-    play 50
-    sleep 1
-  end
-  
-  sample :drum_cymbal_open
+loop do
+  play 50
+  sleep 1
+end
+
+sample :drum_cymbal_open
 ```
 
 Now, get structuring your code with iteration and loops!

--- a/etc/doc/tutorial/en/05.3-Conditionals.md
+++ b/etc/doc/tutorial/en/05.3-Conditionals.md
@@ -18,17 +18,17 @@ two pieces of code, the code to play the drum and the code to play the
 cymbal:
 
 ```
-  loop do
-  
-    if one_in(2)
-      sample :drum_heavy_kick
-    else
-      sample :drum_cymbal_closed
-    end
-    
-    sleep 0.5
-    
+loop do
+
+  if one_in(2)
+    sample :drum_heavy_kick
+  else
+    sample :drum_cymbal_closed
   end
+  
+  sleep 0.5
+  
+end
 ```
 
 Notice that `if` statements have three parts:
@@ -48,17 +48,17 @@ like do/end blocks you can put multiple lines of code in either
 place. For example:
 
 ```
-  loop do
-  
-    if one_in(2)
-      sample :drum_heavy_kick
-      sleep 0.5
-    else
-      sample :drum_cymbal_closed
-      sleep 0.25
-    end
-    
+loop do
+
+  if one_in(2)
+    sample :drum_heavy_kick
+    sleep 0.5
+  else
+    sample :drum_cymbal_closed
+    sleep 0.25
   end
+  
+end
 ```
 
 This time we're sleeping for a different amount of time depending on
@@ -71,15 +71,15 @@ Sometimes you want to optionally execute just one line of code. This is
 possible by placing `if` and then the question at the end. For example:
 
 ```
-  use_synth :dsaw
-  
-  loop do
-    play 50, amp: 0.3, release: 2
-    play 53, amp: 0.3, release: 2 if one_in(2)
-    play 57, amp: 0.3, release: 2 if one_in(3)
-    play 60, amp: 0.3, release: 2 if one_in(4)
-    sleep 1.5
-  end
+use_synth :dsaw
+
+loop do
+  play 50, amp: 0.3, release: 2
+  play 53, amp: 0.3, release: 2 if one_in(2)
+  play 57, amp: 0.3, release: 2 if one_in(3)
+  play 60, amp: 0.3, release: 2 if one_in(4)
+  sleep 1.5
+end
 ```
 
 This will play chords of different numbers with the chance of each note

--- a/etc/doc/tutorial/en/05.4-Threads.md
+++ b/etc/doc/tutorial/en/05.4-Threads.md
@@ -17,16 +17,16 @@ To keep this example simple, you'll have to imagine that this is a
 phat beat and a killer bassline:
 
 ```
-  loop do
-    sample :drum_heavy_kick
-    sleep 1
-  end
-  
-  loop do
-    use_synth :fm
-    play 40, release: 0.2
-    sleep 0.5
-  end
+loop do
+  sample :drum_heavy_kick
+  sleep 1
+end
+
+loop do
+  use_synth :fm
+  play 40, release: 0.2
+  sleep 0.5
+end
 ```
 
 As we've discussed previously, loops are like *black holes* for the
@@ -38,18 +38,18 @@ code. This is where threads come to the rescue.
 ## Threads to the Rescue
 
 ```
-  in_thread do
-    loop do
-      sample :drum_heavy_kick
-      sleep 1
-    end
-  end
-  
+in_thread do
   loop do
-    use_synth :fm
-    play 40, release: 0.2
-    sleep 0.5
+    sample :drum_heavy_kick
+    sleep 1
   end
+end
+
+loop do
+  use_synth :fm
+  play 40, release: 0.2
+  sleep 0.5
+end
 ```
 
 By wrapping the first loop in an `in_thread` do/end block we tell Sonic
@@ -61,24 +61,24 @@ weaved together!
 Now, what if we wanted to add a synth on top. Something like:
 
 ```
-  in_thread do
-    loop do
-      sample :drum_heavy_kick
-      sleep 1
-    end
-  end
-  
+in_thread do
   loop do
-    use_synth :fm
-    play 40, release: 0.2
-    sleep 0.5
+    sample :drum_heavy_kick
+    sleep 1
   end
-  
-  loop do
-    use_synth :zawa
-    play 52, release: 2.5, phase: 2, amp: 0.5
-    sleep 2
-  end
+end
+
+loop do
+  use_synth :fm
+  play 40, release: 0.2
+  sleep 0.5
+end
+
+loop do
+  use_synth :zawa
+  play 52, release: 2.5, phase: 2, amp: 0.5
+  sleep 2
+end
 ```
 
 Now we have the same problem as before. The first loop is played at the
@@ -86,26 +86,26 @@ same time as the second loop due to the `in_thread`. However, *the third
 loop is never reached*. We therefore need another thread:
 
 ```
-  in_thread do
-    loop do
-      sample :drum_heavy_kick
-      sleep 1
-    end
-  end
-  
-  in_thread do
-    loop do
-      use_synth :fm
-      play 40, release: 0.2
-      sleep 0.5
-    end
-  end
-  
+in_thread do
   loop do
-    use_synth :zawa
-    play 52, release: 2.5, phase: 2, amp: 0.5
-    sleep 2
+    sample :drum_heavy_kick
+    sleep 1
   end
+end
+
+in_thread do
+  loop do
+    use_synth :fm
+    play 40, release: 0.2
+    sleep 0.5
+  end
+end
+
+loop do
+  use_synth :zawa
+  play 52, release: 2.5, phase: 2, amp: 0.5
+  sleep 2
+end
 ```
 
 ## Runs as threads
@@ -127,16 +127,16 @@ thread* - no other thread will have their synth switched. Let's see this
 in action:
 
 ```
+play 50
+sleep 1
+
+in_thread do
+  use_synth :tb303
   play 50
-  sleep 1
-  
-  in_thread do
-    use_synth :tb303
-    play 50
-  end
-  
-  sleep 1
-  play 50
+end
+
+sleep 1
+play 50
 ```
 
 Notice how the middle sound was different to the others? The `use_synth`
@@ -150,13 +150,13 @@ automatically inherit all of the current settings from the current
 thread. Let's see that:
 
 ```
-  use_synth :tb303
-  play 50
-  sleep 1
-  
-  in_thread do
-    play 55
-  end
+use_synth :tb303
+play 50
+sleep 1
+
+in_thread do
+  play 55
+end
 ```
 
 Notice how the second note is played with the `:tb303` synth even though
@@ -171,28 +171,28 @@ parent but they don't share any changes back.
 Finally, we can give our threads names:
 
 ```
-  in_thread(name: :bass) do
-    loop do
-      use_synth :prophet
-      play chord(:e2, :m7).choose, release: 0.6
-      sleep 0.5
-    end
+in_thread(name: :bass) do
+  loop do
+    use_synth :prophet
+    play chord(:e2, :m7).choose, release: 0.6
+    sleep 0.5
   end
-  
-  in_thread(name: :drums) do
-    loop do
-      sample :elec_snare
-      sleep 1
-    end
+end
+
+in_thread(name: :drums) do
+  loop do
+    sample :elec_snare
+    sleep 1
   end
+end
 ```
 
 Look at the log pane when you run this code. See how the log reports the
 name of the thread with the message?
 
 ```
-  [Run 36, Time 4.0, Thread :bass]
-   |- synth :prophet, {release: 0.6, note: 47}
+[Run 36, Time 4.0, Thread :bass]
+ |- synth :prophet, {release: 0.6, note: 47}
 ```
 
 ## Only One Thread per Name Allowed
@@ -202,12 +202,12 @@ a given name may be running at the same time. Let's explore this.
 Consider the following code:
 
 ```
-  in_thread do
-    loop do
-      sample :loop_amen
-      sleep sample_duration :loop_amen
-    end
+in_thread do
+  loop do
+    sample :loop_amen
+    sleep sample_duration :loop_amen
   end
+end
 ```
 
 Go ahead and paste that into a buffer and press the Run button. Press
@@ -222,19 +222,19 @@ loops playing simultaneously.
 However, with named threads it is different:
 
 ```
-  in_thread(name: :amen) do
-    loop do
-      sample :loop_amen
-      sleep sample_duration :loop_amen
-    end
+in_thread(name: :amen) do
+  loop do
+    sample :loop_amen
+    sleep sample_duration :loop_amen
   end
+end
 ```
 
 Try pressing the Run button multiple times with this code. You'll only
 ever hear one amen break loop. You'll also see this in the log:
 
 ```
-  ==> Skipping thread creation: thread with name :amen already exists.
+==> Skipping thread creation: thread with name :amen already exists.
 ```
 
 Sonic Pi is telling you that a thread with the name `:amen` is already

--- a/etc/doc/tutorial/en/05.5-Functions.md
+++ b/etc/doc/tutorial/en/05.5-Functions.md
@@ -10,12 +10,12 @@ the ability to give a name to a bunch of code. Let's take a look.
 ## Defining functions
 
 ```
-  define :foo do
-    play 50
-    sleep 1
-    play 55
-    sleep 2
-  end
+define :foo do
+  play 50
+  sleep 1
+  play 55
+  sleep 2
+end
 ```
 
 Here, we've defined a new function called `foo`. We do this with our old
@@ -33,20 +33,20 @@ Once we have defined our function we can call it by just writing its
 name:
 
 ```
-  define :foo do
-    play 50
-    sleep 1
-    play 55
-    sleep 0.5
-  end
-  
-  foo
-  
+define :foo do
+  play 50
   sleep 1
-  
-  2.times do
-    foo
-  end
+  play 55
+  sleep 0.5
+end
+
+foo
+
+sleep 1
+
+2.times do
+  foo
+end
 ```
 
 We can even use `foo` inside iteration blocks or anywhere we may have
@@ -63,7 +63,7 @@ Sonic Pi *remembers* it. Let's try it. Delete all the code in your
 buffer and replace it with:
 
 ```
-  foo
+foo
 ```
 
 Press the Run button - and hear your function play. Where did the code
@@ -79,13 +79,13 @@ max values to `rrand`, you can teach your functions to accept
 arguments. Let's take a look:
 
 ```
-  define :my_player do |n|
-    play n
-  end
-  
-  my_player 80
-  sleep 0.5
-  my_player 90
+define :my_player do |n|
+  play n
+end
+
+my_player 80
+sleep 0.5
+my_player 90
 ```
 
 This isn't very exciting, but it illustrates the point. We've created
@@ -108,19 +108,19 @@ turns into `play 90`.
 Let's see a more interesting example:
 
 ``` 
-  define :chord_player do |root, repeats| 
-    repeats.times do
-      play chord(root, :minor), release: 0.3
-      sleep 0.5
-    end
+define :chord_player do |root, repeats| 
+  repeats.times do
+    play chord(root, :minor), release: 0.3
+    sleep 0.5
   end
-  
-  chord_player :e3, 2
-  sleep 0.5
-  chord_player :a3, 3
-  chord_player :g3, 4
-  sleep 0.5
-  chord_player :e3, 3
+end
+
+chord_player :e3, 2
+sleep 0.5
+chord_player :a3, 3
+chord_player :g3, 4
+sleep 0.5
+chord_player :e3, 3
 ```
 
 Here I used `repeats` as if it was a number in the line `repeats.times

--- a/etc/doc/tutorial/en/05.6-Variables.md
+++ b/etc/doc/tutorial/en/05.6-Variables.md
@@ -7,7 +7,7 @@ Pi makes this very easy, you write the name you wish to use, an equal
 sign (`=`), then the thing you want to remember:
 
 ```
-  sample_name = :loop_amen
+sample_name = :loop_amen
 ```
 
 Here, we've 'remembered' the symbol `:loop_amen` in the variable
@@ -15,8 +15,8 @@ Here, we've 'remembered' the symbol `:loop_amen` in the variable
 used `:loop_amen`. For example:
 
 ```
-  sample_name = :loop_amen
-  sample sample_name
+sample_name = :loop_amen
+sample sample_name
 ```
 
 There are three main reasons for using variables in Sonic Pi:
@@ -38,22 +38,22 @@ comments (as we saw in a previous section). Another is to use meaningful
 variable names. Look at this code:
 
 ```
-  sleep 1.7533
+sleep 1.7533
 ```
 
 Why does it use the number `1.7533`? Where did this number come from?
 What does it mean? However, look at this code:
 
 ```
-  loop_amen_duration = 1.7533
-  sleep loop_amen_duration
+loop_amen_duration = 1.7533
+sleep loop_amen_duration
 ```
 
 Now, it's much clearer what `1.7533` means: it's the duration of the
 sample `:loop_amen`! Of course, you might say why not simply write:
 
 ```
-  sleep sample_duration(:loop_amen)
+sleep sample_duration(:loop_amen)
 ```
 
 Which, of course, is a very nice way of communicating the intent of the
@@ -66,12 +66,12 @@ change things, you have to change it in a lot of places. Take a look at
 this code:
 
 ```
-  sample :loop_amen
-  sleep sample_duration(:loop_amen)
-  sample :loop_amen, rate: 0.5
-  sleep sample_duration(:loop_amen, rate: 0.5)
-  sample :loop_amen
-  sleep sample_duration(:loop_amen)
+sample :loop_amen
+sleep sample_duration(:loop_amen)
+sample :loop_amen, rate: 0.5
+sleep sample_duration(:loop_amen, rate: 0.5)
+sample :loop_amen
+sleep sample_duration(:loop_amen)
 ```
 
 We're doing a lot of things with `:loop_amen`! What if we wanted to
@@ -84,13 +84,13 @@ time - especially if you want to keep people dancing.
 What if you'd written your code like this:
 
 ```
-  sample_name = :loop_amen
-  sample sample_name
-  sleep sample_duration(sample_name)
-  sample sample_name, rate: 0.5
-  sleep sample_duration(sample_name, rate: 0.5)
-  sample sample_name
-  sleep sample_duration(sample_name)
+sample_name = :loop_amen
+sample sample_name
+sleep sample_duration(sample_name)
+sample sample_name, rate: 0.5
+sleep sample_duration(sample_name, rate: 0.5)
+sample sample_name
+sleep sample_duration(sample_name)
 ```
 
 Now, that does exactly the same as above (try it). It also gives us
@@ -105,7 +105,7 @@ of things. For example, you may wish to do things with the duration of a
 sample:
 
 ```
-  sd = sample_duration(:loop_amen)
+sd = sample_duration(:loop_amen)
 ```
 
 We can now use `sd` anywhere we need the duration of the `:loop_amen`
@@ -115,16 +115,16 @@ Perhaps more importantly, a variable allows us to capture the result
 of a call to `play` or `sample`:
 
 ```
-  s = play 50, release: 8
+s = play 50, release: 8
 ```
 
 Now we have caught and remembered `s` as a variable, which allows us
 to control the synth as it is running:
 
 ```
-  s = play 50, release: 8
-  sleep 2
-  control s, note: 62
+s = play 50, release: 8
+sleep 2
+control s, note: 62
 ```
 
 We'll look into controlling synths in more detail in a later section.

--- a/etc/doc/tutorial/en/05.7-Thread-Synchronisation.md
+++ b/etc/doc/tutorial/en/05.7-Thread-Synchronisation.md
@@ -40,19 +40,19 @@ or a long time away.
 Let's explore this in a little more detail:
 
 ```
-  in_thread do
-    loop do
-      cue :tick
-      sleep 1
-    end
+in_thread do
+  loop do
+    cue :tick
+    sleep 1
   end
-  
-  in_thread do
-    loop do
-      sync :tick
-      sample :drum_heavy_kick
-    end
+end
+
+in_thread do
+  loop do
+    sync :tick
+    sample :drum_heavy_kick
   end
+end
 ```
 
 Here we have two threads - one acting like a metronome, not playing any
@@ -65,21 +65,21 @@ the other thread sends the `:tick` message, even if the two threads
 didn't start their execution at the same time:
 
 ```
-  in_thread do
-    loop do
-      cue :tick
-      sleep 1
-    end
+in_thread do
+  loop do
+    cue :tick
+    sleep 1
   end
-  
-  sleep(0.3)
-  
-  in_thread do
-    loop do
-      sync :tick
-      sample :drum_heavy_kick
-    end
+end
+
+sleep(0.3)
+
+in_thread do
+  loop do
+    sync :tick
+    sample :drum_heavy_kick
   end
+end
 ```
 
 That naughty `sleep` call would typically make the second thread out
@@ -97,33 +97,33 @@ not just `:tick`. You just need to ensure that any other threads are
 Let's play with a few `cue` names:
 
 ```
-  in_thread do
-    loop do 
-      cue [:foo, :bar, :baz].choose
-      sleep 0.5
-    end
+in_thread do
+  loop do 
+    cue [:foo, :bar, :baz].choose
+    sleep 0.5
   end
-  
-  in_thread do
-    loop do 
-      sync :foo 
-      sample :elec_beep
-    end
+end
+
+in_thread do
+  loop do 
+    sync :foo 
+    sample :elec_beep
   end
-  
-  in_thread do
-    loop do
-      sync :bar
-      sample :elec_flip
-    end
+end
+
+in_thread do
+  loop do
+    sync :bar
+    sample :elec_flip
   end
-  
-  in_thread do
-    loop do
-      sync :baz
-      sample :elec_blup
-    end
+end
+
+in_thread do
+  loop do
+    sync :baz
+    sample :elec_blup
   end
+end
 ```
 
 Here we have a main `cue` loop which is randomly sending one of the

--- a/etc/doc/tutorial/en/06-FX.md
+++ b/etc/doc/tutorial/en/06-FX.md
@@ -26,7 +26,9 @@ i.e. distortion -, then take another cable and connect (chain) a
 reverb pedal. The output of the reverb pedal can then be plugged into
 the amplifier:
 
-`Guitar -> Distortion -> Reverb -> Amplifier`
+```
+Guitar -> Distortion -> Reverb -> Amplifier
+```
 
 This is called FX chaining. Sonic Pi supports exactly
 this. Additionally, each pedal often has dials and sliders to allow

--- a/etc/doc/tutorial/en/06.1-Adding-FX.md
+++ b/etc/doc/tutorial/en/06.1-Adding-FX.md
@@ -15,13 +15,13 @@ If we want to use reverb we write `with_fx :reverb` as the special code
 to our block like this:
 
 ```
-  with_fx :reverb do
-    play 50
-    sleep 0.5
-    sample :elec_plip
-    sleep 0.5
-    play 62
-  end
+with_fx :reverb do
+  play 50
+  sleep 0.5
+  sample :elec_plip
+  sleep 0.5
+  play 62
+end
 ```
 
 Now play this code and you'll hear it played with reverb. It sounds
@@ -30,16 +30,16 @@ good, doesn't it! Everything sounds pretty nice with reverb.
 Now let's look what happens if we have code outside the do/end block:
 
 ```
-  with_fx :reverb do
-    play 50
-    sleep 0.5
-    sample :elec_plip
-    sleep 0.5
-    play 62
-  end
-  
-  sleep 1
-  play 55
+with_fx :reverb do
+  play 50
+  sleep 0.5
+  sample :elec_plip
+  sleep 0.5
+  play 62
+end
+
+sleep 1
+play 55
 ```
 
 Notice how the final `play 55` isn't played with reverb. This is because
@@ -49,19 +49,19 @@ Similarly, if you make sounds before the do/end block, they also won't
 be captured:
 
 ```
-  play 55
-  sleep 1
-  
-  with_fx :reverb do
-    play 50
-    sleep 0.5
-    sample :elec_plip
-    sleep 0.5
-    play 62
-  end
-  
-  sleep 1
-  play 55
+play 55
+sleep 1
+
+with_fx :reverb do
+  play 50
+  sleep 0.5
+  sample :elec_plip
+  sleep 0.5
+  play 62
+end
+
+sleep 1
+play 55
 ```
 
 ## Echo
@@ -69,13 +69,13 @@ be captured:
 There are many FX to choose from. How about some echo?
 
 ```
-  with_fx :echo do
-    play 50
-    sleep 0.5
-    sample :elec_plip
-    sleep 0.5
-    play 62
-  end
+with_fx :echo do
+  play 50
+  sleep 0.5
+  sample :elec_plip
+  sleep 0.5
+  play 62
+end
 ```
 
 One of the powerful aspects of Sonic Pi's FX blocks is that they may be
@@ -85,38 +85,38 @@ which represents the duration of a given echo in beats. Let's make the
 echo slower:
 
 ```
-  with_fx :echo, phase: 0.5 do
-    play 50
-    sleep 0.5
-    sample :elec_plip
-    sleep 0.5
-    play 62
-  end
+with_fx :echo, phase: 0.5 do
+  play 50
+  sleep 0.5
+  sample :elec_plip
+  sleep 0.5
+  play 62
+end
 ```
 
 Let's also make the echo faster:
 
 ```
-  with_fx :echo, phase: 0.125 do
-    play 50
-    sleep 0.5
-    sample :elec_plip
-    sleep 0.5
-    play 62
-  end
+with_fx :echo, phase: 0.125 do
+  play 50
+  sleep 0.5
+  sample :elec_plip
+  sleep 0.5
+  play 62
+end
 ```
 
 Let's make the echo take longer to fade away by setting the `decay:`
 time to 8 beats:
 
 ```
-  with_fx :echo, phase: 0.5, decay: 8 do
-    play 50
-    sleep 0.5
-    sample :elec_plip
-    sleep 0.5
-    play 62
-  end
+with_fx :echo, phase: 0.5, decay: 8 do
+  play 50
+  sleep 0.5
+  sample :elec_plip
+  sleep 0.5
+  play 62
+end
 ```
 
 ## Nesting FX
@@ -127,15 +127,15 @@ what if you wanted to play some code with echo and then with reverb?
 Easy, just put one inside the other:
 
 ```
-  with_fx :reverb do
-    with_fx :echo, phase: 0.5, decay: 8 do
-      play 50
-      sleep 0.5
-      sample :elec_blup
-      sleep 0.5
-      play 62
-    end
+with_fx :reverb do
+  with_fx :echo, phase: 0.5, decay: 8 do
+    play 50
+    sleep 0.5
+    sample :elec_blup
+    sleep 0.5
+    play 62
   end
+end
 ```
 
 Think about the audio flowing from the inside out. The sound of all

--- a/etc/doc/tutorial/en/06.2-FX-in-Practice.md
+++ b/etc/doc/tutorial/en/06.2-FX-in-Practice.md
@@ -12,12 +12,12 @@ you want to ensure the beats keep flowing.
 Consider this code:
 
 ```
-  loop do
-    with_fx :reverb do
-      play 60, release: 0.1
-      sleep 0.125
-    end
+loop do
+  with_fx :reverb do
+    play 60, release: 0.1
+    sleep 0.125
   end
+end
 ```
 
 In this code we're playing note 60 with a very short release time, so
@@ -39,12 +39,12 @@ guitarist has just *one* reverb pedal which all sounds pass through?
 Simple:
 
 ```
-  with_fx :reverb do
-    loop do
-      play 60, release: 0.1
-      sleep 0.125
-    end
+with_fx :reverb do
+  loop do
+    play 60, release: 0.1
+    sleep 0.125
   end
+end
 ```
 
 We put our loop *inside* the `with_fx` block. This way we only create
@@ -54,14 +54,14 @@ more efficient and would work fine on a Raspberry Pi.
 A compromise is to use `with_fx` over an iteration within a loop:
 
 ```
-  loop do
-    with_fx :reverb do
-      16.times do
-        play 60, release: 0.1
-        sleep 0.125
-      end
+loop do
+  with_fx :reverb do
+    16.times do
+      play 60, release: 0.1
+      sleep 0.125
     end
   end
+end
 ```
 
 This way we've lifted the `with_fx` out of the inner part of the `loop`
@@ -71,12 +71,12 @@ This is such a common pattern that `with_fx` supports an opt to do
 exactly this but without having to write the `16.times` block:
 
 ```
-  loop do
-    with_fx :reverb, reps: 16 do
-      play 60, release: 0.1
-      sleep 0.125
-    end
+loop do
+  with_fx :reverb, reps: 16 do
+    play 60, release: 0.1
+    sleep 0.125
   end
+end
 ```
 
 Both the `reps: 16` and `16.times do` examples will behave

--- a/etc/doc/tutorial/en/07.1-Controlling-Running-Synths.md
+++ b/etc/doc/tutorial/en/07.1-Controlling-Running-Synths.md
@@ -8,7 +8,7 @@ currently running sounds. We do this by using a variable to capture a
 reference to a synth:
 
 ```
-  s = play 60, release: 5
+s = play 60, release: 5
 ```
 
 Here, we have a run-local variable `s` which represents the synth
@@ -19,13 +19,13 @@ Once we have `s`, we can start controlling it via the `control`
 function:
 
 ```
-  s = play 60, release: 5
-  sleep 0.5
-  control s, note: 65
-  sleep 0.5
-  control s, note: 67
-  sleep 3
-  control s, note: 72
+s = play 60, release: 5
+sleep 0.5
+control s, note: 65
+sleep 0.5
+control s, note: 67
+sleep 3
+control s, note: 72
 ```
 
 The thing to notice is that we're not triggering 4 different synths here

--- a/etc/doc/tutorial/en/07.2-Controlling-FX.md
+++ b/etc/doc/tutorial/en/07.2-Controlling-FX.md
@@ -6,16 +6,16 @@ It is also possible to control FX, although this is achieved in a
 slightly different way:
 
 ```
-  with_fx :reverb do |r|
-    play 50
-    sleep 0.5
-    control r, mix: 0.7
-    play 55
-    sleep 1
-    control r, mix: 0.9
-    sleep 1
-    play 62
-  end
+with_fx :reverb do |r|
+  play 50
+  sleep 0.5
+  control r, mix: 0.7
+  play 55
+  sleep 1
+  control r, mix: 0.9
+  sleep 1
+  play 62
+end
 ```
 
 Instead of using a variable, we use the goalpost parameters of the

--- a/etc/doc/tutorial/en/07.3-Sliding-Parameters.md
+++ b/etc/doc/tutorial/en/07.3-Sliding-Parameters.md
@@ -11,13 +11,13 @@ you control synths as introduced in the previous section.
 Consider the following example:
 
 ```
-  s = play 60, release: 5
-  sleep 0.5
-  control s, note: 65
-  sleep 0.5
-  control s, note: 67
-  sleep 3
-  control s, note: 72
+s = play 60, release: 5
+sleep 0.5
+control s, note: 65
+sleep 0.5
+control s, note: 67
+sleep 3
+control s, note: 72
 ```
 
 Here, you can hear the synth pitch changing immediately on each
@@ -26,13 +26,13 @@ changes. As we're controlling the `note:` parameter, to add slide, we
 need to set the `note_slide` parameter of the synth:
 
 ```
-  s = play 60, release: 5, note_slide: 1
-  sleep 0.5
-  control s, note: 65
-  sleep 0.5
-  control s, note: 67
-  sleep 3
-  control s, note: 72
+s = play 60, release: 5, note_slide: 1
+sleep 0.5
+control s, note: 65
+sleep 0.5
+control s, note: 67
+sleep 3
+control s, note: 72
 ```
 
 Now we hear the notes being bent between the `control` calls. It
@@ -55,11 +55,11 @@ the next `control` call.
 It is also possible to slide FX opts:
 
 ```
-  with_fx :wobble, phase: 1, phase_slide: 5 do |e|
-    use_synth :dsaw
-    play 50, release: 5
-    control e, phase: 0.025
-  end
+with_fx :wobble, phase: 1, phase_slide: 5 do |e|
+  use_synth :dsaw
+  play 50, release: 5
+  control e, phase: 0.025
+end
 ```
 
 Now have fun sliding things around for smooth transitions and flowing

--- a/etc/doc/tutorial/en/08.1-Lists.md
+++ b/etc/doc/tutorial/en/08.1-Lists.md
@@ -7,7 +7,7 @@ useful - the list. We met it very briefly before in the section on
 randomisation when we randomly chose from a list of notes to play:
 
 ```
-  play choose([50, 55, 62])
+play choose([50, 55, 62])
 ```
 
 In this section we'll explore using lists to also represent chords
@@ -15,9 +15,9 @@ and scales. First let's recap how we might play a chord. Remember that
 if we don't use `sleep`, sounds all happen at the same time:
 
 ```
-  play 52
-  play 55
-  play 59
+play 52
+play 55
+play 59
 ```
 
 Let's look at other ways to represent this code.
@@ -29,21 +29,21 @@ friendly `play` function is smart enough to know how to play a list of
 notes. Try it:
 
 ```
-  play [52, 55, 59]
+play [52, 55, 59]
 ```
 
 Ooh, that's already nicer to read. Playing a list of notes doesn't stop
 you from using any of the parameters as normal:
 
 ```
-  play [52, 55, 59], amp: 0.3
+play [52, 55, 59], amp: 0.3
 ```
 
 Of course, you can also use the traditional note names instead of the
 MIDI numbers:
 
 ```
-  play [:E3, :G3, :B3]
+play [:E3, :G3, :B3]
 ```
 
 Now those of you lucky enough to have studied some music theory might
@@ -62,7 +62,7 @@ With list indexes we don't count 1, 2, 3... Instead we count 0, 1, 2...
 Let's look at this in a little more detail. Take a look at this list:
 
 ```
-  [52, 55, 59]
+[52, 55, 59]
 ```
 
 There's nothing especially scary about this. Now, what's the second
@@ -70,7 +70,7 @@ element in that list? Yes, of course, it's `55`. That was easy. Let's
 see if we can get the computer to answer it for us too:
 
 ```
-  puts [52, 55, 59][1]
+puts [52, 55, 59][1]
 ```
 
 OK, that looks a bit weird if you've never seen anything like it
@@ -83,8 +83,8 @@ our index with square brackets and because counting starts at `0`, the
 index for the second element is `1`. Look:
 
 ```
-  # indexes:  0   1   2
-             [52, 55, 59]
+# indexes:  0   1   2
+           [52, 55, 59]
 ```
 
 Try running the code `puts [52, 55, 59][1]` and you'll see `55` pop up

--- a/etc/doc/tutorial/en/08.2-Chords.md
+++ b/etc/doc/tutorial/en/08.2-Chords.md
@@ -6,7 +6,7 @@ Sonic Pi has built-in support for chord names which will return
 lists. Try it for yourself:
 
 ```
-  play chord(:E3, :minor)
+play chord(:E3, :minor)
 ```
 
 Now, we're really getting somewhere. That looks a lot more pretty than
@@ -24,7 +24,7 @@ We can easily turn chords into arpeggios with the function
 `play_pattern`:
 
 ```
-  play_pattern chord(:E3, :m7)
+play_pattern chord(:E3, :m7)
 ```
 
 Ok, that's not so fun - it played it really slowly. `play_pattern` will
@@ -33,32 +33,32 @@ each call to `play`. We can use another function `play_pattern_timed` to
 specify our own timings and speed things up:
 
 ```
-  play_pattern_timed chord(:E3, :m7), 0.25
+play_pattern_timed chord(:E3, :m7), 0.25
 ```
 
 We can even pass a list of times which it will treat as a circle of
 times:
 
 ```
-  play_pattern_timed chord(:E3, :m13), [0.25, 0.5]
+play_pattern_timed chord(:E3, :m13), [0.25, 0.5]
 ```
 
 This is the equivalent to:
 
 ```
-  play 52
-  sleep 0.25
-  play 55
-  sleep 0.5
-  play 59
-  sleep 0.25
-  play 62
-  sleep 0.5
-  play 66
-  sleep 0.25
-  play 69
-  sleep 0.5
-  play 73
+play 52
+sleep 0.25
+play 55
+sleep 0.5
+play 59
+sleep 0.25
+play 62
+sleep 0.5
+play 66
+sleep 0.25
+play 69
+sleep 0.5
+play 73
 ```
 
 Which would you prefer to write?

--- a/etc/doc/tutorial/en/08.3-Scales.md
+++ b/etc/doc/tutorial/en/08.3-Scales.md
@@ -6,19 +6,19 @@ Sonic Pi has support for a wide range of scales. How about
 playing a C3 major scale?
 
 ```
-  play_pattern_timed scale(:c3, :major), 0.125, release: 0.1
+play_pattern_timed scale(:c3, :major), 0.125, release: 0.1
 ```
 
 We can even ask for more octaves:
 
 ```
-  play_pattern_timed scale(:c3, :major, num_octaves: 3), 0.125, release: 0.1
+play_pattern_timed scale(:c3, :major, num_octaves: 3), 0.125, release: 0.1
 ```
 
 How about all the notes in a pentatonic scale?
 
 ```
-  play_pattern_timed scale(:c3, :major_pentatonic, num_octaves: 3), 0.125, release: 0.1
+play_pattern_timed scale(:c3, :major_pentatonic, num_octaves: 3), 0.125, release: 0.1
 ```
 
 ## Random notes
@@ -28,11 +28,11 @@ something meaningful. Have a play with this example which picks random
 notes from the chord E3 minor:
 
 ```
-  use_synth :tb303
-  loop do
-    play choose(chord(:E3, :minor)), release: 0.3, cutoff: rrand(60, 120)
-    sleep 0.25
-  end
+use_synth :tb303
+loop do
+  play choose(chord(:E3, :minor)), release: 0.3, cutoff: rrand(60, 120)
+  sleep 0.25
+end
 ```
 
 Try switching in different chord names and cutoff ranges.

--- a/etc/doc/tutorial/en/08.4-Rings.md
+++ b/etc/doc/tutorial/en/08.4-Rings.md
@@ -10,7 +10,7 @@ In the previous section on lists we saw how we could fetch elements out
 of them by using the indexing mechanism:
 
 ```
-  puts [52, 55, 59][1]
+puts [52, 55, 59][1]
 ```
 
 Now, what happens if you want index `100`? Well, there's clearly no
@@ -21,22 +21,22 @@ However, consider you have a counter such as the current beat which
 continually increases. Let's create our counter and our list:
 
 ```
-  counter = 0
-  notes = [52, 55, 59]
+counter = 0
+notes = [52, 55, 59]
 ```
 
 We can now use our counter to access a note in our list:
 
 ```
-  puts notes[counter]
+puts notes[counter]
 ```
 
 Great, we got `52`. Now, let's increment our counter and get another
 note:
 
 ```
-  counter = (inc counter)
-  puts notes[counter]
+counter = (inc counter)
+puts notes[counter]
 ```
 
 Super, we now get `55` and if we do it again we get `59`. However, if we
@@ -50,14 +50,14 @@ We can create rings one of two ways. Either we use the `ring` function
 with the elements of the ring as parameters:
 
 ```
-  (ring 52, 55, 59)
+(ring 52, 55, 59)
 ```
 
 Or we can take a normal list and convert it to a ring by sending it the
 `.ring` message:
 
 ```
-  [52, 55, 59].ring
+[52, 55, 59].ring
 ```
 
 ## Indexing Rings
@@ -68,11 +68,11 @@ negative or larger than the size of the ring and they'll wrap round to
 always point at one of the ring's elements:
 
 ```
-  (ring 52, 55, 59)[0] #=> 52
-  (ring 52, 55, 59)[1] #=> 55
-  (ring 52, 55, 59)[2] #=> 59
-  (ring 52, 55, 59)[3] #=> 52
-  (ring 52, 55, 59)[-1] #=> 59
+(ring 52, 55, 59)[0] #=> 52
+(ring 52, 55, 59)[1] #=> 55
+(ring 52, 55, 59)[2] #=> 59
+(ring 52, 55, 59)[3] #=> 52
+(ring 52, 55, 59)[-1] #=> 59
 ```
 
 ## Using Rings

--- a/etc/doc/tutorial/en/08.5-Ring-Chains.md
+++ b/etc/doc/tutorial/en/08.5-Ring-Chains.md
@@ -9,26 +9,26 @@ of creating new rings is to manipulate existing rings.
 To explore this, take a simple ring:
 
 ```
-  (ring 10, 20, 30, 40, 50)
+(ring 10, 20, 30, 40, 50)
 ```
 
 What if we wanted it backwards? Well we'd use the chain command
 `.reverse` to take the ring and turn it around:
 
 ```
-  (ring 10, 20, 30, 40, 50).reverse  #=> (ring 50, 40, 30, 20, 10)
+(ring 10, 20, 30, 40, 50).reverse  #=> (ring 50, 40, 30, 20, 10)
 ```
 
 Now, what if we wanted the first three values from the ring?
 
 ```
-  (ring 10, 20, 30, 40, 50).take(3)  #=> (ring 10, 20, 30)
+(ring 10, 20, 30, 40, 50).take(3)  #=> (ring 10, 20, 30)
 ```
 
 Finally, what if we wanted to shuffle the ring?
 
 ```
-  (ring 10, 20, 30, 40, 50).shuffle  #=> (ring 40, 30, 10, 50, 20)
+(ring 10, 20, 30, 40, 50).shuffle  #=> (ring 40, 30, 10, 50, 20)
 ```
 
 ## Multiple Chains

--- a/etc/doc/tutorial/en/08.5-Ring-Chains.md
+++ b/etc/doc/tutorial/en/08.5-Ring-Chains.md
@@ -1,5 +1,7 @@
 8.5 Ring Chains
 
+# Ring Chains
+
 In addition to the constructors such as `range` and `spread` another way
 of creating new rings is to manipulate existing rings. 
 

--- a/etc/doc/tutorial/en/09.1-Live-Coding-Fundamentals.md
+++ b/etc/doc/tutorial/en/09.1-Live-Coding-Fundamentals.md
@@ -16,16 +16,16 @@ need a function containing the code we want to play. Let's start
 simple. We also want to loop calls to that function in a thread:
 
 ```
-  define :my_loop do
-    play 50
-    sleep 1
+define :my_loop do
+  play 50
+  sleep 1
+end
+
+in_thread(name: :looper) do
+  loop do
+    my_loop
   end
-  
-  in_thread(name: :looper) do
-    loop do
-      my_loop
-    end
-  end
+end
 ```
 
 If that looks a little too complicated to you, go back and re-read the
@@ -53,11 +53,11 @@ Try changing it again, change the note, change the sleep time. How about
 adding a `use_synth` statement? For example, change it to:
 
 ```
-  define :my_loop do
-    use_synth :tb303
-    play 50, release: 0.3
-    sleep 0.25
-  end
+define :my_loop do
+  use_synth :tb303
+  play 50, release: 0.3
+  sleep 0.25
+end
 ```
 
 Now it sounds pretty interesting, but we can spice it up
@@ -65,42 +65,42 @@ further. Instead of playing the same note again and again, try playing
 a chord:
 
 ```
-  define :my_loop do
-    use_synth :tb303
-    play chord(:e3, :minor), release: 0.3
-    sleep 0.5
-  end
+define :my_loop do
+  use_synth :tb303
+  play chord(:e3, :minor), release: 0.3
+  sleep 0.5
+end
 ```
 
 How about playing random notes from the chord:
 
 ```
-  define :my_loop do
-    use_synth :tb303
-    play choose(chord(:e3, :minor)), release: 0.3
-    sleep 0.25
-  end
+define :my_loop do
+  use_synth :tb303
+  play choose(chord(:e3, :minor)), release: 0.3
+  sleep 0.25
+end
 ```
 
 Or using a random cutoff value:
 
 ```
-  define :my_loop do
-    use_synth :tb303
-    play choose(chord(:e3, :minor)), release: 0.2, cutoff: rrand(60, 130)
-    sleep 0.25
-  end
+define :my_loop do
+  use_synth :tb303
+  play choose(chord(:e3, :minor)), release: 0.2, cutoff: rrand(60, 130)
+  sleep 0.25
+end
 ```
 
 Finally, add some drums:
 
 ```
-  define :my_loop do
-    use_synth :tb303
-    sample :drum_bass_hard, rate: rrand(0.5, 2)
-    play choose(chord(:e3, :minor)), release: 0.2, cutoff: rrand(60, 130)
-    sleep 0.25
-  end
+define :my_loop do
+  use_synth :tb303
+  sample :drum_bass_hard, rate: rrand(0.5, 2)
+  play choose(chord(:e3, :minor)), release: 0.2, cutoff: rrand(60, 130)
+  sleep 0.25
+end
 ```
 
 Now things are getting exciting! 

--- a/etc/doc/tutorial/en/09.2-Live-Loops.md
+++ b/etc/doc/tutorial/en/09.2-Live-Loops.md
@@ -13,10 +13,10 @@ jam with Sonic Pi.
 Let's play. Write the following in a new buffer:
 
 ```
-  live_loop :foo do
-    play 60
-    sleep 1
-  end
+live_loop :foo do
+  play 60
+  sleep 1
+end
 ```
 
 Now press the Run button. You hear a basic beep every beat. Nothing
@@ -28,11 +28,11 @@ Woah! It changed *automatically* without missing a beat. This is live coding.
 Why not change it to be more bass like? Just update your code whilst it's playing:
 
 ```
-  live_loop :foo do
-    use_synth :prophet
-    play :e1, release: 8
-    sleep 8
-  end
+live_loop :foo do
+  use_synth :prophet
+  play :e1, release: 8
+  sleep 8
+end
 ```
 
 Then hit Run.
@@ -40,11 +40,11 @@ Then hit Run.
 Let's make the cutoff move around:
 
 ```
-  live_loop :foo do
-    use_synth :prophet
-    play :e1, release: 8, cutoff: rrand(70, 130)
-    sleep 8
-  end
+live_loop :foo do
+  use_synth :prophet
+  play :e1, release: 8, cutoff: rrand(70, 130)
+  sleep 8
+end
 ```
 
 Hit Run again.
@@ -52,23 +52,23 @@ Hit Run again.
 Add some drums:
 
 ```
-  live_loop :foo do
-    sample :loop_garzul
-    use_synth :prophet
-    play :e1, release: 8, cutoff: rrand(70, 130)
-    sleep 8
-  end
+live_loop :foo do
+  sample :loop_garzul
+  use_synth :prophet
+  play :e1, release: 8, cutoff: rrand(70, 130)
+  sleep 8
+end
 ```
 
 Change the note from `e1` to `c1`:
 
 ```
-  live_loop :foo do
-    sample :loop_garzul
-    use_synth :prophet
-    play :c1, release: 8, cutoff: rrand(70, 130)
-    sleep 8
-  end
+live_loop :foo do
+  sample :loop_garzul
+  use_synth :prophet
+  play :c1, release: 8, cutoff: rrand(70, 130)
+  sleep 8
+end
 ```
 
 Now stop listening to me and play around yourself! Have fun!

--- a/etc/doc/tutorial/en/09.3-Multiple-Live-Loops.md
+++ b/etc/doc/tutorial/en/09.3-Multiple-Live-Loops.md
@@ -5,10 +5,10 @@
 Consider the following live loop:
 
 ```
-  live_loop :foo do
-    play 50
-    sleep 1
-  end
+live_loop :foo do
+  play 50
+  sleep 1
+end
 ```
 
 You may have wondered why it needs the name `:foo`. This name is
@@ -21,16 +21,16 @@ This means that if we want multiple concurrently running live loops, we
 just need to give them different names:
 
 ```
-  live_loop :foo do
-    use_synth :prophet
-    play :c1, release: 8, cutoff: rrand(70, 130)
-    sleep 8
-  end
-  
-  live_loop :bar do
-    sample :bd_haus
-    sleep 0.5
-  end
+live_loop :foo do
+  use_synth :prophet
+  play :c1, release: 8, cutoff: rrand(70, 130)
+  sleep 8
+end
+
+live_loop :bar do
+  sample :bd_haus
+  sleep 0.5
+end
 ```
 
 You can now update and change each live loop independently and it all
@@ -47,15 +47,15 @@ cues to ensure our loops are in sync without having to stop anything.
 Consider this badly synced code:
 
 ```
-  live_loop :foo do
-    play :e4, release: 0.5
-    sleep 0.4
-  end
-  
-  live_loop :bar do
-    sample :bd_haus
-    sleep 1
-  end
+live_loop :foo do
+  play :e4, release: 0.5
+  sleep 0.4
+end
+
+live_loop :bar do
+  sample :bd_haus
+  sleep 1
+end
 ```
 
 Let's see if we can fix the timing and sync without stopping it. First,
@@ -63,15 +63,15 @@ let's fix the `:foo` loop to make the sleep a factor of 1 - something like
 `0.5` will do:
 
 ```
-  live_loop :foo do
-    play :e4, release: 0.5
-    sleep 0.5
-  end
-  
-  live_loop :bar do
-    sample :bd_haus
-    sleep 1
-  end
+live_loop :foo do
+  play :e4, release: 0.5
+  sleep 0.5
+end
+
+live_loop :bar do
+  sample :bd_haus
+  sleep 1
+end
 ```
 
 We're not quite finished yet though - you'll notice that the beats don't
@@ -79,16 +79,16 @@ quite line up correctly. This is because the loops are *out of
 phase*. Let's fix that by syncing one to the other:
 
 ```
-  live_loop :foo do
-    play :e4, release: 0.5
-    sleep 0.5
-  end
-  
-  live_loop :bar do
-    sync :foo
-    sample :bd_haus
-    sleep 1
-  end
+live_loop :foo do
+  play :e4, release: 0.5
+  sleep 0.5
+end
+
+live_loop :bar do
+  sync :foo
+  sample :bd_haus
+  sleep 1
+end
 ```
 
 Wow, everything is now perfectly in time - all without stopping.

--- a/etc/doc/tutorial/en/09.4-Ticking.md
+++ b/etc/doc/tutorial/en/09.4-Ticking.md
@@ -15,21 +15,21 @@ like a current beat number. Tick just implements this idea. It provides
 you with the ability to *tick through rings*. Let's look at an example:
 
 ```
-  counter = 0
-  live_loop :arp do
-    play (scale :e3, :minor_pentatonic)[counter], release: 0.1
-    counter += 1
-    sleep 0.125
-  end
+counter = 0
+live_loop :arp do
+  play (scale :e3, :minor_pentatonic)[counter], release: 0.1
+  counter += 1
+  sleep 0.125
+end
 ```
 
 This is equivalent to:
 
 ```
-  live_loop :arp do
-    play (scale :e3, :minor_pentatonic).tick, release: 0.1
-    sleep 0.125
-  end
+live_loop :arp do
+  play (scale :e3, :minor_pentatonic).tick, release: 0.1
+  sleep 0.125
+end
 ```
 
 Here, we're just grabbing the scale E3 minor pentatonic and ticking 
@@ -38,16 +38,16 @@ scale declaration. This tick is local to the live loop, so each live
 loop can have its own independent tick:
 
 ```
-  live_loop :arp do
-    play (scale :e3, :minor_pentatonic).tick, release: 0.1
-    sleep 0.125
-  end
-  
-  live_loop :arp2 do
-    use_synth :dsaw
-    play (scale :e2, :minor_pentatonic, num_octaves: 3).tick, release: 0.25
-    sleep 0.25
-  end
+live_loop :arp do
+  play (scale :e3, :minor_pentatonic).tick, release: 0.1
+  sleep 0.125
+end
+
+live_loop :arp2 do
+  use_synth :dsaw
+  play (scale :e2, :minor_pentatonic, num_octaves: 3).tick, release: 0.25
+  sleep 0.25
+end
 ```
 
 ## Tick
@@ -55,11 +55,11 @@ loop can have its own independent tick:
 You can also call `tick` as a standard fn and use the value as an index:
 
 ```
-  live_loop :arp do
-    idx = tick
-    play (scale :e3, :minor_pentatonic)[idx], release: 0.1
-    sleep 0.125
-  end
+live_loop :arp do
+  idx = tick
+  play (scale :e3, :minor_pentatonic)[idx], release: 0.1
+  sleep 0.125
+end
 ```
 
 However, it is much nicer to call `.tick` at the end. The `tick` fn is
@@ -84,10 +84,10 @@ Finally, sometimes you'll need more than one tick per live loop. This
 is achieved by giving your tick a name:
 
 ```
-  live_loop :arp do
-    play (scale :e3, :minor_pentatonic).tick(:foo), release: 0.1
-    sleep (ring 0.125, 0.25).tick(:bar)
-  end
+live_loop :arp do
+  play (scale :e3, :minor_pentatonic).tick(:foo), release: 0.1
+  sleep (ring 0.125, 0.25).tick(:bar)
+end
 ```
 
 Here we're using two ticks one for the note to play and another for the

--- a/etc/doc/tutorial/en/11.1-Basic-API.md
+++ b/etc/doc/tutorial/en/11.1-Basic-API.md
@@ -23,7 +23,7 @@ walk around.
 In a fresh Sonic Pi buffer simply enter the following code:
 
 ```
-  mc_message "Hello from Sonic Pi"
+mc_message "Hello from Sonic Pi"
 ```
 
 When you hit the *Run* button, you'll see your message flash up on the
@@ -36,7 +36,7 @@ Now, let's try a little magic. Let's teleport ourselves somewhere! Try
 the following:
 
 ```
-  mc_teleport 50, 50, 50
+mc_teleport 50, 50, 50
 ```
 
 When you hit *Run* - boom! You're instantantly transported to a new
@@ -74,7 +74,7 @@ Let's have a play with coordinates. Navigate to a nice place in the
 Minecraft map and then switch over to Sonic Pi. Now enter the following:
 
 ```
-  puts mc_location
+puts mc_location
 ```
 
 When you hit the *Run* button you'll see the coordinates of your current
@@ -94,21 +94,21 @@ Minecraft with code. Let's say you want to make the block with
 coordinates `40`, `50`, `60` to be glass. That's super easy:
 
 ```
-  mc_set_block :glass, 40, 50, 60
+mc_set_block :glass, 40, 50, 60
 ```
 
 Haha, it really was that easy. To see your handywork just teleport
 nearby and take a look:
 
 ```
-  mc_teleport 35, 50, 60
+mc_teleport 35, 50, 60
 ```
 
 Now turn around and you should see your glass block! Try changing it to
 diamond:
 
 ```
-  mc_set_block :diamond, 40, 50, 60
+mc_set_block :diamond, 40, 50, 60
 ```
 
 If you were looking in the right direction you might have even seen it
@@ -122,7 +122,7 @@ of a specific block is. Let's try it with the diamond block you just
 created:
 
 ```
-  puts mc_get_block 40, 50, 60
+puts mc_get_block 40, 50, 60
 ```
 
 Yey! It's `:diamond`. Try changing it back to glass and asking again -

--- a/etc/doc/tutorial/en/A.01-tips.md
+++ b/etc/doc/tutorial/en/A.01-tips.md
@@ -30,42 +30,42 @@ like the FX added to and wrap it with the FX code. Let's look at an
 example. Say you had the following code:
 
 ```
-  sample :loop_garzul
-  
-  16.times do
-    sample :bd_haus
-    sleep 0.5
-  end
+sample :loop_garzul
+
+16.times do
+  sample :bd_haus
+  sleep 0.5
+end
 ```
 
 If you wanted to add FX to the `:loop_garzul` sample, you'd just tuck it
 inside a `with_fx` block like this:
 
 ```
-  with_fx :flanger do
-    sample :loop_garzul
-  end
-  
-  16.times do
-    sample :bd_haus
-    sleep 0.5
-  end
+with_fx :flanger do
+  sample :loop_garzul
+end
+
+16.times do
+  sample :bd_haus
+  sleep 0.5
+end
 ```
 
 Now, if you wanted to add FX to the bass drum, go and wrap that with
 `with_fx` too:
 
 ```
-  with_fx :flanger do
-    sample :loop_garzul
+with_fx :flanger do
+  sample :loop_garzul
+end
+
+with_fx :echo do
+  16.times do
+    sample :bd_haus
+    sleep 0.5
   end
-  
-  with_fx :echo do
-    16.times do
-      sample :bd_haus
-      sleep 0.5
-    end
-  end
+end
 ```
 
 Remember, you can wrap *any* code within `with_fx` and any sounds
@@ -83,14 +83,14 @@ opts for short. Let's take a quick look. Copy this code into a workspace
 and hit run:
 
 ```
-  sample :guit_em9
+sample :guit_em9
 ```
 
 Ooh, a lovely guitar sound! Now, let's start playing with it. How about
 changing its rate?
 
 ```
-  sample :guit_em9, rate: 0.5
+sample :guit_em9, rate: 0.5
 ```
 
 Hey, what's that `rate: 0.5` bit I just added at the end? That's called
@@ -98,9 +98,9 @@ an opt. All of Sonic Pi's synths and FX support them and there's loads
 to play around with. They're also available for FX too. Try this:
 
 ```
-  with_fx :flanger, feedback: 0.6 do
-    sample :guit_em9
-  end
+with_fx :flanger, feedback: 0.6 do
+  sample :guit_em9
+end
 ```
 
 Now, try increasing that feedback to 1 to hear some crazy sounds! Read the
@@ -116,10 +116,10 @@ the cutoff parameter does to a sample, just play around. Let's have a try!
 Copy this code into one of your Sonic Pi workspaces:
 
 ```
-  live_loop :experiment do
-    sample :loop_amen, cutoff: 70
-    sleep 1.75
-  end
+live_loop :experiment do
+  sample :loop_amen, cutoff: 70
+  sleep 1.75
+end
 ```
 
 Now, hit run and you'll hear a slightly muffled drum break. Now, change
@@ -139,14 +139,14 @@ randomisation. It might sound complicated but it really isn't. Let's
 take a look. Copy this into a spare workspace:
 
 ```
-  live_loop :rand_surfer do
-    use_synth :dsaw
-    notes = (scale :e2, :minor_pentatonic, num_octaves: 2)
-    16.times do
-      play notes.choose, release: 0.1, cutoff: rrand(70, 120)
-      sleep 0.125
-    end
+live_loop :rand_surfer do
+  use_synth :dsaw
+  notes = (scale :e2, :minor_pentatonic, num_octaves: 2)
+  16.times do
+    play notes.choose, release: 0.1, cutoff: rrand(70, 120)
+    sleep 0.125
   end
+end
 ```
 
 Now, when you play this, you'll hear a constant stream of random notes
@@ -159,15 +159,15 @@ Doctor to a particular point in time and space. Let's try it - add the
 line `use_random_seed 1` to the `live_loop`:
 
 ```
-  live_loop :rand_surfer do
-    use_random_seed 1
-    use_synth :dsaw
-    notes = (scale :e2, :minor_pentatonic, num_octaves: 2)
-    16.times do
-      play notes.choose, release: 0.1, cutoff: rrand(70, 120)
-      sleep 0.125
-    end
+live_loop :rand_surfer do
+  use_random_seed 1
+  use_synth :dsaw
+  notes = (scale :e2, :minor_pentatonic, num_octaves: 2)
+  16.times do
+    play notes.choose, release: 0.1, cutoff: rrand(70, 120)
+    sleep 0.125
   end
+end
 ```
 
 Now, every time the `live_loop` loops around, the random stream is

--- a/etc/doc/tutorial/en/A.02-live-coding.md
+++ b/etc/doc/tutorial/en/A.02-live-coding.md
@@ -30,10 +30,10 @@ The key to live coding with Sonic Pi is mastering the `live_loop`. Let's
 look at one:
 
 ```
-  live_loop :beats do
-    sample :bd_haus
-    sleep 0.5
-  end
+live_loop :beats do
+  sample :bd_haus
+  sleep 0.5
+end
 ```
 
 There are 4 core ingredients to a `live_loop`. The first is its
@@ -58,10 +58,10 @@ running, you can change what they do. This is the secret to live coding
 with Sonic Pi. Let's have a play:
 
 ```
-  live_loop :choral_drone do
-    sample :ambi_choir, rate: 0.4
-    sleep 1
-  end
+live_loop :choral_drone do
+  sample :ambi_choir, rate: 0.4
+  sleep 1
+end
 ```
 
 Now press the Run button or hit `alt-r`. You're now listening to
@@ -80,9 +80,9 @@ One of the most important lessons about `live_loop`s is that they need
 rest. Consider the following `live_loop`:
 
 ```
-  live_loop :infinite_impossibilities do
-    sample :ambi_choir
-  end
+live_loop :infinite_impossibilities do
+  sample :ambi_choir
+end
 ```
 
 If you try running this code, you'll immediately see Sonic Pi
@@ -103,19 +103,19 @@ us with an amazingly simple way of playing things at the same
 time. Simply use more than one `live_loop`!
 
 ```
-  live_loop :beats do
-    sample :bd_tek
-    with_fx :echo, phase: 0.125, mix: 0.4 do
-      sample  :drum_cymbal_soft, sustain: 0, release: 0.1
-      sleep 0.5
-    end
+live_loop :beats do
+  sample :bd_tek
+  with_fx :echo, phase: 0.125, mix: 0.4 do
+    sample  :drum_cymbal_soft, sustain: 0, release: 0.1
+    sleep 0.5
   end
-  
-  live_loop :bass do
-    use_synth :tb303
-    synth :tb303, note: :e1, release: 4, cutoff: 120, cutoff_attack: 1
-    sleep 4
-  end
+end
+
+live_loop :bass do
+  use_synth :tb303
+  synth :tb303, note: :e1, release: 4, cutoff: 120, cutoff_attack: 1
+  sleep 4
+end
 ```
 
 Here, we have two `live_loop`s, one looping quickly making beats and
@@ -127,19 +127,19 @@ interesting polyrhythmical structures and even play with phasing Steve
 Reich style. Check this out:
 
 ```
-  # Steve Reich's Piano Phase
-  
-  notes = (ring :E4, :Fs4, :B4, :Cs5, :D5, :Fs4, :E4, :Cs5, :B4, :Fs4, :D5, :Cs5)
-  
-  live_loop :slow do
-    play notes.tick, release: 0.1
-    sleep 0.3
-  end
-  
-  live_loop :faster do
-    play notes.tick, release: 0.1
-    sleep 0.295
-  end
+# Steve Reich's Piano Phase
+
+notes = (ring :E4, :Fs4, :B4, :Cs5, :D5, :Fs4, :E4, :Cs5, :B4, :Fs4, :D5, :Cs5)
+
+live_loop :slow do
+  play notes.tick, release: 0.1
+  sleep 0.3
+end
+
+live_loop :faster do
+  play notes.tick, release: 0.1
+  sleep 0.295
+end
 ```
 
 ## Bringing it all together
@@ -154,32 +154,32 @@ point for a new performance, and most of all have fun! See you next
 time...
 
 ```
-  with_fx :reverb, room: 1 do
-    live_loop :time do
-      synth :prophet, release: 8, note: :e1, cutoff: 90, amp: 3
-      sleep 8
+with_fx :reverb, room: 1 do
+  live_loop :time do
+    synth :prophet, release: 8, note: :e1, cutoff: 90, amp: 3
+    sleep 8
+  end
+end
+
+live_loop :machine do
+  sample :loop_garzul, rate: 0.5, finish: 0.25
+  sample :loop_industrial, beat_stretch: 4, amp: 1
+  sleep 4
+end
+
+live_loop :kik do
+  sample :bd_haus, amp: 2
+  sleep 0.5
+end
+
+with_fx :echo do
+  live_loop :vortex do
+    # use_random_seed 800
+    notes = (scale :e3, :minor_pentatonic, num_octaves: 3)
+    16.times do
+      play notes.choose, release: 0.1, amp: 1.5
+      sleep 0.125
     end
   end
-  
-  live_loop :machine do
-    sample :loop_garzul, rate: 0.5, finish: 0.25
-    sample :loop_industrial, beat_stretch: 4, amp: 1
-    sleep 4
-  end
-  
-  live_loop :kik do
-    sample :bd_haus, amp: 2
-    sleep 0.5
-  end
-  
-  with_fx :echo do
-    live_loop :vortex do
-      # use_random_seed 800
-      notes = (scale :e3, :minor_pentatonic, num_octaves: 3)
-      16.times do
-        play notes.choose, release: 0.1, amp: 1.5
-        sleep 0.125
-      end
-    end
-  end
+end
 ```

--- a/etc/doc/tutorial/en/A.03-coded-beats.md
+++ b/etc/doc/tutorial/en/A.03-coded-beats.md
@@ -31,7 +31,7 @@ I'm sure you're excited to hear that it's also built right into Sonic
 Pi. Clear up a buffer and throw in the following code:
 
 ```
-  sample :loop_amen
+sample :loop_amen
 ```
 
 Hit *Run* and boom! You're listening to one of the most influential
@@ -45,10 +45,10 @@ Let's loop the Amen Break by using our old friend the `live_loop`
 introduced in this tutorial last month:
 
 ```
-  live_loop :amen_break do
-    sample :loop_amen
-    sleep 2
-  end
+live_loop :amen_break do
+  sample :loop_amen
+  sleep 2
+end
 ```
 
 OK, so it is looping, but there's an annoying pause every time
@@ -66,10 +66,10 @@ of control via optional parameters such as `amp:`, `cutoff:` and
 we just call them *opts* to keep things nice and simple. 
 
 ```
-  live_loop :amen_break do
-    sample :loop_amen, beat_stretch: 2
-    sleep 2
-  end  
+live_loop :amen_break do
+  sample :loop_amen, beat_stretch: 2
+  sleep 2
+end  
 ```
 
 Now we're dancing! Although, perhaps we want to speed it up or slow it down
@@ -83,11 +83,11 @@ other words mess with the tempo. This is super easy in Sonic Pi - just
 throw in a `use_bpm` into your live loop:
 
 ```
-  live_loop :amen_break do
-    use_bpm 30
-    sample :loop_amen, beat_stretch: 2
-    sleep 2
-  end 
+live_loop :amen_break do
+  use_bpm 30
+  sample :loop_amen, beat_stretch: 2
+  sleep 2
+end 
 ```
 
 Whilst you're rapping over those slow beats, notice that we're still
@@ -108,11 +108,11 @@ cutoff filter of the sampler. By default this is disabled but you can
 easily turn it on:
 
 ```
-  live_loop :amen_break do
-    use_bpm 50
-    sample :loop_amen, beat_stretch: 2, cutoff: 70
-    sleep 2
-  end  
+live_loop :amen_break do
+  use_bpm 50
+  sample :loop_amen, beat_stretch: 2, cutoff: 70
+  sleep 2
+end  
 ```
 
 Go ahead and change the `cutoff:` opt. For example, increase it to 100,
@@ -131,13 +131,13 @@ Another great tool to play with is the slicer FX. This will chop (slice)
 the sound up. Wrap the `sample` line with the FX code like this:
 
 ```
-  live_loop :amen_break do
-    use_bpm 50
-    with_fx :slicer, phase: 0.25, wave: 0, mix: 1 do
-      sample :loop_amen, beat_stretch: 2, cutoff: 100
-    end
-    sleep 2
+live_loop :amen_break do
+  use_bpm 50
+  with_fx :slicer, phase: 0.25, wave: 0, mix: 1 do
+    sample :loop_amen, beat_stretch: 2, cutoff: 100
   end
+  sleep 2
+end
 ```
 
 Notice how the sound bounces up and down a little more. (You can hear
@@ -161,28 +161,28 @@ changing opt numbers and see where you can take it. Please do share what
 you create! See you next time...
 
 ```
-  use_bpm 100
-  
-  live_loop :amen_break do
-    p = [0.125, 0.25, 0.5].choose
-    with_fx :slicer, phase: p, wave: 0, mix: rrand(0.7, 1) do
-      r = [1, 1, 1, -1].choose
-      sample :loop_amen, beat_stretch: 2, rate: r, amp: 2
-    end
-    sleep 2
+use_bpm 100
+
+live_loop :amen_break do
+  p = [0.125, 0.25, 0.5].choose
+  with_fx :slicer, phase: p, wave: 0, mix: rrand(0.7, 1) do
+    r = [1, 1, 1, -1].choose
+    sample :loop_amen, beat_stretch: 2, rate: r, amp: 2
   end
-  
-  live_loop :bass_drum do
-    sample :bd_haus, cutoff: 70, amp: 1.5
-    sleep 0.5
+  sleep 2
+end
+
+live_loop :bass_drum do
+  sample :bd_haus, cutoff: 70, amp: 1.5
+  sleep 0.5
+end
+
+live_loop :landing do
+  bass_line = (knit :e1, 3, [:c1, :c2].choose, 1)
+  with_fx :slicer, phase: [0.25, 0.5].choose, invert_wave: 1, wave: 0 do
+    s = synth :square, note: bass_line.tick, sustain: 4, cutoff: 60
+    control s, cutoff_slide: 4, cutoff: 120
   end
-  
-  live_loop :landing do
-    bass_line = (knit :e1, 3, [:c1, :c2].choose, 1)
-    with_fx :slicer, phase: [0.25, 0.5].choose, invert_wave: 1, wave: 0 do
-      s = synth :square, note: bass_line.tick, sustain: 4, cutoff: 60
-      control s, cutoff_slide: 4, cutoff: 120
-    end
-    sleep 4
-  end
+  sleep 4
+end
 ```

--- a/etc/doc/tutorial/en/A.04-synth-riffs.md
+++ b/etc/doc/tutorial/en/A.04-synth-riffs.md
@@ -25,11 +25,11 @@ Let's create a simple live loop where we continually change the current
 synth:
 
 ```
-  live_loop :timbre do
-    use_synth (ring :tb303, :blade, :prophet, :saw, :beep, :tri).tick
-    play :e2, attack: 0, release: 0.5, cutoff: 100
-    sleep 0.5
-  end
+live_loop :timbre do
+  use_synth (ring :tb303, :blade, :prophet, :saw, :beep, :tri).tick
+  play :e2, attack: 0, release: 0.5, cutoff: 100
+  sleep 0.5
+end
 ```
 
 Take a look at the code. We're simply ticking through a ring of synth
@@ -69,12 +69,12 @@ want to play. If you already have a good idea, then you can simply
 create a ring with your notes in and tick through them:
 
 ```
-  live_loop :riff do
-    use_synth :prophet
-    riff = (ring :e3, :e3, :r, :g3, :r, :r, :r, :a3)
-    play riff.tick, release: 0.5, cutoff: 80
-    sleep 0.25
-  end
+live_loop :riff do
+  use_synth :prophet
+  riff = (ring :e3, :e3, :r, :g3, :r, :r, :r, :a3)
+  play riff.tick, release: 0.5, cutoff: 80
+  sleep 0.25
+end
 ```
     
 Here, we've defined our melody with a ring which includes both notes
@@ -89,13 +89,13 @@ choose the one you like the best. To do that we need to combine three
 things: rings, randomisation and random seeds. Let's look at an example:
 
 ```
-  live_loop :random_riff do
-    use_synth :dsaw
-    use_random_seed 3
-    notes = (scale :e3, :minor_pentatonic).shuffle
-    play notes.tick, release: 0.25, cutoff: 80
-    sleep 0.25
-  end
+live_loop :random_riff do
+  use_synth :dsaw
+  use_random_seed 3
+  notes = (scale :e3, :minor_pentatonic).shuffle
+  play notes.tick, release: 0.25, cutoff: 80
+  sleep 0.25
+end
 ```
 
 There's a few things going on - let's look at them in turn. First, we
@@ -138,15 +138,15 @@ rhythm. Instead of playing every note we can use a conditional to play a
 note with a given probability. Let's take a look:
 
 ```
-  live_loop :random_riff do
-    use_synth :dsaw
-    use_random_seed 30
-    notes = (scale :e3, :minor_pentatonic).shuffle
-    16.times do
-      play notes.tick, release: 0.2, cutoff: 90 if one_in(2)
-      sleep 0.125
-    end
+live_loop :random_riff do
+  use_synth :dsaw
+  use_random_seed 30
+  notes = (scale :e3, :minor_pentatonic).shuffle
+  16.times do
+    play notes.tick, release: 0.2, cutoff: 90 if one_in(2)
+    sleep 0.125
   end
+end
 ```
 
 A really useful fn to know is `one_in` which will give us a
@@ -169,28 +169,28 @@ OK, so let's combine everything we've learned together into one final
 example. See you next time!
 
 ```
-  live_loop :random_riff do
-    #  uncomment to bring in:
-    #  synth :blade, note: :e4, release: 4, cutoff: 100, amp: 1.5
-    use_synth :dsaw
-    use_random_seed 43
-    notes = (scale :e3, :minor_pentatonic, num_octaves: 2).shuffle.take(8)
-    8.times do
-      play notes.tick, release: rand(0.5), cutoff: rrand(60, 130) if one_in(2)
-      sleep 0.125
-    end
+live_loop :random_riff do
+  #  uncomment to bring in:
+  #  synth :blade, note: :e4, release: 4, cutoff: 100, amp: 1.5
+  use_synth :dsaw
+  use_random_seed 43
+  notes = (scale :e3, :minor_pentatonic, num_octaves: 2).shuffle.take(8)
+  8.times do
+    play notes.tick, release: rand(0.5), cutoff: rrand(60, 130) if one_in(2)
+    sleep 0.125
   end
-   
-  live_loop :drums do
-    use_random_seed 500
-    16.times do
-      sample :bd_haus, rate: 2, cutoff: 110 if rand < 0.35
-      sleep 0.125
-    end
+end
+ 
+live_loop :drums do
+  use_random_seed 500
+  16.times do
+    sample :bd_haus, rate: 2, cutoff: 110 if rand < 0.35
+    sleep 0.125
   end
-   
-  live_loop :bd do
-    sample :bd_haus, cutoff: 100, amp: 3
-    sleep 0.5
-  end
+end
+ 
+live_loop :bd do
+  sample :bd_haus, cutoff: 100, amp: 3
+  sleep 0.5
+end
 ```

--- a/etc/doc/tutorial/en/A.05-acid-bass.md
+++ b/etc/doc/tutorial/en/A.05-acid-bass.md
@@ -28,8 +28,8 @@ using the power of Sonic Pi. Behold, fire up Sonic Pi and throw this
 code into an empty buffer and hit Run:
 
 ```
-  use_synth :tb303
-  play :e1
+use_synth :tb303
+play :e1
 ```
     
 Instant acid bass! Let's play around...
@@ -42,12 +42,12 @@ through one after another, repeating when we get to the end. Let's
 create a live loop that does exactly that:
 
 ```
-  use_synth :tb303
-  live_loop :squelch do
-    n = (ring :e1, :e2, :e3).tick
-    play n, release: 0.125, cutoff: 100, res: 0.8, wave: 0
-    sleep 0.125
-  end
+use_synth :tb303
+live_loop :squelch do
+  n = (ring :e1, :e2, :e3).tick
+  play n, release: 0.125, cutoff: 100, res: 0.8, wave: 0
+  sleep 0.125
+end
 ```
 
 Take a look at each line. 
@@ -126,13 +126,13 @@ we have amazing control over the timbre of the sound by playing with
 both of these envelopes. Let's take a look:
 
 ```
-  use_synth :tb303
-  with_fx :reverb, room: 1 do
-    live_loop :space_scanner do
-      play :e1, cutoff: 100, release: 7, attack: 1, cutoff_attack: 4, cutoff_release: 4
-      sleep 8
-    end
+use_synth :tb303
+with_fx :reverb, room: 1 do
+  live_loop :space_scanner do
+    play :e1, cutoff: 100, release: 7, attack: 1, cutoff_attack: 4, cutoff_release: 4
+    sleep 8
   end
+end
 ```
     
 For each standard envelope opt, there's a `cutoff_` equivalent opt in
@@ -152,25 +152,25 @@ start live coding your own changes. See what crazy sounds you can make
 with it! See you next time...
 
 ```
-  use_synth :tb303
-  use_debug false
-   
-  with_fx :reverb, room: 0.8 do
-    live_loop :space_scanner do
-      with_fx :slicer, phase: 0.25, amp: 1.5 do
-        co = (line 70, 130, steps: 8).tick
-        play :e1, cutoff: co, release: 7, attack: 1, cutoff_attack: 4, cutoff_release: 4
-        sleep 8
-      end
-    end
-   
-    live_loop :squelch do
-      use_random_seed 3000
-      16.times do
-        n = (ring :e1, :e2, :e3).tick
-        play n, release: 0.125, cutoff: rrand(70, 130), res: 0.9, wave: 1, amp: 0.8
-        sleep 0.125
-      end
+use_synth :tb303
+use_debug false
+ 
+with_fx :reverb, room: 0.8 do
+  live_loop :space_scanner do
+    with_fx :slicer, phase: 0.25, amp: 1.5 do
+      co = (line 70, 130, steps: 8).tick
+      play :e1, cutoff: co, release: 7, attack: 1, cutoff_attack: 4, cutoff_release: 4
+      sleep 8
     end
   end
+ 
+  live_loop :squelch do
+    use_random_seed 3000
+    16.times do
+      n = (ring :e1, :e2, :e3).tick
+      play n, release: 0.125, cutoff: rrand(70, 130), res: 0.9, wave: 1, amp: 0.8
+      sleep 0.125
+    end
+  end
+end
 ```

--- a/etc/doc/tutorial/en/A.06-minecraft.md
+++ b/etc/doc/tutorial/en/A.06-minecraft.md
@@ -26,7 +26,7 @@ windows so you can see both Sonic Pi and Minecraft Pi at the same time.
 In a fresh buffer type the following:
 
 ```
-  mc_message "Hello Minecraft from Sonic Pi!"
+mc_message "Hello Minecraft from Sonic Pi!"
 ```
     
 Now, hit Run. Boom! Your message appeared in Minecraft! How easy was
@@ -43,7 +43,7 @@ slow and boring. It would be far better if we had some sort of teleport
 machine. Well, thanks to Sonic Pi, we have one. Try this:
 
 ```
-  mc_teleport 80, 40, 100
+mc_teleport 80, 40, 100
 ```
     
 Crikey! That was a long way up. If you weren't in flying-mode then you
@@ -70,17 +70,17 @@ Using the ideas so far, let's build a Sonic Teleporter which makes a fun
 teleport sound whilst it whizzes us across the Minecraft world:
 
 ```
-  mc_message "Preparing to teleport...."
-  sample :ambi_lunar_land, rate: -1
-  sleep 1
-  mc_message "3"
-  sleep 1
-  mc_message "2"
-  sleep 1
-  mc_message "1"
-  sleep 1
-  mc_teleport 90, 20, 10
-  mc_message "Whoooosh!"
+mc_message "Preparing to teleport...."
+sample :ambi_lunar_land, rate: -1
+sleep 1
+mc_message "3"
+sleep 1
+mc_message "2"
+sleep 1
+mc_message "1"
+sleep 1
+mc_teleport 90, 20, 10
+mc_message "Whoooosh!"
 ```
     
 ![Screen 1](../images/tutorial/articles/A.06-minecraft/Musical-Minecraft-1-small.png)
@@ -92,8 +92,8 @@ you're used to and start clicking the mouse furiously to place blocks
 under the cursor. Or you could use the magic of Sonic Pi. Try this:
 
 ```
-  x, y, z = mc_location
-  mc_set_block :melon, x, y + 5, z
+x, y, z = mc_location
+mc_set_block :melon, x, y + 5, z
 ```
 
 Now look up! There's a melon in the sky! Take a moment to look at the
@@ -105,11 +105,11 @@ order to make something higher up in the sky we just need to increase
 the y value which is why we add 5 to it. Let's make a long trail of them:
 
 ```
-  live_loop :melon_trail do
-    x, y, z = mc_location
-    mc_set_block :melon, x, y-1, z
-    sleep 0.125
-  end
+live_loop :melon_trail do
+  x, y, z = mc_location
+  mc_set_block :melon, x, y-1, z
+  sleep 0.125
+end
 ```
 
 Now, jump over to Minecraft, make sure you're in flying-mode (double tap
@@ -136,16 +136,16 @@ trail again. Now, without stopping the code, just simply change `:melon` to
 simple was that! Fancy some music to go with it? Easy. Try this:
 
 ```
-  live_loop :bass_trail do
-    tick
-    x, y, z = mc_location
-    b = (ring :melon, :brick, :glass).look
-    mc_set_block b, x, y -1, z
-    note = (ring :e1, :e2, :e3).look
-    use_synth :tb303
-    play note, release: 0.1, cutoff: 70
-    sleep 0.125
-  end
+live_loop :bass_trail do
+  tick
+  x, y, z = mc_location
+  b = (ring :melon, :brick, :glass).look
+  mc_set_block b, x, y -1, z
+  note = (ring :e1, :e2, :e3).look
+  use_synth :tb303
+  play note, release: 0.1, cutoff: 70
+  sleep 0.125
+end
 ```
     
 Now, whilst that's playing start changing the code. Change the block
@@ -164,29 +164,29 @@ understand it all, just type it in and have a play by changing some of
 the values whilst it's running live. Have fun and see you next time...
     
 ```
-  live_loop :note_blocks do
-    mc_message "This is Sonic Minecraft"
-    with_fx :reverb do
-      with_fx :echo, phase: 0.125, reps: 32 do
-        tick
-        x = (range 30, 90, step: 0.1).look
-        y = 20
-        z = -10
-        mc_teleport x, y, z
-        ns = (scale :e3, :minor_pentatonic)
-        n = ns.shuffle.choose
-        bs = (knit :glass, 3, :sand, 1)
-        b = bs.look
-        synth :beep, note: n, release: 0.1
-        mc_set_block b, x+20, n-60+y, z+10
-        mc_set_block b, x+20, n-60+y, z-10
-        sleep 0.25
-      end
+live_loop :note_blocks do
+  mc_message "This is Sonic Minecraft"
+  with_fx :reverb do
+    with_fx :echo, phase: 0.125, reps: 32 do
+      tick
+      x = (range 30, 90, step: 0.1).look
+      y = 20
+      z = -10
+      mc_teleport x, y, z
+      ns = (scale :e3, :minor_pentatonic)
+      n = ns.shuffle.choose
+      bs = (knit :glass, 3, :sand, 1)
+      b = bs.look
+      synth :beep, note: n, release: 0.1
+      mc_set_block b, x+20, n-60+y, z+10
+      mc_set_block b, x+20, n-60+y, z-10
+      sleep 0.25
     end
   end
-  
-  live_loop :beats do
-    sample :bd_haus, cutoff: 100
-    sleep 0.5
-  end
+end
+
+live_loop :beats do
+  sample :bd_haus, cutoff: 100
+  sleep 0.5
+end
 ```

--- a/etc/doc/tutorial/en/A.07-bizet.md
+++ b/etc/doc/tutorial/en/A.07-bizet.md
@@ -80,7 +80,6 @@ relationships or patterns. For example, when we re-write our notation
 purely in 16ths you can see that our notation just turns into a nice
 sequence of notes and rests.
 
-
 ![Habanera Riff 2](../images/tutorial/articles/A.07-bizet/habanera2.png)
 
 # Re-coding the Habanera

--- a/etc/doc/tutorial/en/A.07-bizet.md
+++ b/etc/doc/tutorial/en/A.07-bizet.md
@@ -89,17 +89,17 @@ We're now in a position to start translating this bass line to Sonic
 Pi. Let's encode these notes and rests in a ring:
 
 ```
-  (ring :d, :r, :r, :a, :f5, :r, :a, :r)
+(ring :d, :r, :r, :a, :f5, :r, :a, :r)
 ```
     
 Let's see what this sounds like. Throw it in a live loop and tick
 through it:
 
 ```
-  live_loop :habanera do
-    play (ring :d, :r, :r, :a, :f5, :r, :a, :r).tick
-    sleep 0.25
-  end
+live_loop :habanera do
+  play (ring :d, :r, :r, :a, :f5, :r, :a, :r).tick
+  sleep 0.25
+end
 ```
     
 Fabulous, that instantly recognisable riff springs to life through your
@@ -114,21 +114,21 @@ style synth lead.  Let's try it with the starting note `:d` passed
 through a slicer and reverb:
 
 ```
-  live_loop :habanera do
-    use_synth :fm
-    use_transpose -12
-    play (ring :d, :r, :r, :a, :f5, :r, :a, :r).tick
-    sleep 0.25
-  end
-  
-  with_fx :reverb do
-    live_loop :space_light do
-      with_fx :slicer, phase: 0.25 do
-        synth :blade, note: :d, release: 8, cutoff: 100, amp: 2
-      end
-      sleep 8
+live_loop :habanera do
+  use_synth :fm
+  use_transpose -12
+  play (ring :d, :r, :r, :a, :f5, :r, :a, :r).tick
+  sleep 0.25
+end
+
+with_fx :reverb do
+  live_loop :space_light do
+    with_fx :slicer, phase: 0.25 do
+      synth :blade, note: :d, release: 8, cutoff: 100, amp: 2
     end
+    sleep 8
   end
+end
 ```
 
 Now, try the other notes in the bass line: `:a` and `:f5`. Remember, you
@@ -146,35 +146,35 @@ second line by removing the `#` and hit run again - how marvellous is
 that! Now, start mashing it around yourself and have fun.
 
 ```
-  use_debug false
-  bizet_bass = (ring :d, :r, :r, :a, :f5, :r, :a, :r)
-  #bizet_bass = (ring :d, :r, :r, :Bb, :g5, :r, :Bb, :r)
-   
-  with_fx :reverb, room: 1, mix: 0.3 do
-    live_loop :bizet do
-      with_fx :slicer, phase: 0.125 do
-        synth :blade, note: :d4, release: 8,
-          cutoff: 100, amp: 1.5
-      end
-      16.times do
-        tick
-        play bizet_bass.look, release: 0.1
-        play bizet_bass.look - 12, release: 0.3
-        sleep 0.125
-      end
+use_debug false
+bizet_bass = (ring :d, :r, :r, :a, :f5, :r, :a, :r)
+#bizet_bass = (ring :d, :r, :r, :Bb, :g5, :r, :Bb, :r)
+ 
+with_fx :reverb, room: 1, mix: 0.3 do
+  live_loop :bizet do
+    with_fx :slicer, phase: 0.125 do
+      synth :blade, note: :d4, release: 8,
+        cutoff: 100, amp: 1.5
+    end
+    16.times do
+      tick
+      play bizet_bass.look, release: 0.1
+      play bizet_bass.look - 12, release: 0.3
+      sleep 0.125
     end
   end
-   
-  live_loop :ind do
-    sample :loop_industrial, beat_stretch: 1,
-      cutoff: 100, rate: 1
-    sleep 1
-  end
-   
-  live_loop :drums do
-    sample :bd_haus, cutoff: 110
-    synth :beep, note: 49, attack: 0,
-      release: 0.1
-    sleep 0.5
-  end
+end
+ 
+live_loop :ind do
+  sample :loop_industrial, beat_stretch: 1,
+    cutoff: 100, rate: 1
+  sleep 1
+end
+ 
+live_loop :drums do
+  sample :bd_haus, cutoff: 110
+  synth :beep, note: 49, attack: 0,
+    release: 0.1
+  sleep 0.5
+end
 ```

--- a/etc/doc/tutorial/en/A.08-minecraft-vj.md
+++ b/etc/doc/tutorial/en/A.08-minecraft-vj.md
@@ -30,7 +30,7 @@ Minecraft and Sonic Pi. In Minecraft, create a new world, and in Sonic
 Pi choose a fresh buffer and write in this code:
 
 ```
-  mc_message "Let's get started..."
+mc_message "Let's get started..."
 ```
     
 Hit the Run button and you'll see the message over in the Minecraft
@@ -60,14 +60,14 @@ the storm. Grab your current location and use it to create a few sand
 blocks up in the sky nearby:
 
 ```
-  x, y, z = mc_location
-  mc_set_block :sand, x, y + 20, z + 5
-  sleep 2
-  mc_set_block :sand, x, y + 20, z + 6
-  sleep 2
-  mc_set_block :sand, x, y + 20, z + 7
-  sleep 2
-  mc_set_block :sand, x, y + 20, z + 8
+x, y, z = mc_location
+mc_set_block :sand, x, y + 20, z + 5
+sleep 2
+mc_set_block :sand, x, y + 20, z + 6
+sleep 2
+mc_set_block :sand, x, y + 20, z + 7
+sleep 2
+mc_set_block :sand, x, y + 20, z + 8
 ```
     
 When you hit Run, you might have to look around a little as the blocks
@@ -95,15 +95,15 @@ the `live_loop` - Sonic Pi's magical ability which unleashes the full
 power of live coding - changing code on-the-fly whilst it's running!
 
 ```
-  live_loop :sand_storm do
-    x, y, z = mc_location
-    xd = rrand(-10, 10)
-    zd = rrand(-10, 10)
-    co = rrand(70, 130)
-    synth :cnoise, attack: 0, release: 0.125, cutoff: co
-    mc_set_block :sand, x + xd, y+20, z+zd
-    sleep 0.125
-  end
+live_loop :sand_storm do
+  x, y, z = mc_location
+  xd = rrand(-10, 10)
+  zd = rrand(-10, 10)
+  co = rrand(70, 130)
+  synth :cnoise, attack: 0, release: 0.125, cutoff: co
+  mc_set_block :sand, x + xd, y+20, z+zd
+  sleep 0.125
+end
 ```
     
 What fun! We're looping round pretty quickly (8 times a second) and
@@ -143,13 +143,13 @@ coordinates for a square. We can then randomly choose block types from a
 ring of blocks for an interesting effect:
 
 ```
-  x, y, z = mc_location
-  bs = (ring :gold, :diamond, :glass)
-  10.times do |xd|
-    10.times do |yd|
-      mc_set_block bs.choose, x + xd, y + yd, z
-    end
+x, y, z = mc_location
+bs = (ring :gold, :diamond, :glass)
+10.times do |xd|
+  10.times do |yd|
+    mc_set_block bs.choose, x + xd, y + yd, z
   end
+end
 ```
 
 Pretty neat. Whilst we're having fun here, try changing `bs.choose` to

--- a/etc/doc/tutorial/en/A.09-randomisation.md
+++ b/etc/doc/tutorial/en/A.09-randomisation.md
@@ -20,7 +20,7 @@ Pi to choose a number this time. Fire up Sonic Pi v2.7+ and ask it for a
 random number but again don't tell me:
 
 ```
-  print rand
+print rand
 ```
 
 Now for the reveal... was it `0.75006103515625`? Yes! Ha, I can see
@@ -54,10 +54,10 @@ important when we start sharing our pieces with each other.
 Let's use this knowledge to generate a repeatable random melody:
 
 ```
-  8.times do
-   play rrand_i(50, 95)
-   sleep 0.125
-  end
+8.times do
+ play rrand_i(50, 95)
+ sleep 0.125
+end
 ```
 
 Type this into a spare buffer and hit Run. You'll hear a melody
@@ -92,11 +92,11 @@ Computer Science, a random seed is the starting point from which a new
 stream of random values can sprout out and blossom. Let's try it:
 
 ```
-  use_random_seed 0
-  3.times do
-    play rrand_i(50, 95)
-    sleep 0.125
-  end
+use_random_seed 0
+3.times do
+  play rrand_i(50, 95)
+  sleep 0.125
+end
 ```
 
 Great, we get the first three notes of our random melody above: `84`,
@@ -104,11 +104,11 @@ Great, we get the first three notes of our random melody above: `84`,
 else. How about this:
 
 ```
-  use_random_seed 1
-  3.times do
-    play rrand_i(50, 95)
-    sleep 0.125
-  end
+use_random_seed 1
+3.times do
+  play rrand_i(50, 95)
+  sleep 0.125
+end
 ```
 
 Interesting, we get `83`, `71` and `61` . You might notice that the
@@ -128,13 +128,13 @@ resetting power, but let's also throw in a live loop so we can
 experiment live whilst it's playing:
 
 ```
-  live_loop :random_riff do    
-    use_random_seed 0
-    8.times do
-      play rrand_i(50, 95), release: 0.1
-      sleep 0.125
-    end
+live_loop :random_riff do    
+  use_random_seed 0
+  8.times do
+    play rrand_i(50, 95), release: 0.1
+    sleep 0.125
   end
+end
 ```
   
 Now, whilst it's still playing, change the seed value from `0` to
@@ -163,25 +163,25 @@ for your friends by simply switching between your favourite seeds to
 create a full piece.
 
 ```
-  live_loop :random_riff do
-    use_random_seed 10300
-    use_synth :prophet
-    s = [0.125, 0.25, 0.5].choose
-    8.times do
-      r = [0.125, 0.25, 1, 2].choose
-      n = (scale :e3, :minor).choose
-      co = rrand(30, 100)
-      play n, release: r, cutoff: co
-      sleep s
-    end
+live_loop :random_riff do
+  use_random_seed 10300
+  use_synth :prophet
+  s = [0.125, 0.25, 0.5].choose
+  8.times do
+    r = [0.125, 0.25, 1, 2].choose
+    n = (scale :e3, :minor).choose
+    co = rrand(30, 100)
+    play n, release: r, cutoff: co
+    sleep s
   end
-  
-  live_loop :drums do
-    use_random_seed 2001
-    16.times do
-      r = rrand(0.5, 10)
-      sample :drum_bass_hard, rate: r, amp: rand
-      sleep 0.125
-    end
+end
+
+live_loop :drums do
+  use_random_seed 2001
+  16.times do
+    r = rrand(0.5, 10)
+    sample :drum_bass_hard, rate: r, amp: rand
+    sleep 0.125
   end
+end
 ```

--- a/etc/doc/tutorial/en/A.10-controlling-your-sound.md
+++ b/etc/doc/tutorial/en/A.10-controlling-your-sound.md
@@ -20,7 +20,7 @@ Let's create a nice simple sound. Fire up Sonic Pi and in a fresh buffer
 type the following:
 
 ```
-  synth :prophet, note: :e1, release: 8, cutoff: 100
+synth :prophet, note: :e1, release: 8, cutoff: 100
 ```
 
 Now press the Run button at the top left to hear a lovely rumbling synth
@@ -36,9 +36,9 @@ standard variable and then **control** it at a later point in time. For
 example, let's change the value of the `cutoff:` opt after 1 beat:
 
 ```
-  sn = synth :prophet, note: :e1, release: 8, cutoff: 100
-  sleep 1
-  control sn, cutoff: 130
+sn = synth :prophet, note: :e1, release: 8, cutoff: 100
+sleep 1
+control sn, cutoff: 130
 ```
 
 Let's look at each line in turn: 
@@ -85,13 +85,13 @@ you're free to change it as many times as you like. For example, we can
 turn our `:prophet` into a mini arpeggiator with the following:
 
 ```
-  notes = (scale :e3, :minor_pentatonic)
-  sn = synth :prophet, note: :e1, release: 8, cutoff: 100
-  sleep 1
-  16.times do
-    control sn, note: notes.tick
-    sleep 0.125
-  end
+notes = (scale :e3, :minor_pentatonic)
+sn = synth :prophet, note: :e1, release: 8, cutoff: 100
+sleep 1
+16.times do
+  control sn, note: notes.tick
+  sleep 0.125
+end
 ```
 
 In this snippet of code we just added a couple of extra things. First we
@@ -108,7 +108,7 @@ Note that we can change multiple opts simultaneously. Try changing the
 control line to the following and listen for the difference:
 
 ```
-  control sn, note: notes.tick, cutoff: rrand(70, 130)
+control sn, note: notes.tick, cutoff: rrand(70, 130)
 ```
 
 ## Sliding 
@@ -129,9 +129,9 @@ slightly differently than all the other opts in that they tell the synth
 note how to behave **next time they are controlled**. Let's take a look:
 
 ```
-  sn = synth :prophet, note: :e1, release: 8, cutoff: 70, cutoff_slide: 2
-  sleep 1
-  control sn, cutoff: 130
+sn = synth :prophet, note: :e1, release: 8, cutoff: 70, cutoff_slide: 2
+sleep 1
+control sn, cutoff: 130
 ```
 
 Notice how this example is exactly the same as before except with the
@@ -160,17 +160,17 @@ notes, the synth, the FX and the sleep times and see if you can turn it
 into something completely different!
 
 ```
-  live_loop :moon_rise do
-    with_fx :echo, mix: 0, mix_slide: 8 do |fx|
-      control fx, mix: 1
-      notes = (scale :e3, :minor_pentatonic, num_octaves: 2).shuffle
-      sn = synth :prophet , sustain: 8, note: :e1, cutoff: 70, cutoff_slide: 8
-      control sn, cutoff: 130
-      sleep 2
-      32.times do
-        control sn, note: notes.tick, pan: rrand(-1, 1)
-        sleep 0.125
-      end
+live_loop :moon_rise do
+  with_fx :echo, mix: 0, mix_slide: 8 do |fx|
+    control fx, mix: 1
+    notes = (scale :e3, :minor_pentatonic, num_octaves: 2).shuffle
+    sn = synth :prophet , sustain: 8, note: :e1, cutoff: 70, cutoff_slide: 8
+    control sn, cutoff: 130
+    sleep 2
+    32.times do
+      control sn, note: notes.tick, pan: rrand(-1, 1)
+      sleep 0.125
     end
   end
+end
 ```

--- a/etc/doc/tutorial/en/A.11-beat-tracking.md
+++ b/etc/doc/tutorial/en/A.11-beat-tracking.md
@@ -10,7 +10,6 @@ attention to Sonic Pi's unique tick system. By the end of this article
 you'll be ticking your way through rhythms and riffs on your way to
 being a live coding DJ.
 
-
 # Beat Counting
 
 When making music we often want to do a different thing depending on
@@ -47,7 +46,7 @@ We've seen that `tick` does two things. It increments (adds one)
 and returns the current beat. Sometimes we just want to look at the
 current beat without having to increment it which we can do via `look`:
 
-``` 
+```
 puts tick #=> 0
 puts tick #=> 1
 puts look #=> 1
@@ -129,6 +128,7 @@ A really important thing to know is that `tick`s are local to the
 beat counter. This is much more powerful than having a global metronome
 and beat. Let's take a look at this in action:
 
+```
 notes = (ring 57, 62, 55, 59, 64)
 
 with_fx :reverb do
@@ -144,12 +144,14 @@ live_loop :arp2 do
   play notes.tick - 12, release: 0.2
   sleep 0.75
 end
+```
 
 # Clashing Beats
 
 A big cause of confusion with Sonic Pi's tick system is when people want
 to tick over multiple rings in the same `live_loop`:
 
+```
 use_bpm 300
 use_synth :blade
 live_loop :foo do
@@ -157,6 +159,7 @@ live_loop :foo do
   play (scale :e3, :minor_pentatonic).tick
   sleep 1
 end
+```
 
 Even though each `live_loop` has its own independent beat counter, we're
 calling `.tick` twice within the same `live_loop`. This means that the
@@ -177,7 +180,7 @@ together for a final fun example. As usual, don't treat this as a
 finished piece. Start changing things and play around with it and see
 what you can turn it into. See you next time...
 
-
+```
 use_bpm 240
 notes = (scale :e3, :minor_pentatonic).shuffle
 
@@ -201,3 +204,4 @@ live_loop :bar do
   play notes.look, release: r, cutoff: co
   sleep 0.5
 end
+```

--- a/etc/doc/tutorial/en/A.11-beat-tracking.md
+++ b/etc/doc/tutorial/en/A.11-beat-tracking.md
@@ -22,7 +22,7 @@ Let's have a play - to advance the beat we just need to call
 `tick`. Open up a fresh buffer, type in the following and hit Run:
 
 ```
-  puts tick #=> 0
+puts tick #=> 0
 ```
 
 This will return the current beat: `0`. Notice that even if you press
@@ -31,9 +31,9 @@ each run starts a fresh beat counting from 0.  However, whilst the run
 is still active, we can advance the beat as many times as we want:
 
 ```
-  puts tick #=> 0
-  puts tick #=> 1
-  puts tick #=> 2
+puts tick #=> 0
+puts tick #=> 1
+puts tick #=> 2
 ```
 
 Whenever you see the symbol `#=>` at the end of a line of
@@ -48,10 +48,10 @@ and returns the current beat. Sometimes we just want to look at the
 current beat without having to increment it which we can do via `look`:
 
 ``` 
-  puts tick #=> 0
-  puts tick #=> 1
-  puts look #=> 1
-  puts look #=> 1
+puts tick #=> 0
+puts tick #=> 1
+puts look #=> 1
+puts look #=> 1
 ``` 
 
 In this code we tick the beat up twice and then call `look` twice. We'll
@@ -71,7 +71,7 @@ it acts like a regular tick and increments the beat. Secondly it looks
 up the ring value using the beat as the index. Let's take a look:
 
 ```
-  puts (ring :a, :b, :c).tick #=> :a
+puts (ring :a, :b, :c).tick #=> :a
 ```
 
 `.tick` is a special dot version of `tick` which will return the first
@@ -79,11 +79,11 @@ value of the ring `:a`. We can grab each of the values in the ring by
 calling `.tick` multiple times:
 
 ```
-  puts (ring :a, :b, :c).tick #=> :a
-  puts (ring :a, :b, :c).tick #=> :b
-  puts (ring :a, :b, :c).tick #=> :c
-  puts (ring :a, :b, :c).tick #=> :a
-  puts look                   #=> 3
+puts (ring :a, :b, :c).tick #=> :a
+puts (ring :a, :b, :c).tick #=> :b
+puts (ring :a, :b, :c).tick #=> :c
+puts (ring :a, :b, :c).tick #=> :a
+puts look                   #=> 3
 ```
 
 Take a look at the log and you'll see `:a`, `:b`, `:c` and then `:a`
@@ -105,13 +105,13 @@ and understand a simple arpegiator. We need just four things:
 These concepts can all be found in the following code:
 
 ```
-  notes = (ring 57, 62, 55, 59, 64)
-  
-  live_loop :arp do
-    use_synth :dpulse
-    play notes.tick, release: 0.2
-    sleep 0.125
-  end
+notes = (ring 57, 62, 55, 59, 64)
+
+live_loop :arp do
+  use_synth :dpulse
+  play notes.tick, release: 0.2
+  sleep 0.125
+end
 ```
 
 Let's look at each of these lines. First we define our ring of notes

--- a/etc/doc/tutorial/en/A.12-sample-slicing.md
+++ b/etc/doc/tutorial/en/A.12-sample-slicing.md
@@ -20,7 +20,7 @@ following into a fresh buffer and then hit the Run button to hear a
 pre-recorded drum beat:
 
 ```
-  sample :loop_amen
+sample :loop_amen
 ```
 
 A recording of a sound is simply represented as data - lots of numbers 
@@ -60,20 +60,20 @@ to play the first half of the Amen Break, we just need to specify a
 `finish:` of `0.5`:
 
 ```
-  sample :loop_amen, finish: 0.5
+sample :loop_amen, finish: 0.5
 ```
 
 We can add in a `start:` value to play an even smaller section of the sample:
 
 ```
-  sample :loop_amen, start: 0.25, finish: 0.5
+sample :loop_amen, start: 0.25, finish: 0.5
 ```
 
 For fun, you can even have the `finish:` opt's value be *before*
 `start:` and it will play the section backwards:
 
 ```
-  sample :loop_amen, start: 0.5, finish: 0.25
+sample :loop_amen, start: 0.5, finish: 0.25
 ```
 
 # Re-ordering Sample Playback
@@ -95,14 +95,14 @@ slices. We can then play this back to create a new beat. Take a look at
 the code to do this:
 
 ```
-  live_loop :beat_slicer do
-    slice_idx = rand_i(8)
-    slice_size = 0.125
-    s = slice_idx * slice_size
-    f = s + slice_size
-    sample :loop_amen, start: s, finish: f
-    sleep sample_duration :loop_amen, start: s, finish: f
-  end
+live_loop :beat_slicer do
+  slice_idx = rand_i(8)
+  slice_size = 0.125
+  s = slice_idx * slice_size
+  f = s + slice_size
+  sample :loop_amen, start: s, finish: f
+  sleep sample_duration :loop_amen, start: s, finish: f
+end
 ```
 
 1. we choose a random slice to play which should be a random number
@@ -143,22 +143,22 @@ track. Now it's your turn - take the code below as a starting point and
 see if you can take it in your own direction and create something new...
 
 ```
-  live_loop :sliced_amen do
-    n = 8
-    s =  line(0, 1, steps: n).choose
-    f = s + (1.0 / n)
-    sample :loop_amen, beat_stretch: 2, start: s, finish: f
-    sleep 2.0  / n
+live_loop :sliced_amen do
+  n = 8
+  s =  line(0, 1, steps: n).choose
+  f = s + (1.0 / n)
+  sample :loop_amen, beat_stretch: 2, start: s, finish: f
+  sleep 2.0  / n
+end
+
+live_loop :acid_bass do
+  with_fx :reverb, room: 1, reps: 32, amp: 0.6 do
+    tick
+    n = (octs :e0, 3).look - (knit 0, 3 * 8, -4, 3 * 8).look
+    co = rrand(70, 110)
+    synth :beep, note: n + 36, release: 0.1, wave: 0, cutoff: co
+    synth :tb303, note: n, release: 0.2, wave: 0, cutoff: co
+    sleep (ring 0.125, 0.25).look
   end
-  
-  live_loop :acid_bass do
-    with_fx :reverb, room: 1, reps: 32, amp: 0.6 do
-      tick
-      n = (octs :e0, 3).look - (knit 0, 3 * 8, -4, 3 * 8).look
-      co = rrand(70, 110)
-      synth :beep, note: n + 36, release: 0.1, wave: 0, cutoff: co
-      synth :tb303, note: n, release: 0.2, wave: 0, cutoff: co
-      sleep (ring 0.125, 0.25).look
-    end
-  end
+end
 ```


### PR DESCRIPTION
The 2-space indentation done in #1180 was added to work around a minor bug in po4a.

Now that I'm not going to use po4a but a smaller script that handles only our file format, the indentation can be removed.

Also includes some minor fixes to the A-section of the tutorial.