### PR TITLE
Add parameter to scsynth call to avoid triggering the firewall

### DIFF
--- a/app/server/sonicpi/lib/sonicpi/scsynthexternal.rb
+++ b/app/server/sonicpi/lib/sonicpi/scsynthexternal.rb
@@ -205,7 +205,7 @@ module SonicPi
       log "\n\n\n"
     end
 
-    def scsynth_path
+    def 
       case os
       when :raspberry
         "scsynth"
@@ -349,7 +349,7 @@ module SonicPi
       log_boot_msg
       puts "Booting on Windows"
 
-      boot_and_wait(scsynth_path, "-u", @port.to_s, "-a", num_audio_busses_for_current_os.to_s, "-m", "131072", "-D", "0", "-R", "0", "-l", "1", "-i", "16", "-o", "16", "-b", num_buffers_for_current_os.to_s)
+      boot_and_wait(scsynth_path, "-u", @port.to_s, "-a", num_audio_busses_for_current_os.to_s, "-m", "131072", "-D", "0", "-R", "0", "-l", "1", "-i", "16", "-o", "16", "-b", num_buffers_for_current_os.to_s, "-B", "127.0.0.1")
     end
 
     def boot_server_raspberry_pi

--- a/app/server/sonicpi/lib/sonicpi/scsynthexternal.rb
+++ b/app/server/sonicpi/lib/sonicpi/scsynthexternal.rb
@@ -205,7 +205,7 @@ module SonicPi
       log "\n\n\n"
     end
 
-    def 
+    def scsynth_path
       case os
       when :raspberry
         "scsynth"
@@ -341,7 +341,7 @@ module SonicPi
           raise "Unable to boot sound synthesis engine: the input and output rates of your audio card are not the same. Got in: #{audio_in_rate}, out: #{audio_out_rate}."
         end
       end
-      boot_and_wait(scsynth_path, "-u", @port.to_s, "-a", num_audio_busses_for_current_os.to_s, "-m", "131072", "-D", "0", "-R", "0", "-l", "1", "-i", "16", "-o", "16", "-b", num_buffers_for_current_os.to_s)
+      boot_and_wait(scsynth_path, "-u", @port.to_s, "-a", num_audio_busses_for_current_os.to_s, "-m", "131072", "-D", "0", "-R", "0", "-l", "1", "-i", "16", "-o", "16", "-b", num_buffers_for_current_os.to_s, "-B", "127.0.0.1")
     end
 
 
@@ -374,7 +374,7 @@ module SonicPi
 
       buffer_size = raspberry_pi_1? ? 512 : 128
 
-      boot_and_wait("scsynth", "-u", @port.to_s, "-a", num_audio_busses_for_current_os.to_s, "-m", "131072", "-D", "0", "-R", "0", "-l", "1", "-z", buffer_size.to_s,  "-c", "128", "-U", "/usr/lib/SuperCollider/plugins:#{native_path}/extra-ugens/", "-i", "2", "-o", "2", "-b", num_buffers_for_current_os.to_s)
+      boot_and_wait("scsynth", "-u", @port.to_s, "-a", num_audio_busses_for_current_os.to_s, "-m", "131072", "-D", "0", "-R", "0", "-l", "1", "-z", buffer_size.to_s,  "-c", "128", "-U", "/usr/lib/SuperCollider/plugins:#{native_path}/extra-ugens/", "-i", "2", "-o", "2", "-b", num_buffers_for_current_os.to_s, "-B", "127.0.0.1")
 
       `jack_connect SuperCollider:out_1 system:playback_1`
       `jack_connect SuperCollider:out_2 system:playback_2`
@@ -400,7 +400,7 @@ module SonicPi
         puts "Jackd already running. Not starting another server..."
       end
 
-      boot_and_wait("scsynth", "-u", @port.to_s, "-m", "131072", "-a", num_audio_busses_for_current_os.to_s, "-D", "0", "-R", "0", "-l", "1", "-i", "16", "-o", "16", "-b", num_buffers_for_current_os.to_s)
+      boot_and_wait("scsynth", "-u", @port.to_s, "-m", "131072", "-a", num_audio_busses_for_current_os.to_s, "-D", "0", "-R", "0", "-l", "1", "-i", "16", "-o", "16", "-b", num_buffers_for_current_os.to_s, "-B", "127.0.0.1")
 
       `jack_connect SuperCollider:out_1 system:playback_1`
       `jack_connect SuperCollider:out_2 system:playback_2`


### PR DESCRIPTION
SC added the -B parameter to bind to a specific network port. Use that
to bind to 127.0.0.1, and avoid triggering the firewall under Windows