### PR TITLE
Docs - tidy up `at` docs page

### DIFF
--- a/app/server/ruby/lib/sonicpi/lang/core.rb
+++ b/app/server/ruby/lib/sonicpi/lang/core.rb
@@ -2393,7 +2393,7 @@ puts slept #=> Returns false as there were no sleeps in the block"]
 
 Note, all code within the block is executed in its own thread. Therefore despite inheriting all thread locals such as the random stream and ticks, modifications will be isolated to the block and will not affect external code.
 
-`at is just-in-time scheduling using multiple isolated threads. See `time_warp` for ahead-of-time scheduling within the current thread",
+`at` is just-in-time scheduling using multiple isolated threads. See `time_warp` for ahead-of-time scheduling within the current thread.",
           args:           [[:times, :list],
                            [:params, :list]],
           opts:           nil,


### PR DESCRIPTION
A markup highlighting issue has now been fixed, and a small grammatical improvement has been added.

Before:
<img width="662" alt="31308551-245f2a3a-abab-11e7-82a4-5a2b505583a7" src="https://user-images.githubusercontent.com/10395940/31309042-757f7530-abb2-11e7-8b59-7c9636eea1c1.png">

After:
<img width="664" alt="31308554-29927e12-abab-11e7-9526-b13928a71fb8" src="https://user-images.githubusercontent.com/10395940/31309041-72c5cf56-abb2-11e7-818b-bb8f9c2c691d.png">

