### PR TITLE
GUI - fix sample drag and drop

### DIFF
--- a/app/gui/qt/sonicpiscintilla.cpp
+++ b/app/gui/qt/sonicpiscintilla.cpp
@@ -22,7 +22,6 @@
 #include <Qsci/qscicommandset.h>
 #include <Qsci/qscilexer.h>
 #include <QCheckBox>
-#include <QDir>
 
 SonicPiScintilla::SonicPiScintilla(SonicPiLexer *lexer, SonicPiTheme *theme, QString fileName, OscSender *oscSender, QCheckBox *autoIndent)
   : QsciScintilla()
@@ -559,7 +558,7 @@ void SonicPiScintilla::dropEvent(QDropEvent *dropEvent)
     QList<QUrl> urlList = dropEvent->mimeData()->urls();
     QString text;
     for (int i = 0; i < urlList.size(); ++i) {
-      text += "\"" + QDir::toNativeSeparators(urlList.at(i).toLocalFile()) + "\"" + QLatin1Char('\n');
+      text += "\"" + urlList.at(i).toLocalFile() + "\"" + QLatin1Char('\n');
     }
     insert(text);
   }


### PR DESCRIPTION
The last change made for this issue actually again broke the ability to play
samples dragged into Sonic Pi. We don't want native path separators on Windows!

This has been tested on Windows and OS X. At least I now seem to have a working setup to build Sonic Pi on windows so I can test a little more properly :)