### PR TITLE
Linux Mint build fix

### DIFF
--- a/app/gui/qt/build-ubuntu-app
+++ b/app/gui/qt/build-ubuntu-app
@@ -28,7 +28,7 @@ sudo apt-get install -y \
      libqwt-qt5-dev libqt5scintilla2-dev libqt5svg5-dev qt5-qmake qt5-default \
      qttools5-dev qttools5-dev-tools qtdeclarative5-dev libqt5webkit5-dev \
      qtpositioning5-dev libqt5sensors5-dev qtmultimedia5-dev libffi-dev \
-     curl python erlang-base
+     libqt5opengl5-dev curl python erlang-base
 
 ### IF YOU HAVE PROBLEMS WITH qwt
 #cd $SP_APP_SRC/../../../../

--- a/app/gui/qt/build-ubuntu-app
+++ b/app/gui/qt/build-ubuntu-app
@@ -4,7 +4,7 @@
 set -e
 
 #Application/library versions built by this script.
-SUPERCOLLIDER_VERSION=3.8.0
+SUPERCOLLIDER_VERSION=3.9.0
 SC_PLUGINS_VERSION=${SUPERCOLLIDER_VERSION}
 AUBIO_VERSION=0.4.5
 OSMID_VERSION=391f35f789f18126003d2edf32902eb714726802
@@ -118,10 +118,10 @@ erlc pi_server.erl
 
 #Build sonic-pi server extensions, documentation, and binary.
 cd ${SP_APP_SRC}
-../../server/bin/compile-extensions.rb
-../../server/bin/i18n-tool.rb -t
+../../server/ruby/bin/compile-extensions.rb
+../../server/ruby/bin/i18n-tool.rb -t
 cp -f ruby_help.tmpl ruby_help.h
-../../server/bin/qt-doc.rb -o ruby_help.h
+../../server/ruby/bin/qt-doc.rb -o ruby_help.h
 lrelease SonicPi.pro
 qmake -qt=qt5 SonicPi.pro
 make


### PR DESCRIPTION
OS: Linux Mint 18.3

After running the build-ubuntu-app script, I've repeatedly gotten several warnings (and an eventual error) that I eventually discovered were related to SuperCollider being unable to find Qt5 OpenGL. After a LOT of searching online (to no avail), I opened Synaptic looking for a package that might be missing and found libqt5opengl5-dev. I've tested building again with and without it installed and the result is SuperCollider built successfully while I had it installed. Following this, here are the changes I've made to the build script:
    - Added the missing package to the build script
    - Updated references to the app/server/bin folder to point to app/server/ruby/bin
    - Changed the SuperCollider version to 3.9.0, as otherwise Sonic Pi crashed a few seconds after startup (I think this was referenced in an issue as well)

After all this, I now (finally! :D) have a working build of Sonic Pi 3.1.0! Hopefully this helps someone trying to build this in the future.