### PR TITLE
OSC - only show listening message once settings are loaded

### DIFF
--- a/app/gui/qt/mainwindow.cpp
+++ b/app/gui/qt/mainwindow.cpp
@@ -1149,7 +1149,7 @@ void MainWindow::honourPrefs() {
   updateLogAutoScroll();
   toggleScopeAxes();
   toggleMidi(1);
-  toggleOSCServer(1);
+  toggleOSCServer(0);
 
 
 

--- a/app/server/sonicpi/lib/sonicpi/runtime.rb
+++ b/app/server/sonicpi/lib/sonicpi/runtime.rb
@@ -1123,7 +1123,7 @@ module SonicPi
 
       # TODO Add support for TCP
 
-      __restart_cue_server!
+      __restart_cue_server!(false, true)
 
       @gui_heartbeats = {}
       @gui_last_heartbeat = nil


### PR DESCRIPTION
In https://github.com/samaaron/sonic-pi/issues/1656, it was noticed that the log message relating to the OSC server listening locally/remotely was not showing what we'd expect.

Why this was happening:
The OSC server is (re)started twice when Sonic Pi is opened.
Once when the ruby server runtime is initialised, and again when GUI
preference settings have been loaded.

Previously, during the runtime's initialisation, the OSC server was
always started with open = false, silent = false - since the GUI
preferences had not been loaded at this stage. The first log message
about the OSC server therefore always said that the server was only
listening locally, regardless of what the GUI preference had been set to
in previous sessions.

The second time the OSC server was loaded, (as a result of the GUI
honourPrefs() fn), 'open' was correctly set to whatever the preference
had been set to in the previous session, but you are never told this in
the log, since the __restart_cue_server! fn was called with silent =
false.

This commit swaps the value of 'silent' for the two calls to
_restart_cue_server! during startup, so that the first log message about
the OSC server, (always saying listening only locally) is not displayed
- and the second OSC server log message, which will respect the GUI
preference setting about listening locally and possibly remotely, *will*
be displayed.

The resulting log window on my Sonic Pi: (The MIDI error messages are because I have not installed the required MIDI components on my dev environment etc).
*Note: this fix means the OSC listening message is only displayed close to the end of the startup log messages, not at the beginning as before.*

![correct listening message](https://user-images.githubusercontent.com/10395940/27694234-146a9334-5d1e-11e7-9dcb-21475bd7671c.PNG)
