### PR TITLE
Change Windows path to win, instead of windows

### DIFF
--- a/app/gui/qt/sonic-pi.wxs
+++ b/app/gui/qt/sonic-pi.wxs
@@ -38,7 +38,7 @@ light sonic-pi.wixobj etc.wixobj gui.wixobj server.wixobj -ext WixUtilExtension 
 							<Directory Id="NATIVE" Name="native">
 								<Directory Id="WINDOWS" Name="windows">
                                     <Component Id="SCSYNTH.EXE" DiskId="1" Guid="AE2F1766-69A6-4EFB-9DAE-E11A2BD717F5">
-                                        <File Id="SCSYNTH.EXE" Name="scsynth.exe" Source="SourceDir\app\server\native\windows\scsynth.exe" />
+                                        <File Id="SCSYNTH.EXE" Name="scsynth.exe" Source="SourceDir\app\server\native\win\scsynth.exe" />
                                     </Component>
 								</Directory>
 							</Directory>


### PR DESCRIPTION
Otherwise the installer does not work, since there is a path that os too
long in one of the ruby gems.

At the same, I have made a PR for @factoid to change the target install
path for ruby, so that it is win\ruby