### PR TITLE
Fix sample file path drag & drop

### DIFF
--- a/app/gui/qt/sonicpiscintilla.cpp
+++ b/app/gui/qt/sonicpiscintilla.cpp
@@ -558,7 +558,7 @@ void SonicPiScintilla::dropEvent(QDropEvent *dropEvent)
     QList<QUrl> urlList = dropEvent->mimeData()->urls();
     QString text;
     for (int i = 0; i < urlList.size(); ++i) {
-      text += "\"" + urlList.at(i).path() + "\"" + QLatin1Char('\n');
+      text += "\"" + urlList.at(i).toLocalFile() + "\"" + QLatin1Char('\n');
     }
     insert(text);
   }


### PR DESCRIPTION
Previously, when using the drag and drop feature to output a sample's file path, on Windows this was causing an undesired '/' to be output at the front of the path.
According to https://bugreports.qt.io/browse/QTBUG-6868?focusedCommentId=214885&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-214885 the function that was used to do this, Qurl's .path(), was still behaving correctly in this instance - it is only designed to output the path component of a URI - *which may not be a valid file path on the file system*.

A comment in the above link states that Qurl's .toLocalFile() will give a valid path, so .path() has now been replaced with .toLocalFile() accordingly.