### PR TITLE
Stop ls_samples from matching files twice

### DIFF
--- a/app/server/sonicpi/lib/sonicpi/sample_loader.rb
+++ b/app/server/sonicpi/lib/sonicpi/sample_loader.rb
@@ -157,10 +157,11 @@ module SonicPi
       @folder_contents_mutex.synchronize do
         res = @cached_folder_contents[path]
         return res if res
+        pattern = '*.{[wW][aA][vV],[wW][aA][vV][eE],[aA][iI][fF],[aA][iI][fF][fF],[fF][lL][aA][cC]}'
         if recursive
-          res = Dir.chdir(path) { Dir.glob("**/*.{wav,wave,aif,aiff,flac,WAV,WAVE,AIF,AIFF,FLAC}").map {|p| File.expand_path(p) } }.sort
+          res = Dir.chdir(path) { Dir.glob("**/#{pattern}").map { |p| File.expand_path(p) } }.sort
         else
-          res = Dir.chdir(path) { Dir.glob("*.{wav,wave,aif,aiff,flac,WAV,WAVE,AIF,AIFF,FLAC}").map {|p| File.expand_path(p) } }.sort
+          res = Dir.chdir(path) { Dir.glob(pattern).map { |p| File.expand_path(p) } }.sort
         end
         @cached_folder_contents[path] = res.freeze
       end


### PR DESCRIPTION
Previously, in the ls_samples fn, the pattern given to Dir.glob was
matching any found sample twice - once because it matched the lowercase
pattern, and again because the uppercase pattern would also be a match
for samples named in lowercase. (The pattern is not a regex, so case
sensitivity is also handled a little differently).

In order to get around this problem, sets of characters are used, eg:
[wW][aA][vV], instead of matching on either of {wav, WAV} etc.