### PR TITLE
Docs - Remove information about the Align button from tutorial

### DIFF
--- a/etc/doc/tutorial/01.2-Exploring-the-Interface.md
+++ b/etc/doc/tutorial/01.2-Exploring-the-Interface.md
@@ -29,8 +29,7 @@ sound playing.
 
 These orange buttons allow you to manipulate the code editor. The *Size
 +* and *Size -* buttons allow you to make the text bigger and
-smaller. The *Align* button will neaten the code for you to make it look
-more professional.
+smaller.
 
 ## C. Info and Help
 


### PR DESCRIPTION
A minor update to the tutorial

closes https://github.com/samaaron/sonic-pi/issues/1719
  