### PR TITLE
Fix buffer: arg for fx

### DIFF
--- a/app/server/sonicpi/lib/sonicpi/lang/sound.rb
+++ b/app/server/sonicpi/lib/sonicpi/lang/sound.rb
@@ -1962,6 +1962,8 @@ play 60 # plays note 60 with an amp of 0.5, pan of -1 and defaults for rest of a
           fx_synth_name = fx_name
         end
 
+        resolve_buffer_args!(args_h, info)
+
         tracker = SynthTracker.new
         orig_tracker = __system_thread_locals.get(:sonic_pi_local_mod_fx_tracker)
 


### PR DESCRIPTION
This commit ensures that the `buffer[:name, 16]` syntax works. At
present the only effect to use this arg is `:record`