### PR TITLE
Fix typo in tutorial A.16

### DIFF
--- a/etc/doc/tutorial/A.16-practice.md
+++ b/etc/doc/tutorial/A.16-practice.md
@@ -112,7 +112,7 @@ save!
 Many musicians can look at a musical score and hear the music in their
 head without having to play it. This is a very useful skill and it's
 well worth incorporating into your live coding practice sessions. The
-imporant point is to be able to have some understanding of what the code
+important point is to be able to have some understanding of what the code
 is going to sound like. You don't need to be able to hear it exactly in
 your head, but instead it's useful to know if the code is going to be
 fast, slow, loud, rhythmic, melodic, random, etc. The final goal is then


### PR DESCRIPTION
In the tutorial's Appendix A under A.16 `imporant` should be `important`.

