### PR TITLE
Fixed and improved recipe for Ubuntu build.

### DIFF
--- a/app/gui/qt/build-ubuntu-app
+++ b/app/gui/qt/build-ubuntu-app
@@ -7,11 +7,13 @@ set -e
 SUPERCOLLIDER_VERSION=3.8.0
 SC_PLUGINS_VERSION=${SUPERCOLLIDER_VERSION}
 AUBIO_VERSION=0.4.5
+OSMID_VERSION=391f35f789f18126003d2edf32902eb714726802
 
 #Internal definitions
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 SP_APP_SRC=${SCRIPT_DIR}
 SP_ROOT=${SP_APP_SRC}/../../../../
+OSMID_DIR=${SP_APP_SRC}/../../server/native/linux/osmid
 
 echo "This script has been tested on ubuntu 16.04, it should work on ubuntu 15.10."
 echo "14.04 users may need to install some of the dependencies by hand from source"
@@ -26,7 +28,7 @@ sudo apt-get install -y \
      libqwt-qt5-dev libqt5scintilla2-dev libqt5svg5-dev qt5-qmake qt5-default \
      qttools5-dev qttools5-dev-tools qtdeclarative5-dev libqt5webkit5-dev \
      qtpositioning5-dev libqt5sensors5-dev qtmultimedia5-dev libffi-dev \
-     curl python
+     curl python erlang-base
 
 ### IF YOU HAVE PROBLEMS WITH qwt
 #cd $SP_APP_SRC/../../../../
@@ -53,7 +55,7 @@ git clone https://github.com/supercollider/supercollider.git || true
 cd supercollider
 git checkout Version-${SUPERCOLLIDER_VERSION}
 git submodule init && git submodule update
-mkdir build || true
+mkdir -p build
 cd build
 cmake -DSC_EL=no ..
 make
@@ -67,7 +69,7 @@ cd sc3-plugins
 git checkout Version-${SC_PLUGINS_VERSION}
 git submodule init && git submodule update
 cp -r external_libraries/nova-simd/* source/VBAPUGens
-mkdir build || true
+mkdir -p build
 cd build
 cmake -DSC_PATH=/usr/local/include/SuperCollider -DCMAKE_INSTALL_PREFIX=/usr/local -DCMAKE_BUILD_TYPE=Release ..
 make
@@ -82,6 +84,23 @@ make getwaf
 ./waf configure
 ./waf build
 sudo ./waf install
+
+#Install osmid (for MIDI support)
+cd ${SP_ROOT}
+git clone https://github.com/llloret/osmid.git || true
+cd osmid
+git checkout ${OSMID_VERSION}
+mkdir -p build
+cd build
+cmake ..
+make
+mkdir -p ${OSMID_DIR}
+install m2o o2m -t ${OSMID_DIR}
+
+#Build Erlang files
+cd ${SP_APP_SRC}/../../server/erlang
+erlc osc.erl
+erlc pi_server.erl
 
 #Build sonic-pi server extensions, documentation, and binary.
 cd ${SP_APP_SRC}

--- a/app/gui/qt/build-ubuntu-app
+++ b/app/gui/qt/build-ubuntu-app
@@ -1,6 +1,17 @@
-#!/bin/sh
+#!/bin/bash
 
-SP_APP_SRC=`pwd`
+#Fail script on first error encountered
+set -e
+
+#Application/library versions built by this script.
+SUPERCOLLIDER_VERSION=3.8.0
+SC_PLUGINS_VERSION=${SUPERCOLLIDER_VERSION}
+AUBIO_VERSION=0.4.5
+
+#Internal definitions
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+SP_APP_SRC=${SCRIPT_DIR}
+SP_ROOT=${SP_APP_SRC}/../../../../
 
 echo "This script has been tested on ubuntu 16.04, it should work on ubuntu 15.10."
 echo "14.04 users may need to install some of the dependencies by hand from source"
@@ -8,7 +19,14 @@ echo "We're working to make this script a one shot solution for all Linux platfo
 echo "Please direct rage and suggestions to Factoid in (https://gitter.im/samaaron/sonic-pi)"
 
 #Install dependencies for building supercollider, as well as qt5 and supporting libraries for gui
-sudo apt-get install -y g++ ruby ruby-dev pkg-config git build-essential libjack-jackd2-dev libsndfile1-dev libasound2-dev libavahi-client-dev libicu-dev libreadline6-dev libfftw3-dev libxt-dev libudev-dev cmake libboost1.58-dev libqwt-qt5-dev libqt5scintilla2-dev libqt5svg5-dev qt5-qmake qt5-default qttools5-dev qttools5-dev-tools qtdeclarative5-dev libqt5webkit5-dev qtpositioning5-dev libqt5sensors5-dev qtmultimedia5-dev libffi-dev
+sudo apt-get install -y \
+     g++ ruby ruby-dev pkg-config git build-essential libjack-jackd2-dev \
+     libsndfile1-dev libasound2-dev libavahi-client-dev libicu-dev \
+     libreadline6-dev libfftw3-dev libxt-dev libudev-dev cmake libboost1.58-dev \
+     libqwt-qt5-dev libqt5scintilla2-dev libqt5svg5-dev qt5-qmake qt5-default \
+     qttools5-dev qttools5-dev-tools qtdeclarative5-dev libqt5webkit5-dev \
+     qtpositioning5-dev libqt5sensors5-dev qtmultimedia5-dev libffi-dev \
+     curl python
 
 ### IF YOU HAVE PROBLEMS WITH qwt
 #cd $SP_APP_SRC/../../../../
@@ -29,46 +47,48 @@ sudo apt-get install -y g++ ruby ruby-dev pkg-config git build-essential libjack
 #make
 #sudo make install
 
-#Build supercollider 3.8 from source
-cd ../../../../
-SP_ROOT=`pwd`
-git clone https://github.com/supercollider/supercollider.git
+#Build supercollider from source
+cd ${SP_ROOT}
+git clone https://github.com/supercollider/supercollider.git || true
 cd supercollider
+git checkout Version-${SUPERCOLLIDER_VERSION}
 git submodule init && git submodule update
-mkdir build
+mkdir build || true
 cd build
-cmake -DSC_EL=no -DCMAKE_PREFIX_PATH=/usr/lib/x86_64-linux-gnu/qt5 ..
+cmake -DSC_EL=no ..
 make
 sudo make install
 #This should install to /usr/local/
 
-#Build sc3 plugins and install to /usr/local/ so supercollider 3.7.1 can find them
-cd $SP_ROOT
-git clone https://github.com/supercollider/sc3-plugins.git
+#Build sc3 plugins and install to /usr/local/ so supercollider can find them
+cd ${SP_ROOT}
+git clone https://github.com/supercollider/sc3-plugins.git || true
 cd sc3-plugins
+git checkout Version-${SC_PLUGINS_VERSION}
 git submodule init && git submodule update
 cp -r external_libraries/nova-simd/* source/VBAPUGens
-mkdir build
+mkdir build || true
 cd build
 cmake -DSC_PATH=/usr/local/include/SuperCollider -DCMAKE_INSTALL_PREFIX=/usr/local -DCMAKE_BUILD_TYPE=Release ..
 make
 sudo make install
 
-#Install libaubio 4.2.2 (apt-get version is too old)
-cd $SP_ROOT
-git clone git://git.aubio.org/git/aubio/
+#Install libaubio (apt-get version is too old)
+cd ${SP_ROOT}
+git clone https://git.aubio.org/git/aubio/ || true
 cd aubio
+git checkout ${AUBIO_VERSION}
 make getwaf
 ./waf configure
 ./waf build
 sudo ./waf install
 
 #Build sonic-pi server extensions, documentation, and binary.
-cd $SP_APP_SRC
+cd ${SP_APP_SRC}
 ../../server/bin/compile-extensions.rb
 ../../server/bin/i18n-tool.rb -t
 cp -f ruby_help.tmpl ruby_help.h
 ../../server/bin/qt-doc.rb -o ruby_help.h
-lrelease SonicPi.pro 
-qmake -qt=qt5 SonicPi.pro 
+lrelease SonicPi.pro
+qmake -qt=qt5 SonicPi.pro
 make


### PR DESCRIPTION
- `aubio` repository pull failed (needed `https`, not `git` prefix)
- Pin externally pulled repositories to fixed versions to ensure reproducibility
- Add new dependency packages (curl, python) to allow build to work in clean `Docker` container
- Use `bash` and add `set -e` to fail build on first error
- New recipe was tested in pristine pull of `Ubuntu 16.04` `Docker` container
- Added osmid and Erlang files to build process for MIDI support
- Fixes #1742 #1752 