### PR TITLE
Doc - fix formatting of assert_error example

### DIFF
--- a/app/server/sonicpi/lib/sonicpi/lang/core.rb
+++ b/app/server/sonicpi/lib/sonicpi/lang/core.rb
@@ -4436,7 +4436,7 @@ end                         # Will not throw an exception as the block contains 
 assert_error ThreadError do
   1 / 0
 end                         # Will throw an exception as the block contains a ZeroDivisionError rather than
-                              a ThreadError."]
+                            # a ThreadError."]
 
 
 


### PR DESCRIPTION
The last example for the assert_error fn was breaking across table cell boundaries. This has been fixed in a similar manner to one of the examples just above it, by putting a `#` where we wish the new line to wrap correctly.

Before:
![before](https://user-images.githubusercontent.com/10395940/27637918-0795ee04-5c44-11e7-98de-38c0183726d2.PNG)

After:
![after](https://user-images.githubusercontent.com/10395940/27637930-0ffe6eb8-5c44-11e7-8625-aacff72d7cd7.PNG)
