### PR TITLE
Fix for scope data updates

### DIFF
--- a/app/gui/qt/mainwindow.cpp
+++ b/app/gui/qt/mainwindow.cpp
@@ -249,7 +249,6 @@ if(settings.value("first_time", 1).toInt() == 1) {
 }
 
 void MainWindow::setupTheme() {
-
   // Syntax highlighting
   QString themeFilename = QDir::homePath() + QDir::separator() + ".sonic-pi" + QDir::separator() + "theme.properties";
   QFile themeFile(themeFilename);
@@ -615,6 +614,10 @@ void MainWindow::updateFocusMode(){
   updateTabsVisibility();
   updateButtonVisibility();
   updateLogVisibility();
+}
+
+void MainWindow::toggleScopePaused() {
+  scopeInterface->togglePause();
 }
 
 void MainWindow::toggleLogVisibility() {
@@ -2368,7 +2371,6 @@ void MainWindow::setupAction(QAction *action, char key, QString tooltip,
 
 void MainWindow::createShortcuts()
 {
-
   new QShortcut(metaKey('{'), this, SLOT(tabPrev()));
   new QShortcut(metaKey('}'), this, SLOT(tabNext()));
   new QShortcut(QKeySequence("F8"), this, SLOT(reloadServerCode()));
@@ -2380,6 +2382,7 @@ void MainWindow::createShortcuts()
   new QShortcut(shiftMetaKey('M'), this, SLOT(toggleDarkMode()));
   new QShortcut(QKeySequence("F11"), this, SLOT(toggleLogVisibility()));
   new QShortcut(shiftMetaKey('L'), this, SLOT(toggleLogVisibility()));
+  new QShortcut(QKeySequence("F12"),this, SLOT(toggleScopePaused()));
 }
 
 void MainWindow::createToolBar()

--- a/app/gui/qt/mainwindow.h
+++ b/app/gui/qt/mainwindow.h
@@ -165,6 +165,7 @@ private slots:
     void toggleFullScreenMode();
     void updateFocusMode();
     void toggleFocusMode();
+    void toggleScopePaused();
     void updateLogVisibility();
     void toggleLogVisibility();
     void updateTabsVisibility();

--- a/app/gui/qt/scope.cpp
+++ b/app/gui/qt/scope.cpp
@@ -23,13 +23,8 @@
 #include <qwt_text_label.h>
 #include <cmath>
 
-ScopePanel::ScopePanel( const std::string& name, QWidget* parent ) : QWidget(parent), name(name), plot(QwtText(name.c_str()),this), max_y(0), counter(0), channel(0)
+ScopePanel::ScopePanel( const std::string& name, double* sample_x, double* sample_y, QWidget* parent ) : QWidget(parent), name(name), plot(QwtText(name.c_str()),this) 
 {
-  for( unsigned int i = 0; i < 4096; ++i )
-  {
-    sample_x[i] = i;
-    sample_y[i] = 0.0f;
-  }
   plot_curve.setRawSamples( sample_x, sample_y, 4096 );
   plot_curve.setItemAttribute( QwtPlotItem::AutoScale );
   plot_curve.attach(&plot);
@@ -69,57 +64,15 @@ bool ScopePanel::setAxes(bool b)
   return b;
 }
 
-void ScopePanel::setChannel( unsigned int i )
+void ScopePanel::refresh( )
 {
-  channel = i;
-}
-
-void ScopePanel::setReader( scope_buffer_reader* shmReader )
-{
-  reader = shmReader;
-}
-
-void ScopePanel::refresh()
-{
-  if( reader == nullptr ) return;
-  if( !reader->valid() ) return;
   if( !plot.isVisible() ) return;
-
-  unsigned int frames;
-  if( reader->pull( frames ) )
-  {
-//    ++counter;
-    float* data = reader->data();
-    unsigned int offset = reader->max_frames() * channel;
-    for( unsigned int i = 0; i < 4096 - frames; ++i )
-    {
-      sample_y[i] = sample_y[i+frames];
-    }
-
-    for( unsigned int i = 0; i < frames; ++i )
-    {
-      sample_y[4096-frames+i] = data[i+offset];
-    }
-    plot.replot();
-  }
-/*
-    if( counter > 100 )
-    {
-      counter = 0;
-      if( max_y == 0 ) max_y = 1;
-      if( max_y > 1 ) max_y = 1;
-      if( max_y > plot.axisInterval(QwtPlot::Axis::yLeft).maxValue() )
-      {
-        plot.setAxisScale(QwtPlot::Axis::yLeft,-max_y,max_y);
-      }
-      max_y = 0;
-    }
-*/
+  plot.replot();
 }
 
-Scope::Scope( QWidget* parent ) : QWidget(parent), left("Left",this), right("Right",this)
+Scope::Scope( QWidget* parent ) : QWidget(parent), left("Left",sample_x,sample[0],this), right("Right",sample_x,sample[1],this)
 {
-  right.setChannel(1);
+  for( unsigned int i = 0; i < 4096; ++i ) sample_x[i] = i;
   QTimer *scopeTimer = new QTimer(this);
   connect(scopeTimer, SIGNAL(timeout()), this, SLOT(refreshScope()));
   //scopeTimer->start(735*1000/44100); // sample size (4096)*1000 ms/s / Sample Rate (Hz)
@@ -166,10 +119,32 @@ void Scope::refreshScope() {
   {
     shmClient.reset(new server_shared_memory_client(4556));
     shmReader = shmClient->get_scope_buffer_reader(0);
-    left.setReader(&shmReader);
-    right.setReader(&shmReader);
+  }
+  if( !shmReader.valid() )
+  {
+    qDebug() << "Couldn't get reader!";
+    return;
+  }
+
+  unsigned int frames;
+  if( shmReader.pull( frames ) )
+  {
+    qDebug() << "Got " << frames << " frames";
+    for( unsigned int j = 0; j < 2; ++j )
+    {
+      float* data = shmReader.data();
+      unsigned int offset = shmReader.max_frames() * j;
+      for( unsigned int i = 0; i < 4096 - frames; ++i )
+      {
+        sample[j][i] = sample[j][i+frames];
+      }
+
+      for( unsigned int i = 0; i < frames; ++i )
+      {
+        sample[j][4096-frames+i] = data[i+offset];
+      }
+    }
   }
   left.refresh();
   right.refresh();
-  repaint();
 }

--- a/app/gui/qt/scope.h
+++ b/app/gui/qt/scope.h
@@ -30,24 +30,16 @@ class ScopePanel : public QWidget
   Q_OBJECT
 
 public:
-  ScopePanel( const std::string& name, QWidget* parent = 0 );
+  ScopePanel( const std::string& name, double* sample_x, double* sample_y, QWidget* parent = 0 );
   virtual ~ScopePanel();
 
-  void setChannel( unsigned int i );
-  void setReader( scope_buffer_reader* shmReader );
   void refresh();
   bool setAxes( bool on );
 
 private:
   std::string name;
-  scope_buffer_reader* reader;
   QwtPlot plot;
   QwtPlotCurve plot_curve;
-  double sample_x[4096];
-  double sample_y[4096];
-  double max_y;
-  int counter;
-  unsigned int channel;
 };
 
 class Scope : public QWidget 
@@ -67,6 +59,8 @@ private slots:
  
 private: 
   std::unique_ptr<server_shared_memory_client> shmClient;
+  double sample_x[4096];
+  double sample[2][4096];
   scope_buffer_reader shmReader;
   ScopePanel left,right;
 };

--- a/app/gui/qt/scope.h
+++ b/app/gui/qt/scope.h
@@ -53,6 +53,7 @@ public:
   bool setLeftScope(bool on);
   bool setRightScope(bool on);
   bool setScopeAxes(bool on);
+  void togglePause();
 
 private slots:
   void refreshScope();
@@ -63,6 +64,7 @@ private:
   double sample[2][4096];
   scope_buffer_reader shmReader;
   ScopePanel left,right;
+  bool paused;
 };
 
 #endif

--- a/app/server/sonicpi/lib/sonicpi/studio.rb
+++ b/app/server/sonicpi/lib/sonicpi/studio.rb
@@ -386,7 +386,7 @@ module SonicPi
 
     def start_scope
       scope_synth = "sonic-pi-scope"
-      @scope = @server.trigger_synth(:head, @monitor_group, scope_synth, { "max_frames" => 735 })
+      @scope = @server.trigger_synth(:head, @monitor_group, scope_synth, { "max_frames" => 1024 })
     end
 
     def internal_load_sample(path, server=@server)


### PR DESCRIPTION
Data updates are pulled into a single place now, used by each renderer. This fixes the rendering bug and paves the way for easy implementation of the Lissajous scope. I added a "pause scope" button to F12 for debugging when trying to track down a visual artifact. It appears to vanish for powers of two, so max_frames is now 1024, up from 735.