### PR TITLE
Include all Qt linguist files in build.

### DIFF
--- a/app/gui/qt/SonicPi.pro
+++ b/app/gui/qt/SonicPi.pro
@@ -94,20 +94,7 @@ HEADERS  += mainwindow.h \
             sonicpitheme.h \
             scope.h
 
-TRANSLATIONS = lang/sonic-pi_de.ts \
-               lang/sonic-pi_es.ts \
-               lang/sonic-pi_fi.ts \
-               lang/sonic-pi_fr.ts \
-               lang/sonic-pi_hu.ts \
-               lang/sonic-pi_is.ts \
-               lang/sonic-pi_it.ts \
-               lang/sonic-pi_ja.ts \
-               lang/sonic-pi_nb.ts \
-               lang/sonic-pi_nl.ts \
-               lang/sonic-pi_pl.ts \
-               lang/sonic-pi_ro.ts \
-               lang/sonic-pi_ru.ts \
-               lang/sonic-pi_zh-Hans.ts \
+TRANSLATIONS = lang/*.ts
 
 OTHER_FILES += \
     images/copy.png \


### PR DESCRIPTION
This will build the GUI with all existing translations, making manual activation like #1218 #1235 etc. unnecessary.

Downside is that it will also include incomplete translations (although I sincerely hope to have complete GUI translations by the time of the next release).