### PR TITLE
Update build-rpi-app

### DIFF
--- a/app/gui/qt/build-rpi-app
+++ b/app/gui/qt/build-rpi-app
@@ -78,7 +78,7 @@ sudo make install
 
 #Install libaubio 4.2.2 (apt-get version is too old)
 cd $SP_ROOT
-git clone git://git.aubio.org/git/aubio/
+git clone https://git.aubio.org/git/aubio/
 cd aubio
 make getwaf
 ./waf configure


### PR DESCRIPTION
```
jamie@machine:~/sonic-pi-3.0.1/app/gui/qt$ git clone git://git.aubio.org/git/aubio/
Cloning into 'aubio'...
fatal: unable to connect to git.aubio.org:
git.aubio.org[0: 94.23.252.31]: errno=Connection refused
git.aubio.org[1: 2001:41d0:2:7f1f::1]: errno=Network is unreachable

jamie@machine:~/sonic-pi-3.0.1/app/gui/qt$ git clone https://git.aubio.org/git/aubio/
Cloning into 'aubio'...
remote: Counting objects: 17841, done.
remote: Compressing objects: 100% (7537/7537), done.
remote: Total 17841 (delta 12741), reused 14365 (delta 10089)
Receiving objects: 100% (17841/17841), 10.78 MiB | 1.75 MiB/s, done.
Resolving deltas: 100% (12741/12741), done.
Checking connectivity... done.
```