### PR TITLE
one-byte fix to docs ;)

### DIFF
--- a/etc/doc/tutorial/11.1-MIDI-In.md
+++ b/etc/doc/tutorial/11.1-MIDI-In.md
@@ -41,7 +41,7 @@ events such as:
 /midi/nanokey2_keyboard/0/1/note_on   [55, 81]
 /midi/nanokey2_keyboard/0/1/note_on   [53, 96]
 /midi/nanokey2_keyboard/0/1/note_off  [55, 64]
- ```
+```
 
 Once you can see a stream of messages like this, you've successfully
 connected your MIDI device. Congratulations, let's see what we can do


### PR DESCRIPTION
leading space on the close-multiline-code-sample marker ``` broke the
formatting in the qt gui, on macos at least.