### PR TITLE
Fix tutorial link

### DIFF
--- a/etc/doc/tutorial/C.01-Basic-API.md
+++ b/etc/doc/tutorial/C.01-Basic-API.md
@@ -1,4 +1,4 @@
-11.1 Basic API
+C.1 Basic API
 
 # Basic Minecraft Pi API
 


### PR DESCRIPTION
I was having a look at the online copy of this tutorial, and I noticed that the link from the table of contents (left pane) to the "Minecraft Pi - Basic API" subsection is incorrectly numbered (11.1 instead of C.1), and so it links to the wrong section of the doc. Hopefully this should fix it?