### PR TITLE
Modified run-debian-app, and fixed mistakes in INSTALL-LINUX.md

### DIFF
--- a/INSTALL-LINUX.md
+++ b/INSTALL-LINUX.md
@@ -46,7 +46,7 @@ In this section, you will find information to help with building Sonic Pi on a P
 
 ### Get the Sonic Pi Source Code
 
-First, we need to download the source code to a reasonable location. You can do this via a few different ways depending on which version you want to build: 
+First, we need to download the source code to a reasonable location. You can do this via a few different ways depending on which version you want to build:
 * **Get the source code for a certain release of Sonic Pi:**
   Type these commands in your terminal (replace 'v3.1.0' with the version of sonic pi that you want to get the source code for):
   ````
@@ -77,18 +77,18 @@ If the script doesn't work you may need to resolve dependencies yourself, see 'I
 
 checkinstall has been added because it turns manually built programs into packages which can be installed and removed from your system. The packages seem to be easier to uninstall than programs installed via. `make install`, as you can uninstall packages via your package manager. If you think that there's a better program/package to do this, then let us know.
 
-If this script isn't there, make a new file in /app/gui/qt called `build-debian-app`, and go to https://github.com/samaaron/sonic-pi/app/gui/qt/build-debian-app and copy the contents of that to the new file on your computer. Then save the file, and run this command in your terminal in the `/app/gui/qt/` folder to make it executable: `chmod -u+x build-debian-app`. Now you should be able to run this script.
+If this script isn't there, make a new file in /app/gui/qt called `build-debian-app`, and go to https://github.com/samaaron/sonic-pi/blob/master/app/gui/qt/build-debian-app and copy the contents of that to the new file on your computer. Then save the file, and run this command in your terminal in the `/app/gui/qt/` folder to make it executable: `chmod -u+x build-debian-app`. Now you should be able to run this script.
 
 ### Running Sonic Pi
 
 You can now run Sonic Pi using the `run-debian-app` script:
 ````
 cd ../../../ # Go to the root of the sonic-pi source code folder
-./build-debian-app
+./run-debian-app
 ````
 This script will open Sonic Pi, and clean up any leftover processes when it closes.
 
-If this script isn't there, make a new file in the root of the sonic-pi source code folder, called `run-debian-app`, and go to https://github.com/samaaron/sonic-pi/run-debian-app and copy the contents of that to the new file on your computer. Then save the file, and run this command in your terminal in the root of the sonic-pi source code folder, to make it executable: `chmod -u+x build-debian-app`. Now you should be able to run this script.
+If this script isn't there, make a new file in the root of the sonic-pi source code folder, called `run-debian-app`, and go to https://github.com/samaaron/sonic-pi/blob/master/run-debian-app and copy the contents of that to the new file on your computer. Then save the file, and run this command in your terminal in the root of the sonic-pi source code folder, to make it executable: `chmod -u+x run-debian-app`. Now you should be able to run this script.
 
 **There's no guarantees that these scripts will work 100%.** I haven't tested them that much, and I've only tested them on one system.
 
@@ -103,13 +103,13 @@ This information applies to Sonic Pi v3.1.0, but it **may** be useful informatio
 * **aubio & osmid** - The latest versions of these seem to work fine.
 * All other required packages can be installed from the Debian repositories:
 
-   ` sudo apt-get install -y 
-    g++ ruby ruby-dev pkg-config git build-essential libjack-jackd2-dev 
-    libsndfile1-dev libasound2-dev libavahi-client-dev libicu-dev 
-    libreadline6-dev libfftw3-dev libxt-dev libudev-dev cmake libboost-dev 
-    libqwt-qt5-dev libqt5scintilla2-dev libqt5svg5-dev qt5-qmake qt5-default 
-    qttools5-dev qttools5-dev-tools qtdeclarative5-dev libqt5webkit5-dev 
-    qtpositioning5-dev libqt5sensors5-dev qtmultimedia5-dev libffi-dev 
+   ` sudo apt-get install -y
+    g++ ruby ruby-dev pkg-config git build-essential libjack-jackd2-dev
+    libsndfile1-dev libasound2-dev libavahi-client-dev libicu-dev
+    libreadline6-dev libfftw3-dev libxt-dev libudev-dev cmake libboost-dev
+    libqwt-qt5-dev libqt5scintilla2-dev libqt5svg5-dev qt5-qmake qt5-default
+    qttools5-dev qttools5-dev-tools qtdeclarative5-dev libqt5webkit5-dev
+    qtpositioning5-dev libqt5sensors5-dev qtmultimedia5-dev libffi-dev
     curl python erlang-base`
 
 #### Ruby Server Extensions

--- a/INSTALL-LINUX.md
+++ b/INSTALL-LINUX.md
@@ -66,14 +66,14 @@ First, we need to download the source code to a reasonable location. You can do 
 
 ### Building Sonic Pi
 
-There's a bash script file called `/app/gui/qt/build-debian-app`, which is an install script to help assist in installing dependecies and building Sonic Pi. You can run it by typing these commands into the terminal:
+There's a bash script file called `/app/gui/qt/build-debian-app`, which is an install script to help assist in installing dependecies and building Sonic Pi. It's been tested with Sonic Pi v3.1 (as of the time of writing), it may or may not work with other versions. You can run it by typing these commands into the terminal:
 ````
 cd app/gui/qt/
 ./build-debian-app
 ````
 It's a modified version of /app/gui/qt/build-ubuntu-app that includes: some changes that to get it working, updated versions of packages, the option to install some packages via: `make install`, or `checkinstall install=no` & `dpkg -i`, and other fixes/tweaks.
 
-If the script doesn't work you may need to resolve dependencies yourself, see 'Information about dependencies (for Sonic Pi v3.1.0)' for more info.
+If the script doesn't work you may need to resolve dependencies yourself, see 'Information about dependencies' for more info.
 
 checkinstall has been added because it turns manually built programs into packages which can be installed and removed from your system. The packages seem to be easier to uninstall than programs installed via. `make install`, as you can uninstall packages via your package manager. If you think that there's a better program/package to do this, then let us know.
 

--- a/run-debian-app
+++ b/run-debian-app
@@ -1,13 +1,14 @@
 #!/bin/bash
 # Sonic Pi Launch Script for Debian 9/Stretch - by SunderB
 set -e # Quit script on error
+# -x # Verbose
 echo "Starting Sonic Pi... Please leave this window open, it will clear up processes and close automatically."
-./app/gui/qt/sonic-pi # Run Sonic Pi
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+"${SCRIPT_DIR}/app/gui/qt/sonic-pi" # Run Sonic Pi
 
 # The script will resume when Sonic Pi is closed.
 # Close left over beam.smp processes
 echo "Sonic Pi closed. Closing any left over processes..."
-# -x # Verbose
 
 # Set up array
 pidsArray=()


### PR DESCRIPTION
Hi, this change should allow run-debian-app to be run in the terminal when the user is located in any directory. For example, if you are in the terminal, in your home directory, you can now run the script by typing `/path/to/sonic-pi/run-debian-app`. Previously it could fail due to it using relative paths.

Edit: I've also fixed some mistakes in INSTALL-LINUX.md.

P.S. I'm not sure whether the commit message is clear enough, if it's not clear enough, then I could amend the commit and re-submit a pull request.