### PR TITLE
Various edits after proof reading

### DIFF
--- a/app/server/sonicpi/lib/sonicpi/synths/synthinfo.rb
+++ b/app/server/sonicpi/lib/sonicpi/synths/synthinfo.rb
@@ -4046,7 +4046,7 @@ Steal This Sound,  Mitchell Sigman"
       end
 
       def doc
-        "Outputs a mono signal to a soundcard output of your choice. By default will mix the incoming stereo signal (generated within the FX block) into a single mono channel. However, with the `mode:` opt, it is possible to alternatively send the either the incoming left or right channels out directly. "
+        "Outputs a mono signal to a soundcard output of your choice. By default will mix the incoming stereo signal (generated within the FX block) into a single mono channel. However, with the `mode:` opt, it is possible to alternatively send either the incoming left or right channel out directly. "
       end
 
       def kill_delay(args_h)

--- a/etc/doc/tutorial/05.6-Variables.md
+++ b/etc/doc/tutorial/05.6-Variables.md
@@ -3,7 +3,7 @@
 # Variables
 
 A useful thing to do in your code is to create names for things. Sonic
-Pi makes this very easy, you write the name you wish to use, an equal
+Pi makes this very easy: you write the name you wish to use, an equal
 sign (`=`), then the thing you want to remember:
 
 ```
@@ -31,7 +31,7 @@ it's important to remember that it's not just the computer that reads
 the code. Other people may read it too and try to understand what's going
 on. Also, you're likely to read your own code in the future and try to
 understand what's going on. Although it might seem obvious to you now -
-it might not be so obvious to others or even your future self! 
+it might not be so obvious to others or even your future self!
 
 One way to help others understand what your code is doing is to write
 comments (as we saw in a previous section). Another is to use meaningful
@@ -185,7 +185,7 @@ live_loop :shuffled do
 end
 ```
 
-However, sometimes to do want to share things across threads. For
+However, sometimes we do want to share things across threads. For
 example, the current key, BPM, synth etc. In these cases, the solution
 is to use Sonic Pi's special thread-safe state system via the fns `get`
 and `set`. This is discussed later on in section 10.

--- a/etc/doc/tutorial/13-Multichannel-Audio.md
+++ b/etc/doc/tutorial/13-Multichannel-Audio.md
@@ -8,14 +8,7 @@ then generated audio which has played through our stereo speaker
 system. However, many computers also have the ability to input sound,
 perhaps through a microphone, in addition to the ability to send sound
 out to more than two speakers. Often, this capability is made possible
-through the use of an external sound card - which are available for all
+through the use of an external sound card - these are available for all
 platforms. In this section of the tutorial we'll take a look at how we
 can take advantage of these external sound cards and effortlessly work
 with multiple channels of audio in and out of Sonic Pi.
-
-
-
-
-
-
-

--- a/etc/doc/tutorial/13.1-Sound-In.md
+++ b/etc/doc/tutorial/13.1-Sound-In.md
@@ -2,7 +2,7 @@
 
 # Sound In
 
-One simple (and perhaps familiar) way of accessing sound inputs is using our friend  `synth` by specifying the `:sound_in` synth:
+One simple (and perhaps familiar) way of accessing sound inputs is using our friend `synth` by specifying the `:sound_in` synth:
 
 ```
 synth :sound_in
@@ -17,7 +17,7 @@ plug any audio input to the first input.
 ## Increasing the Duration
 
 One thing you might notice is that just like `synth :dsaw` the
-`:sound_in` synth only lasts for 1 beat as it has a standard envelope. If you'd like to keep it open for a little longer, change the ADSR envelope settings. For examplethe following will keep the synth open for 8 beats before closing the connection:
+`:sound_in` synth only lasts for 1 beat as it has a standard envelope. If you'd like to keep it open for a little longer, change the ADSR envelope settings. For example the following will keep the synth open for 8 beats before closing the connection:
 
 ```
 synth :sound_in, sustain: 8
@@ -51,8 +51,8 @@ end
 
 ## Multiple Inputs
 
-You can also select which audio input you want to play with the `input:`
-opt. You can also specify a stereo input (two consectutive inputs) using
+You can select which audio input you want to play with the `input:`
+opt. You can also specify a stereo input (two consecutive inputs) using
 the `:sound_in_stereo` synth. For example, if you have a sound card with
 at least three inputs, you can treat the first two as a stereo stream
 and add distortion and the third as a mono stream and add reverb with

--- a/etc/doc/tutorial/13.2-Live-Audio.md
+++ b/etc/doc/tutorial/13.2-Live-Audio.md
@@ -2,7 +2,7 @@
 
 # Live Audio
 
-The `:sound_in` synth as described in the previous section provide a
+The `:sound_in` synth as described in the previous section provides a
 very flexible and familiar method for working with input audio. However,
 as also discussed it has a few issues when working with a single input
 of audio as a single instrument (such as a voice or guitar). By far the
@@ -105,7 +105,7 @@ panning. However, just like `:sound_in_stereo` it's also possible to
 tell `live_audio` to read two consecutive audio inputs and treat them as
 the left and right channels directly. This is achieved via the `:stereo`
 opt. For example, to treat input 2 as the left signal and input 3 as the
-right signal, you need to configure the `input:o opt to 2 and enable
+right signal, you need to configure the `input:` opt to 2 and enable
 stereo mode as follows:
 
 ```

--- a/etc/doc/tutorial/13.3-Sound-Out.md
+++ b/etc/doc/tutorial/13.3-Sound-Out.md
@@ -3,7 +3,7 @@
 # Sound Out
 
 So far in this section we've looked at how to get multiple streams of
-audio into Sonic Pi either through the use of the `:sound_in` or via the
+audio into Sonic Pi - either through the use of the `:sound_in` synth or via the
 powerful `live_audio` system. In addition to working with multiple
 streams of input audio, Sonic Pi can also output multiple streams of
 audio. This is achieved via the `:sound_out` FX.
@@ -21,9 +21,9 @@ with_fx :reverb do    # C
 end
 ```
 
-The simplest way to understand what's happing with the audio stream is
-to start at the inner most audio context and work our way out. In this
-case, the inner most context is labelled `A` and is the `:bd_haus` being
+The simplest way to understand what's happening with the audio stream is
+to start at the innermost audio context and work our way out. In this
+case, the innermost context is labelled `A` and is the `:bd_haus` sample being
 triggered. The audio for this goes directly into its context which is
 `B` - the `:echo` FX. This then adds echo to the incoming audio and
 outputs it to its context which is `C` - the `:reverb` FX. This then
@@ -35,7 +35,7 @@ through.
 ## Sound Out FX
 
 The above behaviour is true for all synths (including `live_audio`) and
-the majority of FX with the exception of `:sound_out`. The sound out FX
+the majority of FX with the exception of `:sound_out`. The `:sound_out` FX
 does two things. Firstly it outputs its audio to its external context as
 described above. Secondly it *also* outputs its audio directly to an
 output on your sound card. Let's take a look:
@@ -48,34 +48,34 @@ with_fx :reverb do      # C
 end
 ```
 
-In this example, our `:bd_haus` synth outputs its audio to its external
+In this example, our `:bd_haus` sample outputs its audio to its external
 context which is the `:sound_out` FX. This in turn outputs its audio to
-its external the `:reverb` FX (as expected). However, it *also* outputs
+its external context the `:reverb` FX (as expected). However, it *also* outputs
 a mono mix to the 3rd output of the system's soundcard. The audio
 generated within `:sound_out` therefore has two destinations - the
 `:reverb` FX and audio card output 3.
 
 ## Mono and Stereo out
 
-As we've seen, by default, the `sound_out` outputs a mono mix of the
+As we've seen, by default, the `:sound_out` FX outputs a mono mix of the
 stereo input to a specific channel in addition to passing the stereo
 feed to the outer context (as expected). If outputting a mono mix isn't
 precisely what you want to do, there are a number of alternative
 options. Firstly, by using the `mode:` opt you can choose to output just
 the left or just the right input signal to the audio card. Or you can
-use the `sound_out_stereo` FX to output to two consecutive sound card
+use the `:sound_out_stereo` FX to output to two consecutive sound card
 outputs. See the function documentation for more information and
 examples.
 
 ## Direct Out
 
-As we have seen, the default behaviour for `sound_out` and
-`sound_out_stereo` is to send the audio both to its external context (as
+As we have also seen, the default behaviour for `:sound_out` and
+`:sound_out_stereo` is to send the audio both to their external context (as
 is typical of all FX) *and* to the specified output on your
-soundcard. However, occasionally you my wish to *only* send to the
+soundcard. However, occasionally you may wish to *only* send to the
 output on your soundcard and not to the external context (and therefore
-not have any chance of the sound being mixed and send to the standard
-output channels 1 and 2). This is possible by using the stanard FX opt
+not have any chance of the sound being mixed and sent to the standard
+output channels 1 and 2). This is possible by using the standard FX opt
 `amp:` which operates on the audio *after* the FX has been able to
 manipulate the audio:
 
@@ -86,9 +86,9 @@ end
 ```
 
 In the above example, the `:loop_amen` sample is sent to its outer
-context, the `sound_out` FX. This then sends a mono mix to audio card
+context, the `:sound_out` FX. This then sends a mono mix to audio card
 output 3 and then multiplies the audio by 0 which essentially silences
 it. It is this silenced signal which is then sent out to the
-`sound_out`'s outer context which is the standard output. Therefore with
+`:sound_out`'s outer context which is the standard output. Therefore with
 this code, the default output channels will not receive any audio, and
 channel 3 will receive a mono mix of the amen drum break.


### PR DESCRIPTION
This includes edits for tutorial sections 5.6 (variables) and 13 (multichannel audio), as well as a fix for the `:sound_out` docstring. 