### PR TITLE
download, compile and install aubio lib

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,11 @@ before_install:
       sudo apt-get update -q
       sudo apt-get --yes install libqt5scintilla2-dev qtbase5-dev qttools5-dev qttools5-dev-tools qt5-default libqt5opengl5-dev libqt5svg5-dev libqwt-qt5-dev libboost-all-dev
    fi
+ - wget http://aubio.org/pub/aubio-0.4.2.tar.bz2
+ - tar xvjf aubio-0.4.2.tar.bz2
+ - cd aubio-0.4.2
+ - ./waf configure build
+ - sudo ./waf install
 
 script:
  - set -e


### PR DESCRIPTION
Make travis build properly again, by downloading, compiling and installing aubio 0.4.2.

With this, travis builds properly on ruby 2.1 anb 2.2. (jobs 4 and 5 on Jenkins).

There are other errors (not related to aubio) that prevents the other build jobs from building properly on travis.