### PR TITLE
Correct OSC example

### DIFF
--- a/etc/doc/tutorial/12.1-Receiving-OSC.md
+++ b/etc/doc/tutorial/12.1-Receiving-OSC.md
@@ -42,7 +42,7 @@ from pythonosc import osc_message_builder
 from pythonosc import udp_client
 
 sender = udp_client.SimpleUDPClient('127.0.0.1', 4559)
-sender.send_message('/trigger/prophet', 70, 100, 8)
+sender.send_message('/trigger/prophet', [70, 100, 8])
 ```
 
 Or, if we're sending OSC from Clojure we might do something like this from the REPL:


### PR DESCRIPTION
sender.send_message caon only receive 2 arguments max. put the data in a list [...]