### PR TITLE
Instructions for sc3-plugins installation that works on Debian Jessie.

### DIFF
--- a/INSTALL-LINUX.md
+++ b/INSTALL-LINUX.md
@@ -112,6 +112,11 @@ git submodule init
 git submodule update
 git checkout efba3baaea873f4e4d44aec3bb7468dd0938b4a6
 cp -r external_libraries/nova-simd/* source/VBAPUGens
+rm -rf source/NCAnalysisUGens # these plugins don't work with Jessie's supercollider
+sed -i "/# NCAnalysisUGens/,/^#/d" source/CMakeLists.txt
+sed -i s/JoshUGens// source/CMakeLists.txt
+sed -i s/TagSystemUGens// source/CMakeLists.txt
+sed -i s/NCAnalysisUGens// source/CMakeLists.txt
 mkdir build
 cd build
 ```


### PR DESCRIPTION
Remove incompatible plugins before building s3c-plugins, as per
https://gist.github.com/Sciss/02af79296b35f1e7536f

Note that I have only tested this with 2.10; the list of dependencies
that must be tracked down manually on master make it a non-starter.