### PR TITLE
Typos - fix typo in tech_saws docstring

### DIFF
--- a/app/server/ruby/lib/sonicpi/synths/synthinfo.rb
+++ b/app/server/ruby/lib/sonicpi/synths/synthinfo.rb
@@ -3089,7 +3089,7 @@ Steal This Sound,  Mitchell Sigman"
       end
 
       def doc
-        "Slightly modified supersaw implementation beased on http://sccode.org/1-4YS"
+        "Slightly modified supersaw implementation based on http://sccode.org/1-4YS"
       end
 
       def arg_defaults


### PR DESCRIPTION
Thanks to Martin Gondermann for making [a great live coding video](https://www.youtube.com/watch?v=Jcv5W3RXDzc) which incidentally helped me to spot this 😄 

