### PR TITLE
Sample doesn't like float slices

### DIFF
--- a/app/server/sonicpi/lib/sonicpi/lang/sound.rb
+++ b/app/server/sonicpi/lib/sonicpi/lang/sound.rb
@@ -4362,7 +4362,7 @@ Also, if you wish your synth to work with Sonic Pi's automatic stereo sound infr
           raise "Sample opt num_slices: needs to be greater than 0. Got: #{num_slices}" unless num_slices.is_a?(Numeric) && num_slices > 0
           slices = sample_buffer(path).slices(num_slices)
           if slice_idx.is_a? Numeric
-            slice_idx = slice_idx
+            slice_idx = slice_idx.round
             slice = slices[slice_idx]
           elsif slice_idx.is_a? Proc
             slice = slice_idx.call(slices)


### PR DESCRIPTION
`sample` has a similar issue to #1607 in its `slice` arg:
```ruby
(range 0, 4).each do |i|
  sample :loop_amen, slice: i
end
```
```
Runtime Error: [buffer 0, line 2] - NoMethodError
Thread death!
 undefined method `&' for 0.0:Float
```
I think this should fix it.