### PR TITLE
Sound - Don't print messages for blank nodes

### DIFF
--- a/app/server/ruby/lib/sonicpi/lang/sound.rb
+++ b/app/server/ruby/lib/sonicpi/lang/sound.rb
@@ -3935,7 +3935,7 @@ play (chord_invert (chord :A3, \"M\"), 2) #Second inversion - (ring 64, 69, 73)
         node.control args_h
 
         unless __thread_locals.get(:sonic_pi_mod_sound_synth_silent)
-          __delayed_message "control node #{node.id}, #{arg_h_pp(args_h)}"
+          __delayed_message "control node #{node.id}, #{arg_h_pp(args_h)}" unless node.is_a?(BlankNode)
         end
         return node
       end


### PR DESCRIPTION
Previously, when attempting to control blank nodes (eg rest notes),
The messages that got printed to the log panel tried to print out
the node id. Since BlankNodes don't have ids set, this made the
resulting message look a little odd.

We now avoid printing messages to the log if we attempt to control
a BlankNode.