### PR TITLE
Doc - fix value described as default tremolo depth

### DIFF
--- a/app/server/ruby/lib/sonicpi/synths/synthinfo.rb
+++ b/app/server/ruby/lib/sonicpi/synths/synthinfo.rb
@@ -7238,7 +7238,7 @@ Use FX `:band_eq` with a negative db for the opposite effect - to attenuate a gi
           :phase_offset => 0,
           :wave => 2,
           :invert_wave => 0,
-          :depth => 5,
+          :depth => 0.5,
           :depth_slide => 0,
           :depth_slide_shape => 1,
           :depth_slide_curve => 0


### PR DESCRIPTION
According to synthinfo metadata, tremolo's depth parameter is valid between 0 and 1 inclusive. However, the docs describe the default depth value as 5:

![capture](https://user-images.githubusercontent.com/10395940/31825271-3884f02e-b5e4-11e7-9878-ab40c328bb97.PNG)

Additionally, the default depth value specified in the synthdef design file is 0.5, so the value of 5 was likely a typo.