### PR TITLE
Workspace reported as nil if line == -1

### DIFF
--- a/app/server/sonicpi/lib/sonicpi/runtime.rb
+++ b/app/server/sonicpi/lib/sonicpi/runtime.rb
@@ -336,10 +336,10 @@ module SonicPi
       info = __current_job_info
       err_msg.gsub(/for #<SonicPiSpiderUser[a-z0-9:]+>/, '')
       res = ""
+      w = info[:workspace]
       if line != -1
 
         # TODO: Remove this hack when we have projects
-        w = info[:workspace]
         w = normalise_buffer_name(w)
         w = "buffer " + w
         # TODO: end of hack


### PR DESCRIPTION
While debugging why emacs was having trouble reporting live_loops not sleeping I noticed a little bug reporting a nil workspace name.

In current function w is referenced but not set if line is -1.