### PR TITLE
Add hexatonic blues scales

### DIFF
--- a/app/server/sonicpi/lib/sonicpi/scale.rb
+++ b/app/server/sonicpi/lib/sonicpi/scale.rb
@@ -94,7 +94,9 @@ module SonicPi
            augmented:          [3, 1, 3, 1, 3, 1],
            purvi:              [1, 3, 2, 1, 1, 3, 1],
            chinese:            [4, 2, 1, 4, 1],
-           lydian_minor:       [2, 2, 2, 1, 1, 2, 2]}}.call
+           lydian_minor:       [2, 2, 2, 1, 1, 2, 2],
+           blues_major:        [2, 1, 1, 3, 2, 3],
+           blues_minor:        [3, 2, 1, 1, 3, 2]}}.call
 
     # Zero indexed for CS compatibility
     DEGREES = {:i    => 0,


### PR DESCRIPTION
I'd like to see the blues scales added to Sonic PI, they're great for "easy improvisation" exercises and thus also lead to good results when choosing notes at random ;-)

The blues_minor scale is only the _major scale rotated once. Maybe you'd prefer to use that property.

Source: https://en.wikipedia.org/wiki/Blues_scale