### PR TITLE
create static lib for qscintilla and link statically, and also link against boost lib

### DIFF
--- a/INSTALL-WINDOWS.md
+++ b/INSTALL-WINDOWS.md
@@ -217,6 +217,13 @@ nmake install
 And now, install Boost C++ libs:
 Download Boost 1.61 from http://www.boost.org/users/history/version_1_61_0.html, and decompress into c:\.
 
+An now we compile the binary boost files. Go to c:\boost_1_61_0, and execute the following:
+```
+bootstrap
+b2 toolset=msvc-12.0
+```
+
+
 
 Create the C:\sonic-pi\app\server\rb-native\windows\2.3.0 directory.
 

--- a/INSTALL-WINDOWS.md
+++ b/INSTALL-WINDOWS.md
@@ -192,7 +192,7 @@ When downloaded extract the ```Qscintilla_gpl-2.9.2``` folder to ```c:\```
 Return to the visual studio command window. 
 ```
 cd c:\QScintilla_gpl-2.9.2\Qt4Qt5
-qmake qscintilla.pro
+qmake qscintilla.pro CONFIG+=staticlib
 nmake
 ```
 (it will now be compiled)

--- a/app/gui/qt/SonicPi.pro
+++ b/app/gui/qt/SonicPi.pro
@@ -54,7 +54,8 @@ win32 {
   include ( c:/qwt-6.1.2/features/qwt.prf )
   LIBS += -lqscintilla2
   QMAKE_CXXFLAGS += -Ic:/boost_1_61_0
-  QMAKE_CXXFLAGS += /WX 
+#  QMAKE_CXXFLAGS += /WX
+  QMAKE_LFLAGS += /LIBPATH:C:\boost_1_61_0\bin.v2\libs\date_time\build\msvc-12.0\release\link-static\threading-multi
   DEFINES += _CRT_SECURE_NO_WARNINGS _WINSOCK_DEPRECATED_NO_WARNINGS
 }
 


### PR DESCRIPTION
Doing this, the problems about the DLLs go away, but I am not really sure if this is the way to go, and whether it is fine to link statically. I will let you decide.

Compilation is getting further, but it is failing with this:
```
        link /NOLOGO /DYNAMICBASE /NXCOMPAT /INCREMENTAL:NO /SUBSYSTEM:WINDOWS,5.01 "/MANIFESTDEPENDENCY:type='win32' name='Microsoft.Windows.Common-Controls' version='6.0.0.0' publicKeyToken='6595b64144ccf1df' language='*' processorArchitecture='*'" /MANIFEST:embed /OUT:release\sonic-pi.exe @C:\Users\luisl\AppData\Local\Temp\nm3826.tmp
qscintilla2.lib(qscilexer.obj) : error LNK2005: "public: virtual class QStringList __thiscall QsciLexer::autoCompletionWordSeparators(void)const " (?autoCompletionWordSeparators@QsciLexer@@UBE?AVQStringList@@XZ) already defined in sonicpilexer.obj
LINK : fatal error LNK1104: cannot open file 'libboost_date_time-vc120-mt-1_61.lib'
NMAKE : fatal error U1077: '"C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\BIN\link.EXE"' : return code '0x450'
Stop.
NMAKE : fatal error U1077: '"C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\BIN\nmake.exe"' : return code '0x2'
Stop.
```

**Any idea why this is being redefined?**