### PR TITLE
Add simple keyboard press/release message from GUI to server.

### DIFF
--- a/app/gui/qt/mainwindow.cpp
+++ b/app/gui/qt/mainwindow.cpp
@@ -276,7 +276,7 @@ void MainWindow::setupWindowStructure() {
 
   // Setup output and error panes
 
-  outputPane = new SonicPiLog;
+  outputPane = new SonicPiLog(this);
   errorPane = new QTextBrowser;
   errorPane->setOpenExternalLinks(true);
   update_info = new QLabel(tr("Sonic Pi update info"));

--- a/app/gui/qt/mainwindow.h
+++ b/app/gui/qt/mainwindow.h
@@ -81,6 +81,7 @@ public:
     enum {UDP=0, TCP=1};
     QCheckBox *dark_mode;
     bool loaded_workspaces;
+    void sendOSC(oscpkt::Message m);
 
 protected:
     void closeEvent(QCloseEvent *event);
@@ -210,7 +211,6 @@ private:
     std::string number_name(int);
     std::string workspaceFilename(SonicPiScintilla* text);
     SonicPiScintilla* filenameToWorkspace(std::string filename);
-    void sendOSC(oscpkt::Message m);
     void initPrefsWindow();
     void initDocsWindow();
     void refreshDocContent();

--- a/app/gui/qt/sonicpilog.cpp
+++ b/app/gui/qt/sonicpilog.cpp
@@ -39,14 +39,15 @@ void SonicPiLog::keyReleaseEvent(QKeyEvent *event)
 }
 
 void SonicPiLog::keyEvent(QKeyEvent *event) {
-  event->ignore();
-  if (
-    (event->modifiers() == Qt::NoModifier) ||
-    (event->modifiers() == Qt::ShiftModifier) ||
-    (event->modifiers() == Qt::KeypadModifier) ||
-    (event->modifiers() == Qt::ShiftModifier + Qt::KeypadModifier)
-    // ...but ignore any other keypad modifier combination
-    ) {
+  if ( (event->modifiers() &
+    // we only want to handle
+    // Qt::NoModifier / Qt::ShiftModifier / Qt::KeypadModifier
+    // key events, so this excludes all others:
+      (Qt::ControlModifier |
+      Qt::AltModifier |
+      Qt::MetaModifier |
+      Qt::GroupSwitchModifier)
+    ) == 0) {
     QString s = "";
     switch (event->key()) {
       // Special keys
@@ -78,8 +79,10 @@ void SonicPiLog::keyEvent(QKeyEvent *event) {
       msg.pushStr(s.toStdString());
       window->sendOSC(msg);
       event->accept();
+      return;
     }
   }
+  event->ignore();
 }
 
 void SonicPiLog::forceScrollDown(bool force)

--- a/app/gui/qt/sonicpilog.cpp
+++ b/app/gui/qt/sonicpilog.cpp
@@ -68,7 +68,7 @@ void SonicPiLog::keyEvent(QKeyEvent *event) {
     }
     if (s != "") {
       // Handle shift key
-      if (event->modifiers() == Qt::ShiftModifier) s = s.toUpper();
+      if (event->modifiers() & Qt::ShiftModifier) s = s.toUpper();
     } else {
       // Normal key on keyboard, let system handle shift modifier
       s = event->text();

--- a/app/gui/qt/sonicpilog.h
+++ b/app/gui/qt/sonicpilog.h
@@ -14,6 +14,7 @@
 #ifndef SONICPILOG_H
 #define SONICPILOG_H
 
+#include "mainwindow.h"
 #include <QPlainTextEdit>
 
 class SonicPiTheme;
@@ -22,7 +23,7 @@ class SonicPiLog : public QPlainTextEdit
 {
     Q_OBJECT
 public:
-    explicit SonicPiLog(QWidget *parent = 0);
+    explicit SonicPiLog(MainWindow *window = 0, QWidget *parent = 0);
     bool forceScroll;
 
     struct Message
@@ -44,11 +45,17 @@ public:
 signals:
 
 public slots:
+    void keyPressEvent(QKeyEvent *event);
+    void keyReleaseEvent(QKeyEvent *event);
     void setTextColor(QColor c);
     void setTextBackgroundColor(QColor c);
     void setFontFamily(QString font_name);
     void handleMultiMessage(SonicPiLog::MultiMessage mm);
     void forceScrollDown(bool force);
+
+private:
+    void keyEvent(QKeyEvent *event);
+    MainWindow *window;
 
 protected:
 };

--- a/app/server/bin/sonic-pi-server.rb
+++ b/app/server/bin/sonic-pi-server.rb
@@ -317,6 +317,18 @@ osc_server.add_method("/gui-heartbeat") do |args|
   sp.__gui_heartbeat gui_id
 end
 
+osc_server.add_method("/keyboard/press") do |args|
+  key = args[0]
+  log("Received event keyboard press '#{key}'")
+  # do something here
+end
+
+osc_server.add_method("/keyboard/release") do |args|
+  key = args[0]
+  log("Received event keyboard release '#{key}'")
+  # do something here
+end
+
 # Send stuff out from Sonic Pi back out to osc_server
 out_t = Thread.new do
   continue = true


### PR DESCRIPTION
To allow future use with the Makey Makey kit, this extends the GUI's protocol window a little bit.

It allows the protocol window to acquire the keyboard focus (when clicked by the user). From that point on, a small selection of special keys and the normal letter / number / punctuation keys will be sent as OSC messages to the ruby backend. Special keys ("up", "return", etc.) are spelled out as strings. F-keys were omitted, as the GUI is using them as shortcuts.

The ruby backend code is just a stub that needs logic added by you.

To test this, run `tail -f ~/.sonic-pi/log/* | grep keyboard` while using the GUI and click the protocol window to give it the keyboard focus.

I'm not sure yet how to visualize to the user that "something happened" when the keyboard focus has been acquired by the Sonic Pi backend. Any suggestions?

Thanks.
