### PR TITLE
Selecting files which have ".WAV" (or some upper-case) extension

### DIFF
--- a/app/server/sonicpi/lib/sonicpi/sample_loader.rb
+++ b/app/server/sonicpi/lib/sonicpi/sample_loader.rb
@@ -158,9 +158,9 @@ module SonicPi
         res = @cached_folder_contents[path]
         return res if res
         if recursive
-          res = Dir.chdir(path) { Dir.glob("**/*.{wav,wave,aif,aiff,flac}").map {|p| File.expand_path(p) } }.sort
+          res = Dir.chdir(path) { Dir.glob("**/*.{wav,wave,aif,aiff,flac,WAV,WAVE,AIF,AIFF,FLAC}").map {|p| File.expand_path(p) } }.sort
         else
-          res = Dir.chdir(path) { Dir.glob("*.{wav,wave,aif,aiff,flac}").map {|p| File.expand_path(p) } }.sort
+          res = Dir.chdir(path) { Dir.glob("*.{wav,wave,aif,aiff,flac,WAV,WAVE,AIF,AIFF,FLAC}").map {|p| File.expand_path(p) } }.sort
         end
         @cached_folder_contents[path] = res.freeze
       end


### PR DESCRIPTION
This PR enables `sample` function to select files which have upper-case extension (for example, ".WAV") as an indexed candidate.

For example, if there's "CB.WAV" in the "/Users/kn1kn1/808", the code

```
sample "/Users/kn1kn1/808", 0
```

fails as follows:

```
{run: 2, time: 0.0}
 └─ sample ["/Users/kn1kn1/808", 0]
           - no match found, skipping.
```

Applying this PR, the code will succeed as follows:

```
 {run: 2, time: 0.0}
 └─ sample "~/808",
           "CB.WAV"
```
