### PR TITLE
SonicPi.pro changes for Windows

### DIFF
--- a/app/gui/qt/SonicPi.pro
+++ b/app/gui/qt/SonicPi.pro
@@ -64,7 +64,7 @@ macx {
 
 # Windows only
 win32 {
-  include ( c:/qwt-6.1.2/features/qwt.prf )
+  include ( c:/qwt-6.1.3/features/qwt.prf )
   LIBS += -lqscintilla2
   QMAKE_CXXFLAGS += -Ic:/boost_1_61_0
 #  QMAKE_CXXFLAGS += /WX
@@ -89,11 +89,6 @@ SOURCES += main.cpp \
            sonic_pi_tcp_osc_server.cpp \
            sonicpitheme.cpp \
            scope.cpp
-win32 {
-# have to link these explicitly for some reason
-  SOURCES += platform/win/moc_qsciscintilla.cpp \
-             platform/win/moc_qsciscintillabase.cpp
-}
 
 HEADERS  += mainwindow.h \
             oscpkt.hh \


### PR DESCRIPTION
@samaaron, after pulling this in, plase have a look at the top of your file. There are some paths that look suspiciously local to you.
Also, WIndows is using qwt 6.1.3, and the inclusion is inside a win32 block below, so you should make it conditional no !win32 in the top, or have 6.1.3 for everything