### PR TITLE
contrib/docker: add some docker recipes

### DIFF
--- a/contrib/docker/build.sh
+++ b/contrib/docker/build.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+docker build -f sonic-pi.docker -t debian:sonic-pi .

--- a/contrib/docker/run.sh
+++ b/contrib/docker/run.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+#
+# Run sonic-pi in the docker container
+pasuspender -- docker run -it --privileged -v /dev/snd:/dev/snd:rw -e DISPLAY=$DISPLAY -v /tmp/.X11-unix:/tmp/.X11-unix debian:sonic-pi /home/sonic/start-sonic.sh

--- a/contrib/docker/sonic-pi.docker
+++ b/contrib/docker/sonic-pi.docker
@@ -1,0 +1,34 @@
+# Create Debian Sonic PI Image
+FROM debian:testing
+
+# Duplicate deb line as deb-src
+RUN cat /etc/apt/sources.list | sed "s/deb/deb-src/" >> /etc/apt/sources.list
+RUN apt update
+RUN apt dist-upgrade -y
+# install basic handy tools
+RUN apt install -y sudo apt-utils debconf-utils procps psmisc lsof
+# install jackd1 first, we can run it without realtime extensions
+RUN DEBIAN_FRONTEND=noninteractive apt install -y jackd1
+# finally install sonic-pi (and a helpful test program)
+RUN DEBIAN_FRONTEND=noninteractive apt install -y sonic-pi ecasound
+
+# Setup the user
+
+# Allow the docker run to use your user-id for the sonic user
+# Replace 1000 with your user id
+RUN export uid=1000 && useradd -u ${uid} -m sonic -G audio
+
+# User permissions
+RUN echo "sonic ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/sonic && \
+    chmod 0440 /etc/sudoers.d/sonic
+
+#
+# # Replace 18 with whatever group ID can see you audio HW
+RUN export gid=18 && addgroup --system --gid ${gid} host-audio
+RUN usermod -a -G host-audio sonic
+
+# Add the run script
+ADD start-sonic.sh /home/sonic
+
+USER sonic
+WORKDIR /home/sonic

--- a/contrib/docker/start-sonic.sh
+++ b/contrib/docker/start-sonic.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+#
+# Start sonic-pi up in the container
+#
+
+# first the jackd server
+jackd -r -P 95 -d alsa -n 2 -r 48000 &
+
+# then sonic-pi
+sonic-pi


### PR DESCRIPTION
Every time I've tried to get into SonicPi I've been thwarted by the
build process and list of dependencies.  However as Sonic Pi is already
shipping in Debian we could just create a docker app.

  sonic-pi.docker - describes a Debian Testing + Sonic Pi image
  build.sh - script to build the image
  start-sonic.sh - a helper script put in the image
  run.sh - script to run the image

Signed-off-by: Alex Bennée alex.bennee@linaro.org
