### PR TITLE
Depency Replace

### DIFF
--- a/app/gui/qt/build-ubuntu-app
+++ b/app/gui/qt/build-ubuntu-app
@@ -24,7 +24,7 @@ echo "Please direct rage and suggestions to Factoid in (https://gitter.im/samaar
 sudo apt-get install -y \
      g++ ruby ruby-dev pkg-config git build-essential libjack-jackd2-dev \
      libsndfile1-dev libasound2-dev libavahi-client-dev libicu-dev \
-     libreadline6-dev libfftw3-dev libxt-dev libudev-dev cmake libboost1.58-dev \
+     libreadline6-dev libfftw3-dev libxt-dev libudev-dev cmake libboost-dev \
      libqwt-qt5-dev libqt5scintilla2-dev libqt5svg5-dev qt5-qmake qt5-default \
      qttools5-dev qttools5-dev-tools qtdeclarative5-dev libqt5webkit5-dev \
      qtpositioning5-dev libqt5sensors5-dev qtmultimedia5-dev libffi-dev \


### PR DESCRIPTION
libboost1.58-dev no longer exists in the Ubuntu repositories. The equivalent depency now is named just libboost-dev.