### PR TITLE
Fix macOS build script to work across more versions & make it idempotent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,6 +81,7 @@ app/gui/qt/qrc__*
 *.DS_Store
 *.log
 *.swp
+*.tmp
 \.#*
 .lein-plugins
 *~

--- a/app/gui/qt/Brewfile
+++ b/app/gui/qt/Brewfile
@@ -1,0 +1,7 @@
+brew "qt"
+brew "boost"
+brew "cmake"
+brew "pkg-config"
+brew "aubio"
+brew "wget"
+brew "qscintilla2"

--- a/app/gui/qt/Brewfile-qt55
+++ b/app/gui/qt/Brewfile-qt55
@@ -1,0 +1,6 @@
+brew "qt55"
+brew "boost"
+brew "cmake"
+brew "pkg-config"
+brew "aubio"
+brew "wget"

--- a/app/gui/qt/SonicPi.pro
+++ b/app/gui/qt/SonicPi.pro
@@ -34,7 +34,7 @@ macx {
   QMAKE_CXXFLAGS += -Wall -Werror -Wextra -Wno-unused-variable -Wno-unused-parameter
   CONFIG += warn_off
   TARGET = 'Sonic Pi'
-  LIBS += -lqscintilla2_qt5
+  LIBS += -lqscintilla2
 }
 
 # Windows only

--- a/app/gui/qt/SonicPi.pro
+++ b/app/gui/qt/SonicPi.pro
@@ -34,7 +34,11 @@ macx {
   QMAKE_CXXFLAGS += -Wall -Werror -Wextra -Wno-unused-variable -Wno-unused-parameter
   CONFIG += warn_off
   TARGET = 'Sonic Pi'
-  LIBS += -lqscintilla2
+  LIBS += -lqscintilla2_qt5
+  debug {
+    QMAKE_LFLAGS += -g -O0
+    QMAKE_CXXFLAGS += -g -O0
+  }
 }
 
 # Windows only

--- a/app/gui/qt/build-osx-app
+++ b/app/gui/qt/build-osx-app
@@ -36,32 +36,35 @@ See https://github.com/nodejs/node-gyp/issues/569
 EOF
   exit 1
 fi
-
 #Ensure homebrew is installed
 if [[ -z "$(which brew)" ]]; then
   echo "No homebrew found - installing Homebrew from https://brew.sh"
   /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
 fi
+
 #Install homebrew prerequisites
-brew install qt55 boost cmake pkg-config aubio libsndfile wget
+brew bundle
 QT55="$(brew --prefix qt55)"
+
+function wget-idempotent (){
+    if [[ ! -f "$2" ]]; then
+        wget "$1" -O "$2"
+    fi
+}
+
+function git-clone-idempotent (){
+    if [[ ! -d "$2" ]]; then
+        git clone "$1" "$2"
+    fi
+}
+#function skip() {
 
 #Download and extract source packages
 cd "$SP_ROOT"
 pwd
-if [[ ! -d supercollider ]]; then
-    git clone https://github.com/supercollider/supercollider.git
-fi
-if [[ ! -d sc3-plugins ]]; then
-  git clone https://github.com/supercollider/sc3-plugins.git
-fi
-if [[ ! -f QScintilla_gpl-2.9.2.tar.gz ]]; then
-  wget 'https://sourceforge.net/projects/pyqt/files/QScintilla2/QScintilla-2.9.2/QScintilla_gpl-2.9.2.tar.gz'
-fi
-if [[ ! -f qwt-6.1.2.tar.bz2 ]]; then
-  wget 'https://downloads.sourceforge.net/project/qwt/qwt/6.1.2/qwt-6.1.2.tar.bz2'
-fi
-tar -xf QScintilla_gpl-2.9.2.tar.gz
+git-clone-idempotent https://github.com/supercollider/supercollider.git supercollider
+git-clone-idempotent https://github.com/supercollider/sc3-plugins.git sc3-plugins
+wget-idempotent 'https://downloads.sourceforge.net/project/qwt/qwt/6.1.2/qwt-6.1.2.tar.bz2' qwt-6.1.2.tar.bz2
 tar -xf qwt-6.1.2.tar.bz2
 
 #Build supercollider 3.8 from source
@@ -85,13 +88,8 @@ cmake -DSC_PATH="$SP_ROOT/supercollider/" -DCMAKE_INSTALL_PREFIX=/usr/local -DCM
 make
 sudo make install
 rsync -arv SC3plugins "$SP_ROOT/supercollider/build/editors/sc-ide/SuperCollider.app/Contents/Resources/plugins/"
-
-
-#Build qscintilla libraries for Qt5
-cd "$SP_ROOT/QScintilla_gpl-2.9.2/Qt4Qt5/"
-"$QT55/bin/qmake" qscintilla.pro
-make
-sudo make install
+#copy qscintilla2 features into qt5 features
+cp /usr/local/opt/qscintilla2/data/mkspecs/features/* "$QT55/mkspecs/features"
 
 #Build qwt libraries for Qt5
 cd "$SP_ROOT/qwt-6.1.2"
@@ -106,6 +104,7 @@ cd "$SP_APP_SRC"
 "$SP_SRC/app/server/ruby/bin/i18n-tool.rb" -t
 cp -f ruby_help.tmpl ruby_help.h
 "$SP_SRC/app/server/ruby/bin/qt-doc.rb" -o ruby_help.h
+#}
 "$QT55/bin/lrelease" SonicPi.pro 
 "$QT55/bin/qmake" SonicPi.pro 
 make
@@ -117,11 +116,10 @@ make
 cd "$SP_APP_SRC/Sonic Pi.app"
 ln -f -s "$SP_SRC/app/" ./
 ln -f -s "$SP_SRC/etc/" ./
-ln -f -s "$SP_ROOT/supercollider/build/editors/sc-ide/SuperCollider.app/Contents/Resources/scsynth" "$SP_SRC/app/server/native/osx/scsynth"
 ln -f -s "$SP_ROOT/supercollider/build/editors/sc-ide/SuperCollider.app/Contents/Resources/scsynth" "$SP_SRC/app/server/native/scsynth"
 mkdir -p "$SP_SRC/app/server/native/ruby/bin"
 ln -f -s "$(which ruby)" "$SP_SRC/app/server/native/ruby/bin/ruby"
-rsync -arv "$SP_ROOT/QScintilla_gpl-2.9.2/Qt4Qt5/libqscintilla2".* Contents/MacOS/
+rsync -arv /usr/local/opt/qscintilla2/lib/*.dylib Contents/MacOS/
 rsync -arv "$SP_ROOT/qwt-6.1.2/lib/" Contents/MacOS/
 install_name_tool -change qwt.framework/Versions/6/qwt @executable_path/qwt.framework/Versions/6/qwt Contents/MacOS/Sonic\ Pi 
 install_name_tool -change libqscintilla2.12.dylib @executable_path/libqscintilla2.12.dylib Contents/MacOS/Sonic\ Pi 

--- a/app/gui/qt/build-osx-app
+++ b/app/gui/qt/build-osx-app
@@ -61,7 +61,11 @@ fi
 
 #Install homebrew prerequisites
 brew bundle --file="$BREWFILE"
-QT="$(brew --prefix qt)"
+if [[ "$MAC_OS_VERSION" -lt "$MAC_OS_MODERN_VERSION" ]]; then
+    QT="$(brew --prefix qt55)"
+else
+    QT="$(brew --prefix qt)"
+fi
 
 function wget-idempotent (){
     if [[ ! -f "$2" ]]; then

--- a/app/gui/qt/build-osx-app
+++ b/app/gui/qt/build-osx-app
@@ -1,6 +1,13 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
-SP_APP_SRC=`pwd`
+set -euo pipefail
+
+# Enable to show verbose debugging
+set -xv
+
+SP_APP_SRC="$(pwd)"        # This directory
+SP_SRC="$SP_APP_SRC/../../.."  # sources for Sonic Pi as a whole
+SP_ROOT="$SP_SRC/.."       # parent dir above Sonic Pi sources
 
 echo "Note, this script assumes you have already installed SuperCollider 3.7.1 to your Applications folder"
 echo "And you have also installed the sc3-plugins."
@@ -10,80 +17,109 @@ echo "Installation instructions are here https://github.com/supercollider/sc3-pl
 echo "We're working to make this script a one shot solution for all OSX platforms"
 echo "Please direct rage and suggestions to Factoid in (https://gitter.im/samaaron/sonic-pi)"
 
+#Ensure XCode full version is installed
+if [[ -z "$(which xcodebuild)" ]] || ! xcodebuild --help 2>&1 > /dev/null; then
+  echo "Please install XCode from the App Store."
+  echo "You will need the full version, not just the command line tools."
+  exit 1
+fi
+
+#Ensure homebrew is installed
+if [[ -z "$(which brew)" ]]; then
+  echo "No homebrew found - installing Homebrew from https://brew.sh"
+  /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+fi
 #Install homebrew prerequisites
-brew install qt55 boost cmake pkg-config aubio
+brew install qt55 boost cmake pkg-config aubio libsndfile wget
+QT55=$(brew --prefix qt55)
+
+#Download and extract source packages
+cd "$SP_ROOT"
+pwd
+if [[ ! -d supercollider ]]; then
+    git clone https://github.com/supercollider/supercollider.git
+fi
+if [[ ! -d sc3-plugins ]]; then
+  git clone https://github.com/supercollider/sc3-plugins.git
+fi
+if [[ ! -f QScintilla_gpl-2.9.2.tar.gz ]]; then
+  wget 'https://sourceforge.net/projects/pyqt/files/QScintilla2/QScintilla-2.9.2/QScintilla_gpl-2.9.2.tar.gz'
+fi
+if [[ ! -f qwt-6.1.2.tar.bz2 ]]; then
+  wget 'https://downloads.sourceforge.net/project/qwt/qwt/6.1.2/qwt-6.1.2.tar.bz2'
+fi
+tar -xf QScintilla_gpl-2.9.2.tar.gz
+tar -xf qwt-6.1.2.tar.bz2
 
 #Build supercollider 3.8 from source
-cd ../../../../
-SP_ROOT=`pwd`
-git clone https://github.com/supercollider/supercollider.git
-cd supercollider
+cd "$SP_ROOT/supercollider"
+#rm -rf editors # work around 'untracked files in working directory' error
+git checkout Version-3.9.3
 git submodule init && git submodule update
-mkdir build
+#rm -rf build
+mkdir -p build
 cd build
-cmake -DSC_EL=no -DCMAKE_PREFIX_PATH=/usr/local/opt/qt55/lib/cmake ..
+cmake -DSC_EL=no -DCMAKE_PREFIX_PATH="$QT55/lib/cmake" ..
 make
 sudo make install
 #This should install to /usr/local/
 
 #Build sc3 plugins and install to /usr/local/ so supercollider 3.8 can find them
-cd $SP_ROOT
-git clone https://github.com/supercollider/sc3-plugins.git
-cd sc3-plugins
+cd "$SP_ROOT/sc3-plugins"
 git submodule init && git submodule update
 cp -r external_libraries/nova-simd/* source/VBAPUGens
-mkdir build
+mkdir -p build
 cd build
-cmake -DSC_PATH=../../supercollider/ -DCMAKE_INSTALL_PREFIX=/usr/local -DCMAKE_BUILD_TYPE=Release ..
+cmake -DSC_PATH="$SP_ROOT/supercollider/" -DCMAKE_INSTALL_PREFIX=/usr/local -DCMAKE_BUILD_TYPE=Release ..
 make
 sudo make install
-rsync -arv SC3plugins ../../supercollider/build/editors/sc-ide/SuperCollider.app/Contents/Resources/plugins/
+rsync -arv SC3plugins "$SP_ROOT/supercollider/build/editors/sc-ide/SuperCollider.app/Contents/Resources/plugins/"
 
-#Download and extract source packages
-cd ../../../../
-wget 'https://sourceforge.net/projects/pyqt/files/QScintilla2/QScintilla-2.9.2/QScintilla_gpl-2.9.2.tar.gz'
-wget 'https://downloads.sourceforge.net/project/qwt/qwt/6.1.2/qwt-6.1.2.tar.bz2'
-tar -xf QScintilla_gpl-2.9.2.tar.gz
-tar -xf qwt-6.1.2.tar.bz2
 
 #Build qscintilla libraries for Qt5
-cd QScintilla_gpl-2.9.2/Qt4Qt5/
-/usr/local/opt/qt55/bin/qmake qscintilla.pro
+cd "$SP_ROOT/QScintilla_gpl-2.9.2/Qt4Qt5/"
+"$QT55/bin/qmake" qscintilla.pro
 make
 sudo make install
 
 #Build qwt libraries for Qt5
-cd ../../
-cd qwt-6.1.2
-/usr/local/opt/qt55/bin/qmake qwt.pro
+cd "$SP_ROOT/qwt-6.1.2"
+"$QT55/bin/qmake" qwt.pro
 make
 sudo make install
-sudo cp /usr/local/qwt-6.1.2/features/* /usr/local/opt/qt55/mkspecs/features/
+sudo cp /usr/local/qwt-6.1.2/features/* "$QT55/mkspecs/features/"
 
 #Build Sonic-Pi server extensions, documentation, and gui
-cd $SP_APP_SRC
-../../server/bin/compile-extensions.rb
-../../server/bin/i18n-tool.rb -t
+cd "$SP_APP_SRC"
+"$SP_SRC/app/server/ruby/bin/compile-extensions.rb"
+"$SP_SRC/app/server/ruby/bin/i18n-tool.rb" -t
 cp -f ruby_help.tmpl ruby_help.h
-../../server/bin/qt-doc.rb -o ruby_help.h
-/usr/local/opt/qt55/bin/lrelease SonicPi.pro 
-/usr/local/opt/qt55/bin/qmake SonicPi.pro 
+"$SP_SRC/app/server/ruby/bin/qt-doc.rb" -o ruby_help.h
+"$QT55/bin/lrelease" SonicPi.pro 
+"$QT55/bin/qmake" SonicPi.pro 
 make
 
 ### FOR FINAL RELEASE ONLY MOVE THIS INTO package-osx-app ###
-#/usr/local/opt/qt55/bin/macdeployqt 'Sonic Pi.app'
+#"$QT55/bin/macdeployqt" 'Sonic Pi.app'
 
 #Soft Link extra stuff that the app will need at runtime
-cd 'Sonic Pi.app'
-ln -f -s ../../../../app/ ./
-ln -f -s ../../../../etc/ ./
-ln -f -s ../../../../../supercollider/build/editors/sc-ide/SuperCollider.app/Contents/Resources/scsynth ../../../../app/server/native/osx/scsynth
-rsync -arv ../../../../../QScintilla_gpl-2.9.2/Qt4Qt5/libqscintilla2.* Contents/MacOS/
-rsync -arv ../../../../../qwt-6.1.2/lib/ Contents/MacOS/
+cd "$SP_APP_SRC/Sonic Pi.app"
+ln -f -s "$SP_SRC/app/" ./
+ln -f -s "$SP_SRC/etc/" ./
+ln -f -s "$SP_ROOT/supercollider/build/editors/sc-ide/SuperCollider.app/Contents/Resources/scsynth" "$SP_SRC/app/server/native/osx/scsynth"
+ln -f -s "$SP_ROOT/supercollider/build/editors/sc-ide/SuperCollider.app/Contents/Resources/scsynth" "$SP_SRC/app/server/native/scsynth"
+mkdir -p "$SP_SRC/app/server/native/ruby/bin"
+ln -f -s "$(which ruby)" "$SP_SRC/app/server/native/ruby/bin/ruby"
+rsync -arv "$SP_ROOT/QScintilla_gpl-2.9.2/Qt4Qt5/libqscintilla2".* Contents/MacOS/
+rsync -arv "$SP_ROOT/qwt-6.1.2/lib/" Contents/MacOS/
 install_name_tool -change qwt.framework/Versions/6/qwt @executable_path/qwt.framework/Versions/6/qwt Contents/MacOS/Sonic\ Pi 
 install_name_tool -change libqscintilla2.12.dylib @executable_path/libqscintilla2.12.dylib Contents/MacOS/Sonic\ Pi 
+#Copy plugins in place
+mkdir -p "$SP_SRC/app/server/native/supercollider/plugins"
+rsync -arv "$SP_ROOT/supercollider/build/server/plugins/"*.scx "$SP_SRC/app/server/native/supercollider/plugins/"
+
 
 ### FOR FINAL RELEASE ONLY MOVE THIS INTO package-osx-app ###
-#rsync -arv ../../../../app ./
-#rsync -arv ../../../../etc ./
+#rsync -arv "$SP_SRC/app" ./
+#rsync -arv "$SP_SRC/etc" ./
 #cp -R /Applications/SuperCollider/SuperCollider.app/Contents/Resources/scsynth ./app/server/native/osx/scsynth

--- a/app/gui/qt/build-osx-app
+++ b/app/gui/qt/build-osx-app
@@ -79,6 +79,7 @@ function git-clone-idempotent (){
     fi
 }
 
+function skip() {
 #Download and extract source packages
 cd "$SP_ROOT"
 git-clone-idempotent https://github.com/supercollider/supercollider.git supercollider
@@ -136,8 +137,16 @@ cd "$SP_APP_SRC"
 "$SP_SRC/app/server/ruby/bin/i18n-tool.rb" -t
 cp -f ruby_help.tmpl ruby_help.h
 "$SP_SRC/app/server/ruby/bin/qt-doc.rb" -o ruby_help.h
+}
+if [[ "$MAC_OS_VERSION" -lt "$MAC_OS_MODERN_VERSION" ]]; then
+    sed -e "s/lqscintilla2_qt5/lqscintilla2/g" \
+        "$SP_APP_SRC/SonicPi.pro" \
+        > "$SP_APP_SRC/SonicPi.pro.tmp"
+else
+    cp "$SP_APP_SRC/SonicPi.pro" "$SP_APP_SRC/SonicPi.pro.tmp"
+fi
 "$QT/bin/lrelease" SonicPi.pro 
-"$QT/bin/qmake" SonicPi.pro 
+"$QT/bin/qmake" SonicPi.pro.tmp 
 make
 
 ### FOR FINAL RELEASE ONLY MOVE THIS INTO package-osx-app ###

--- a/app/gui/qt/build-osx-app
+++ b/app/gui/qt/build-osx-app
@@ -79,7 +79,6 @@ function git-clone-idempotent (){
     fi
 }
 
-function skip() {
 #Download and extract source packages
 cd "$SP_ROOT"
 git-clone-idempotent https://github.com/supercollider/supercollider.git supercollider
@@ -137,7 +136,6 @@ cd "$SP_APP_SRC"
 "$SP_SRC/app/server/ruby/bin/i18n-tool.rb" -t
 cp -f ruby_help.tmpl ruby_help.h
 "$SP_SRC/app/server/ruby/bin/qt-doc.rb" -o ruby_help.h
-}
 if [[ "$MAC_OS_VERSION" -lt "$MAC_OS_MODERN_VERSION" ]]; then
     sed -e "s/lqscintilla2_qt5/lqscintilla2/g" \
         "$SP_APP_SRC/SonicPi.pro" \

--- a/app/gui/qt/build-osx-app
+++ b/app/gui/qt/build-osx-app
@@ -5,7 +5,7 @@ set -euo pipefail
 IFS=$'\n\t'
 
 # Uncomment 'set -vx' to enhance debugging 
-#set -vx
+set -vx
 
 # Print line numbers and function names http://wiki.bash-hackers.org/scripting/debuggingtips
 export PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
@@ -18,10 +18,22 @@ echo "This script installs supercollider and the sc3-plugins from source"
 echo "We're working to make this script a one shot solution for all OSX platforms"
 echo "Please direct rage and suggestions to Factoid in (https://gitter.im/samaaron/sonic-pi)"
 
-#Ensure XCode full version is installed
+#Ensure XCode full version is installed and configured, 
+#as xcodebuild gets invoked later in the build, and it will fail otherwise
 if [[ -z "$(which xcodebuild)" ]] || ! xcodebuild --help 2>&1 > /dev/null; then
-  echo "Please install XCode from the App Store."
-  echo "You will need the full version, not just the command line tools."
+  cat 1>&2 <<EOF
+
+Please install XCode from the App Store.
+You will need the full version, not just the command line tools.
+
+If you already have XCode installed, you may need to issue this command
+to let the tools find the right developer directory:
+
+    sudo xcode-select -r
+
+See https://github.com/nodejs/node-gyp/issues/569
+
+EOF
   exit 1
 fi
 

--- a/app/gui/qt/build-osx-app
+++ b/app/gui/qt/build-osx-app
@@ -1,19 +1,20 @@
 #!/usr/bin/env bash
 
+# Use bash unofficial strict mode http://redsymbol.net/articles/unofficial-bash-strict-mode/
 set -euo pipefail
+IFS=$'\n\t'
 
-# Enable to show verbose debugging
-set -xv
+# Uncomment 'set -vx' to enhance debugging 
+#set -vx
 
-SP_APP_SRC="$(pwd)"        # This directory
+# Print line numbers and function names http://wiki.bash-hackers.org/scripting/debuggingtips
+export PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
+
+SP_APP_SRC="$(pwd)"            # This directory
 SP_SRC="$SP_APP_SRC/../../.."  # sources for Sonic Pi as a whole
-SP_ROOT="$SP_SRC/.."       # parent dir above Sonic Pi sources
+SP_ROOT="$SP_SRC/.."           # parent dir above Sonic Pi sources
 
-echo "Note, this script assumes you have already installed SuperCollider 3.7.1 to your Applications folder"
-echo "And you have also installed the sc3-plugins."
-echo "SC 3.7.1 can be downloaded from https://github.com/supercollider/supercollider/releases"
-echo "The plugins can be downloaded from https://github.com/supercollider/sc3-plugins/releases"
-echo "Installation instructions are here https://github.com/supercollider/sc3-plugins"
+echo "This script installs supercollider and the sc3-plugins from source"
 echo "We're working to make this script a one shot solution for all OSX platforms"
 echo "Please direct rage and suggestions to Factoid in (https://gitter.im/samaaron/sonic-pi)"
 
@@ -31,7 +32,7 @@ if [[ -z "$(which brew)" ]]; then
 fi
 #Install homebrew prerequisites
 brew install qt55 boost cmake pkg-config aubio libsndfile wget
-QT55=$(brew --prefix qt55)
+QT55="$(brew --prefix qt55)"
 
 #Download and extract source packages
 cd "$SP_ROOT"
@@ -53,10 +54,8 @@ tar -xf qwt-6.1.2.tar.bz2
 
 #Build supercollider 3.8 from source
 cd "$SP_ROOT/supercollider"
-#rm -rf editors # work around 'untracked files in working directory' error
 git checkout Version-3.9.3
 git submodule init && git submodule update
-#rm -rf build
 mkdir -p build
 cd build
 cmake -DSC_EL=no -DCMAKE_PREFIX_PATH="$QT55/lib/cmake" ..
@@ -64,7 +63,7 @@ make
 sudo make install
 #This should install to /usr/local/
 
-#Build sc3 plugins and install to /usr/local/ so supercollider 3.8 can find them
+#Build sc3 plugins and install to /usr/local/ so supercollider can find them
 cd "$SP_ROOT/sc3-plugins"
 git submodule init && git submodule update
 cp -r external_libraries/nova-simd/* source/VBAPUGens

--- a/app/gui/qt/build-osx-app
+++ b/app/gui/qt/build-osx-app
@@ -1,18 +1,29 @@
 #!/usr/bin/env bash
+# Build Sonic Pi for Mac OS X
+#
+# This uses bash in order to provide better debugging features than
+# are present in normal /bin/sh alone.
 
 # Use bash unofficial strict mode http://redsymbol.net/articles/unofficial-bash-strict-mode/
 set -euo pipefail
 IFS=$'\n\t'
 
+# Get directory script lives in https://stackoverflow.com/a/246128
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
+
 # Uncomment 'set -vx' to enhance debugging 
-set -vx
+#set -vx
 
 # Print line numbers and function names http://wiki.bash-hackers.org/scripting/debuggingtips
+#shellcheck disable=SC2016
 export PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
 
-SP_APP_SRC="$(pwd)"            # This directory
+# Set variables
+SP_APP_SRC="$DIR"              # This directory
 SP_SRC="$SP_APP_SRC/../../.."  # sources for Sonic Pi as a whole
 SP_ROOT="$SP_SRC/.."           # parent dir above Sonic Pi sources
+MAC_OS_MODERN_VERSION=12       # Below Mac OS X 10.12 (Sierra), use qt 5.5
+MAC_OS_VERSION="$(sw_vers -productVersion  | cut -d\. -f2)"
 
 echo "This script installs supercollider and the sc3-plugins from source"
 echo "We're working to make this script a one shot solution for all OSX platforms"
@@ -20,7 +31,7 @@ echo "Please direct rage and suggestions to Factoid in (https://gitter.im/samaar
 
 #Ensure XCode full version is installed and configured, 
 #as xcodebuild gets invoked later in the build, and it will fail otherwise
-if [[ -z "$(which xcodebuild)" ]] || ! xcodebuild --help 2>&1 > /dev/null; then
+if [[ -z "$(which xcodebuild)" ]] || ! xcodebuild --help >/dev/null 2>&1; then
   cat 1>&2 <<EOF
 
 Please install XCode from the App Store.
@@ -42,8 +53,14 @@ if [[ -z "$(which brew)" ]]; then
   /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
 fi
 
+if [[ "$MAC_OS_VERSION" -lt "$MAC_OS_MODERN_VERSION" ]]; then
+    BREWFILE="$SP_APP_SRC/Brewfile-qt55"
+else
+    BREWFILE="$SP_APP_SRC/Brewfile"
+fi
+
 #Install homebrew prerequisites
-brew bundle
+brew bundle --file="$BREWFILE"
 QT="$(brew --prefix qt)"
 
 function wget-idempotent (){
@@ -57,15 +74,17 @@ function git-clone-idempotent (){
         git clone "$1" "$2"
     fi
 }
-function skip() {
 
 #Download and extract source packages
 cd "$SP_ROOT"
-pwd
 git-clone-idempotent https://github.com/supercollider/supercollider.git supercollider
 git-clone-idempotent https://github.com/supercollider/sc3-plugins.git sc3-plugins
 wget-idempotent 'https://downloads.sourceforge.net/project/qwt/qwt/6.1.2/qwt-6.1.2.tar.bz2' qwt-6.1.2.tar.bz2
 tar -xf qwt-6.1.2.tar.bz2
+if [[ "$MAC_OS_VERSION" -lt "$MAC_OS_MODERN_VERSION" ]]; then
+    wget-idempotent 'https://sourceforge.net/projects/pyqt/files/QScintilla2/QScintilla-2.9.2/QScintilla_gpl-2.9.2.tar.gz' QScintilla_gpl-2.9.2.tar.gz
+    tar -xf QScintilla_gpl-2.9.2.tar.gz
+fi
 
 #Build supercollider 3.8 from source
 cd "$SP_ROOT/supercollider"
@@ -88,9 +107,17 @@ cmake -DSC_PATH="$SP_ROOT/supercollider/" -DCMAKE_INSTALL_PREFIX=/usr/local -DCM
 make
 sudo make install
 rsync -arv SC3plugins "$SP_ROOT/supercollider/build/editors/sc-ide/SuperCollider.app/Contents/Resources/plugins/"
-#copy qscintilla2 features into qt5 features
-}
-cp /usr/local/opt/qscintilla2/data/mkspecs/features/* "$QT/mkspecs/features"
+
+if [[ "$MAC_OS_VERSION" -lt "$MAC_OS_MODERN_VERSION" ]]; then
+    #Build qscintilla libraries for Qt5
+    cd "$SP_ROOT/QScintilla_gpl-2.9.2/Qt4Qt5/"
+    "$QT/bin/qmake" qscintilla.pro
+    make
+    sudo make install
+else
+    #copy qscintilla2 features into qt5 features
+    cp /usr/local/opt/qscintilla2/data/mkspecs/features/* "$QT/mkspecs/features"
+fi
 
 #Build qwt libraries for Qt5
 cd "$SP_ROOT/qwt-6.1.2"
@@ -119,7 +146,11 @@ ln -f -s "$SP_SRC/etc/" ./
 ln -f -s "$SP_ROOT/supercollider/build/editors/sc-ide/SuperCollider.app/Contents/Resources/scsynth" "$SP_SRC/app/server/native/scsynth"
 mkdir -p "$SP_SRC/app/server/native/ruby/bin"
 ln -f -s "$(which ruby)" "$SP_SRC/app/server/native/ruby/bin/ruby"
-rsync -arv /usr/local/opt/qscintilla2/lib/*.dylib Contents/MacOS/
+if [[ "$MAC_OS_VERSION" -lt "$MAC_OS_MODERN_VERSION" ]]; then
+    rsync -arv "$SP_ROOT/QScintilla_gpl-2.9.2/Qt4Qt5/libqscintilla2".* Contents/MacOS/
+else
+    rsync -arv /usr/local/opt/qscintilla2/lib/*.dylib Contents/MacOS/
+fi
 rsync -arv "$SP_ROOT/qwt-6.1.2/lib/" Contents/MacOS/
 install_name_tool -change qwt.framework/Versions/6/qwt @executable_path/qwt.framework/Versions/6/qwt Contents/MacOS/Sonic\ Pi 
 install_name_tool -change libqscintilla2.12.dylib @executable_path/libqscintilla2.12.dylib Contents/MacOS/Sonic\ Pi 

--- a/etc/doc/lang/sonic-pi-tutorial-fr.po
+++ b/etc/doc/lang/sonic-pi-tutorial-fr.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Sonic Pi\n"
-"PO-Revision-Date: 2018-09-01 21:16+0000\n"
+"PO-Revision-Date: 2018-09-09 00:17+0000\n"
 "Last-Translator: Olivier Humbert <trebmuh@tuxfamily.org>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/sonic-pi/tutorial/"
 "fr/>\n"
@@ -13755,36 +13755,33 @@ msgstr ""
 "qui veut dire qu'il représente aussi un 16e de temps."
 
 #: A.07-bizet.md:77
-#, fuzzy
 msgid ""
 "When we attempt to decode and explore new things a very handy trick is to make"
 " everything as similar as possible to try and see any relationships or pattern"
 "s. For example, when we re-write our notation purely in 16ths you can see that"
 " our notation just turns into a nice sequence of notes and rests."
 msgstr ""
-"Quand on essaie de décoder et d'explorer de nouvelles choses un truc très prat"
-"ique est de rendre tout le plus semblable possible pour essayer de voir des re"
-"lations ou modèles. Par exemple quand on réécrit notre notation uniquement en "
-"double-croches on peut voir que notre notation devient une séquence agréable d"
-"e notes et de silences."
+"Quand on essaie de décoder et d'explorer de nouvelles choses, un truc très "
+"pratique est de faire en sorte que tout se ressemble le plus possible pour "
+"essayer de voir des relations ou des modèles. Par exemple, lorsqu'on réécrit "
+"notre notation uniquement en double-croches, vous pouvez voir que notre "
+"notation se transforme en une belle séquence de notes et de silences."
 
 #: A.07-bizet.md:83
 msgid "![Habanera Riff 2](../images/tutorial/articles/A.07-bizet/habanera2.png)"
 msgstr "![Riff Habanera 2](../images/tutorial/articles/A.07-bizet/habanera2.png)"
 
 #: A.07-bizet.md:85
-#, fuzzy
 msgid "Re-coding the Habanera"
-msgstr "Re-programmer la Habanera"
+msgstr "Recodage de la Habanera"
 
 #: A.07-bizet.md:87
-#, fuzzy
 msgid ""
 "We're now in a position to start translating this bass line to Sonic Pi. Let's"
 " encode these notes and rests in a ring:"
 msgstr ""
-"Nous sommes maintenant prêts a traduire cette ligne de basse dans Sonic Pi. En"
-"codons ces notes et silences dans un anneau :"
+"Nous sommes maintenant prêt à commencer la traduction de cette ligne de "
+"basse en Sonic Pi. Encodons ces notes et silences dans un anneau :"
 
 #: A.07-bizet.md:90
 #, no-wrap
@@ -13820,9 +13817,8 @@ msgstr ""
 "la peine, bien joué !"
 
 #: A.07-bizet.md:108
-#, fuzzy
 msgid "Moody Synths"
-msgstr "Synthés de mauvaise humeur"
+msgstr "Synthés grincheux"
 
 #: A.07-bizet.md:110
 #, fuzzy
@@ -15647,14 +15643,12 @@ msgstr ""
 "end"
 
 #: A.12-sample-slicing.md:1
-#, fuzzy
 msgid "A.12 Sample Slicing"
-msgstr "A.12 Découpe d'échantillon"
+msgstr "A.12 Tranchage d'échantillon"
 
 #: A.12-sample-slicing.md:3
-#, fuzzy
 msgid "Sample Slicing"
-msgstr "Découpe d'échantillon"
+msgstr "Tranchage d'échantillon"
 
 #: A.12-sample-slicing.md:5
 msgid ""
@@ -15674,9 +15668,8 @@ msgstr ""
 " vos sessions de Live Coding."
 
 #: A.12-sample-slicing.md:13
-#, fuzzy
 msgid "Sound as Data"
-msgstr "Le son en tant que donnée"
+msgstr "Le son en tant que données"
 
 #: A.12-sample-slicing.md:15
 #, fuzzy
@@ -15750,7 +15743,6 @@ msgstr ""
 "pouvez voir un exemple d'un tel graphique en haut du diagramme."
 
 #: A.12-sample-slicing.md:51
-#, fuzzy
 msgid "Playing Part of a Sample"
 msgstr "Jouer une partie d'un échantillon"
 
@@ -15774,11 +15766,10 @@ msgstr ""
 "pécifier un `finish:` à `0.5` :"
 
 #: A.12-sample-slicing.md:66
-#, fuzzy
 msgid "We can add in a `start:` value to play an even smaller section of the sample:"
 msgstr ""
-"Nous pouvons ajouter une valeur `start:` pour jouer une partie encore plus pet"
-"ite de l'échantillon :"
+"Nous pouvons ajouter une valeur `start:` pour jouer une partie encore plus "
+"petite de l'échantillon :"
 
 #: A.12-sample-slicing.md:68
 #, no-wrap
@@ -15786,13 +15777,12 @@ msgid "sample :loop_amen, start: 0.25, finish: 0.5"
 msgstr "sample :loop_amen, start: 0.25, finish: 0.5"
 
 #: A.12-sample-slicing.md:72
-#, fuzzy
 msgid ""
 "For fun, you can even have the `finish:` opt's value be *before* `start:` and "
 "it will play the section backwards:"
 msgstr ""
-"Pour le plaisir, vous pouvez même avoir une valeur `finish:` inférieur à la va"
-"leur `start:` et la section sera jouée à l'envers :"
+"Pour le plaisir, vous pouvez même avoir la valeur `finish:` inférieure à la "
+"valeur `start:` et il jouera la section à l'envers :"
 
 #: A.12-sample-slicing.md:75
 #, no-wrap


### PR DESCRIPTION
This rework of the Mac OS X `app/gui/qt/build-osx-app` script and supporting files makes the macOS  build more robust, working across multiple macOS versions. I tested this vs. both Mac OS X Yosemite (10.10.5) and macOS High Sierra (10.13.6). It is untested currently on intermediate versions. On newer macOS versions, this uses the Homebrew formula for `qt`, on older ones, it uses `qt55`. 

The build script has been made idempotent, so that you can run it multiple times and it will result in a correct build on the second and subsequent builds. I switched the shell to `bash` in order to take advantage of its features such as settings to fail fast on errors and print more debugging information. The script is also error-free when linted with [shellcheck](https://www.shellcheck.net/).

The `aubio` brew package seems to work fine on both old and new MacOS versions.

It looks like on modern macOS versions, the brew package for qscintilla2 works fine.

This uses `brew bundle` to install Homebrew packages in an idempotent way. It will also install Homebrew if it is not present on the host since it is absolutely required for correct operation.

I did not modify the 2 other build scripts that apply to macOS in this PR, but we might discuss whether `build-osx-sierra` and `mac-build-app` and `mac-release` might be removed or folded into `build-osx-app`.

cc: @samaaron @kevinchau321 @juliancheal 