### PR TITLE
Fix MIDI on platforms with older versions of Erlang (< 19.1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,6 +84,7 @@ app/gui/qt/qrc__*
 \.#*
 .lein-plugins
 *~
+*.orig
 
 # Native
 

--- a/app/gui/qt/build-ubuntu-app
+++ b/app/gui/qt/build-ubuntu-app
@@ -99,6 +99,20 @@ install m2o o2m -t ${OSMID_DIR}
 
 #Build Erlang files
 cd ${SP_APP_SRC}/../../server/erlang
+#The current implementation of osc.erl uses Erlang features that require
+#at least Erlang 19.1 to be installed. 16.04 LTS is currently at 18.3.
+#If versions < 19.1 are installed, and we use the current code, the MIDI
+#implementation breaks because the Erlang OSC router is failing.
+ERLANG_VERSION=$(./print_erlang_version)
+if [ -e "osc.erl.orig" ]; then
+    # Handle, if the original file in the source tree ever gets updated.
+    rm osc.erl.orig
+    git checkout osc.erl
+fi
+if [[ "${ERLANG_VERSION}" < "19.1" ]]; then
+    echo "Found Erlang version < 19.1 (${ERLANG_VERSION})! Updating source code."
+    sed -i.orig 's|erlang:system_time(nanosecond)|erlang:system_time(nano_seconds)|' osc.erl
+fi
 erlc osc.erl
 erlc pi_server.erl
 

--- a/app/server/erlang/print_erlang_version
+++ b/app/server/erlang/print_erlang_version
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+erl -eval '{ok, Version} = file:read_file(filename:join([code:root_dir(), "releases", erlang:system_info(otp_release), "OTP_VERSION"])), io:fwrite(Version), halt().' -noshell


### PR DESCRIPTION
On Ubuntu 16.04, the Erlang version is 18.3. The current implementation of `osc.erl` requires at least version 19.1 to support the keyword `nanosecond` used in the `now()` method (see https://bugs.erlang.org/browse/ERL-339). This breaks the MIDI implementation because the Erlang OSC server spits out errors for every message. With these changes applied, I finally see activity on the MIDI output port (LED is my external MIDI device is blinking).

Changes:
- Added script to print out Erlang version (yes...it is THAT hard).
- Update Ubuntu build script to detect older version and update the `osc.erl` source file with the old keyword `nano_seconds`. Make backup of old source file.
- Add backup of source file to .gitignore.