### PR TITLE
Fix references to comp: opt in sample opt docs

### DIFF
--- a/app/server/sonicpi/lib/sonicpi/synths/synthinfo.rb
+++ b/app/server/sonicpi/lib/sonicpi/synths/synthinfo.rb
@@ -3567,7 +3567,7 @@ Note that if the microphone and speaker are close together (on a laptop or in a 
 
           :threshold =>
           {
-            :doc => "Threshold value determining the break point between slope_below and slope_above. Only valid if the compressor is enabled by turning on the comp: opt.",
+            :doc => "Threshold value determining the break point between slope_below and slope_above. Only valid if the compressor is enabled by turning on the compress: opt.",
             :validations => [v_positive(:threshold)],
             :modulatable => true
           },
@@ -3582,7 +3582,7 @@ Note that if the microphone and speaker are close together (on a laptop or in a 
 
           :slope_below =>
           {
-            :doc => "Slope of the amplitude curve below the threshold. A value of 1 means that the output of signals with amplitude below the threshold will be unaffected. Greater values will magnify and smaller values will attenuate the signal. Only valid if the compressor is enabled by turning on the comp: opt.",
+            :doc => "Slope of the amplitude curve below the threshold. A value of 1 means that the output of signals with amplitude below the threshold will be unaffected. Greater values will magnify and smaller values will attenuate the signal. Only valid if the compressor is enabled by turning on the compress: opt.",
             :validations => [],
             :modulatable => true
           },
@@ -3597,7 +3597,7 @@ Note that if the microphone and speaker are close together (on a laptop or in a 
 
           :slope_above =>
           {
-            :doc => "Slope of the amplitude curve above the threshold. A value of 1 means that the output of signals with amplitude above the threshold will be unaffected. Greater values will magnify and smaller values will attenuate the signal. Only valid if the compressor is enabled by turning on the comp: opt.",
+            :doc => "Slope of the amplitude curve above the threshold. A value of 1 means that the output of signals with amplitude above the threshold will be unaffected. Greater values will magnify and smaller values will attenuate the signal. Only valid if the compressor is enabled by turning on the compress: opt.",
 
             :validations => [],
             :modulatable => true
@@ -3613,7 +3613,7 @@ Note that if the microphone and speaker are close together (on a laptop or in a 
 
           :clamp_time =>
           {
-            :doc => "Time taken for the amplitude adjustments to kick in fully (in seconds). This is usually pretty small (not much more than 10 milliseconds). Also known as the time of the attack phase. Only valid if the compressor is enabled by turning on the comp: opt.",
+            :doc => "Time taken for the amplitude adjustments to kick in fully (in seconds). This is usually pretty small (not much more than 10 milliseconds). Also known as the time of the attack phase. Only valid if the compressor is enabled by turning on the compress: opt.",
             :validations => [v_positive(:clamp_time)],
             :modulatable => true
           },
@@ -3628,7 +3628,7 @@ Note that if the microphone and speaker are close together (on a laptop or in a 
 
           :relax_time =>
           {
-            :doc => "Time taken for the amplitude adjustments to be released. Usually a little longer than clamp_time. If both times are too short, you can get some (possibly unwanted) artefacts. Also known as the time of the release phase. Only valid if the compressor is enabled by turning on the comp: opt.",
+            :doc => "Time taken for the amplitude adjustments to be released. Usually a little longer than clamp_time. If both times are too short, you can get some (possibly unwanted) artefacts. Also known as the time of the release phase. Only valid if the compressor is enabled by turning on the compress: opt.",
             :validations => [v_positive(:relax_time)],
             :modulatable => true
           },

--- a/etc/doc/cheatsheets/synths.md
+++ b/etc/doc/cheatsheets/synths.md
@@ -2914,31 +2914,31 @@
     - constraints: must be one of the following values: [0, 1]
     - May be changed whilst playing
   * threshold:
-    - doc: Threshold value determining the break point between slope_below and slope_above. Only valid if the compressor is enabled by turning on the comp: opt.
+    - doc: Threshold value determining the break point between slope_below and slope_above. Only valid if the compressor is enabled by turning on the compress: opt.
     - default: 0.2
     - constraints: must be zero or greater
     - May be changed whilst playing
     - Has slide parameters for shaping changes
   * clamp_time:
-    - doc: Time taken for the amplitude adjustments to kick in fully (in seconds). This is usually pretty small (not much more than 10 milliseconds). Also known as the time of the attack phase. Only valid if the compressor is enabled by turning on the comp: opt.
+    - doc: Time taken for the amplitude adjustments to kick in fully (in seconds). This is usually pretty small (not much more than 10 milliseconds). Also known as the time of the attack phase. Only valid if the compressor is enabled by turning on the compress: opt.
     - default: 0.01
     - constraints: must be zero or greater
     - May be changed whilst playing
     - Has slide parameters for shaping changes
   * slope_above:
-    - doc: Slope of the amplitude curve above the threshold. A value of 1 means that the output of signals with amplitude above the threshold will be unaffected. Greater values will magnify and smaller values will attenuate the signal. Only valid if the compressor is enabled by turning on the comp: opt.
+    - doc: Slope of the amplitude curve above the threshold. A value of 1 means that the output of signals with amplitude above the threshold will be unaffected. Greater values will magnify and smaller values will attenuate the signal. Only valid if the compressor is enabled by turning on the compress: opt.
     - default: 0.5
     - constraints: none
     - May be changed whilst playing
     - Has slide parameters for shaping changes
   * slope_below:
-    - doc: Slope of the amplitude curve below the threshold. A value of 1 means that the output of signals with amplitude below the threshold will be unaffected. Greater values will magnify and smaller values will attenuate the signal. Only valid if the compressor is enabled by turning on the comp: opt.
+    - doc: Slope of the amplitude curve below the threshold. A value of 1 means that the output of signals with amplitude below the threshold will be unaffected. Greater values will magnify and smaller values will attenuate the signal. Only valid if the compressor is enabled by turning on the compress: opt.
     - default: 1
     - constraints: none
     - May be changed whilst playing
     - Has slide parameters for shaping changes
   * relax_time:
-    - doc: Time taken for the amplitude adjustments to be released. Usually a little longer than clamp_time. If both times are too short, you can get some (possibly unwanted) artefacts. Also known as the time of the release phase. Only valid if the compressor is enabled by turning on the comp: opt.
+    - doc: Time taken for the amplitude adjustments to be released. Usually a little longer than clamp_time. If both times are too short, you can get some (possibly unwanted) artefacts. Also known as the time of the release phase. Only valid if the compressor is enabled by turning on the compress: opt.
     - default: 0.01
     - constraints: must be zero or greater
     - May be changed whilst playing
@@ -3122,31 +3122,31 @@
     - constraints: must be one of the following values: [0, 1]
     - May be changed whilst playing
   * threshold:
-    - doc: Threshold value determining the break point between slope_below and slope_above. Only valid if the compressor is enabled by turning on the comp: opt.
+    - doc: Threshold value determining the break point between slope_below and slope_above. Only valid if the compressor is enabled by turning on the compress: opt.
     - default: 0.2
     - constraints: must be zero or greater
     - May be changed whilst playing
     - Has slide parameters for shaping changes
   * clamp_time:
-    - doc: Time taken for the amplitude adjustments to kick in fully (in seconds). This is usually pretty small (not much more than 10 milliseconds). Also known as the time of the attack phase. Only valid if the compressor is enabled by turning on the comp: opt.
+    - doc: Time taken for the amplitude adjustments to kick in fully (in seconds). This is usually pretty small (not much more than 10 milliseconds). Also known as the time of the attack phase. Only valid if the compressor is enabled by turning on the compress: opt.
     - default: 0.01
     - constraints: must be zero or greater
     - May be changed whilst playing
     - Has slide parameters for shaping changes
   * slope_above:
-    - doc: Slope of the amplitude curve above the threshold. A value of 1 means that the output of signals with amplitude above the threshold will be unaffected. Greater values will magnify and smaller values will attenuate the signal. Only valid if the compressor is enabled by turning on the comp: opt.
+    - doc: Slope of the amplitude curve above the threshold. A value of 1 means that the output of signals with amplitude above the threshold will be unaffected. Greater values will magnify and smaller values will attenuate the signal. Only valid if the compressor is enabled by turning on the compress: opt.
     - default: 0.5
     - constraints: none
     - May be changed whilst playing
     - Has slide parameters for shaping changes
   * slope_below:
-    - doc: Slope of the amplitude curve below the threshold. A value of 1 means that the output of signals with amplitude below the threshold will be unaffected. Greater values will magnify and smaller values will attenuate the signal. Only valid if the compressor is enabled by turning on the comp: opt.
+    - doc: Slope of the amplitude curve below the threshold. A value of 1 means that the output of signals with amplitude below the threshold will be unaffected. Greater values will magnify and smaller values will attenuate the signal. Only valid if the compressor is enabled by turning on the compress: opt.
     - default: 1
     - constraints: none
     - May be changed whilst playing
     - Has slide parameters for shaping changes
   * relax_time:
-    - doc: Time taken for the amplitude adjustments to be released. Usually a little longer than clamp_time. If both times are too short, you can get some (possibly unwanted) artefacts. Also known as the time of the release phase. Only valid if the compressor is enabled by turning on the comp: opt.
+    - doc: Time taken for the amplitude adjustments to be released. Usually a little longer than clamp_time. If both times are too short, you can get some (possibly unwanted) artefacts. Also known as the time of the release phase. Only valid if the compressor is enabled by turning on the compress: opt.
     - default: 0.01
     - constraints: must be zero or greater
     - May be changed whilst playing


### PR DESCRIPTION
This updates these references to the correct opt name, 'compress:'. I guess when I provided #1010 I didn't realise the references to comp: would be in other files too. Hopefully this is the last of them. (I did a global search and couldn't find any others).