### PR TITLE
Allow depending on libaubio.so.5.

### DIFF
--- a/app/server/vendor/ruby-aubio-prerelease/lib/aubio/api.rb
+++ b/app/server/vendor/ruby-aubio-prerelease/lib/aubio/api.rb
@@ -5,7 +5,7 @@ module Aubio
     extend FFI::Library
     # idea inspired by https://github.com/qoobaa/magic/blob/master/lib/magic/api.rb
     lib_paths = Array(ENV["AUBIO_LIB"] || Dir["/{opt,usr}/{,local/}{lib,lib64,Cellar/aubio**}/libaubio.{*.dylib,so.*}"])
-    fallback_names = %w(libaubio.4.2.2.dylib libaubio.so.1 aubio1.dll)
+    fallback_names = %w(libaubio.4.2.2.dylib libaubio.so.1 libaubio.so.5 aubio1.dll)
     ffi_lib(lib_paths + fallback_names)
 
     # tempo


### PR DESCRIPTION
On an Ubuntu Zesty install, the major version of the packaged libaubio
is 5. Without this, that causes build_zesty_app to fail without this patch
on a clean install, as the code only looks for libaubio.so.1.