### PR TITLE
Sound - Fix undefined variable error

### DIFF
--- a/app/server/sonicpi/lib/sonicpi/lang/sound.rb
+++ b/app/server/sonicpi/lib/sonicpi/lang/sound.rb
@@ -1338,7 +1338,7 @@ set_mixer_control! lpf: 30, lpf_slide: 16 # slide the global lpf to 30 over 16 b
         synth_name = current_synth unless synth_name
         sn_sym = synth_name.to_sym
         info = Synths::SynthInfo.get_info(sn_sym)
-        raise "Unknown synth #{sn.inspect}" unless info || __thread_locals.get(:sonic_pi_mod_sound_use_external_synths)
+        raise "Unknown synth #{sn_sym.inspect}" unless info || __thread_locals.get(:sonic_pi_mod_sound_use_external_synths)
 
 
         args_h = resolve_synth_opts_hash_or_array(args)


### PR DESCRIPTION
When trying to use an external synth, if the 'Enable external synths and FX' checkbox was not checked, this would result in an undefined variable error.
This has now been fixed. It now raises the 'Unknown synth :blah' error as expected.
Fixes an issue pointed out by @rbnpi at https://groups.google.com/d/msg/sonic-pi/jAV3YfVaL08/ew3G1zPjBQAJ

Before:
![before](https://cloud.githubusercontent.com/assets/10395940/20346965/d995f216-ac39-11e6-994e-d6ceeb5631ab.png)

After:
![after](https://cloud.githubusercontent.com/assets/10395940/20346970/de162ea0-ac39-11e6-8505-0c546fc8ec70.png)
