### PR TITLE
GUI - fix light mode prefs pro icon

### DIFF
--- a/app/gui/qt/mainwindow.cpp
+++ b/app/gui/qt/mainwindow.cpp
@@ -2296,7 +2296,11 @@ void MainWindow::toggleIcons() {
         helpAct->setIcon(pro_help_icon);
       }
 
-      prefsAct->setIcon(pro_prefs_icon);
+      if (prefsWidget->isVisible()) {
+        prefsAct->setIcon(pro_prefs_bordered_icon);
+      } else {
+        prefsAct->setIcon(pro_prefs_icon);
+      }
     }
   } else {
     toolBar->setIconSize(QSize(73, 30));


### PR DESCRIPTION
Previously, the pro icon for the preferences button would always be
reset to 'off' (non bordered) when switching from dark to light mode,
even if the preferences pane was visible. This has now been fixed.