### PR TITLE
Util - Don't convert home dir on Windows

### DIFF
--- a/app/server/sonicpi/lib/sonicpi/util.rb
+++ b/app/server/sonicpi/lib/sonicpi/util.rb
@@ -94,7 +94,11 @@ module SonicPi
     end
 
     def unify_tilde_dir(path)
-      path.gsub(/\A#{@@tilde_dir}/, "~")
+      if os == :windows
+        path
+      else
+        path.gsub(/\A#{@@tilde_dir}/, "~")
+      end
     end
 
     def num_buffers_for_current_os


### PR DESCRIPTION
Since the tilde home directory shortcut does not exist on Windows, it does not
make sense to me to output the user's home directory as ~ in that case.

Current behaviour:
![current behviour](https://user-images.githubusercontent.com/10395940/27259134-6ff29a32-543e-11e7-9b8d-9ef793a73e2c.PNG)

Without converting home dir on Windows:
![without converting home dir](https://user-images.githubusercontent.com/10395940/27259143-83edd01a-543e-11e7-8996-cda611dea5b5.PNG)
