### PR TITLE
Update runtime.rb

### DIFF
--- a/app/server/sonicpi/lib/sonicpi/runtime.rb
+++ b/app/server/sonicpi/lib/sonicpi/runtime.rb
@@ -319,6 +319,10 @@ module SonicPi
       __system_thread_locals.get(:sonic_pi_spider_time) + @mod_sound_studio.sched_ahead_time
     end
 
+    def __current_sched_ahead_time
+       @mod_sound_studio.sched_ahead_time
+    end
+    
     def __current_thread_name
       __system_thread_locals.get(:sonic_pi_local_spider_users_thread_name) || ""
     end


### PR DESCRIPTION
Add def __current_sched_ahead_time  function. Which was needed to stop use of midi function in new API Midi module from throwing an error.