### PR TITLE
Escape \" in page titles for generated documentation.

### DIFF
--- a/app/server/bin/qt-doc.rb
+++ b/app/server/bin/qt-doc.rb
@@ -91,12 +91,12 @@ make_tab = lambda do |name, doc_items, titleize=false, should_sort=true, with_ke
         toc_level -= 1
       end
     end
-    toc << "<li><a href=\"\##{item_var}\">#{title}</a></li>\n"
+    toc << "<li><a href=\"\##{item_var}\">#{title.gsub(/"/, '&quot;')}</a></li>\n"
 
     docs << "    { "
 
     docs << "QString::fromUtf8(" unless title.ascii_only?
-    docs << "\"#{title}\""
+    docs << "\"#{title.gsub(/"/, '\\"')}\""
     docs << ")" unless title.ascii_only?
 
     docs << ", "


### PR DESCRIPTION
This fixes a current build problem, as the dutch tutorial translation currently contains "quoted" words in some page titles.