### PR TITLE
Fix jack_connect call for system:capture inputs.

### DIFF
--- a/app/server/sonicpi/lib/sonicpi/scsynthexternal.rb
+++ b/app/server/sonicpi/lib/sonicpi/scsynthexternal.rb
@@ -428,8 +428,8 @@ module SonicPi
 
       `jack_connect SuperCollider:out_1 system:playback_1`
       `jack_connect SuperCollider:out_2 system:playback_2`
-      `jack_connect SuperCollider:in_1 system_capture_1`
-      `jack_connect SuperCollider:in_2 system_capture_2`
+      `jack_connect SuperCollider:in_1 system:capture_1`
+      `jack_connect SuperCollider:in_2 system:capture_2`
     end
   end
 end


### PR DESCRIPTION
Fix typo, which resulted in failed jack_connect call.