### PR TITLE
Add build script for Ubuntu 18.04

### DIFF
--- a/app/gui/qt/build-ubuntu-18-04
+++ b/app/gui/qt/build-ubuntu-18-04
@@ -1,0 +1,134 @@
+# Based on https://github.com/samaaron/sonic-pi/blob/master/app/gui/qt/build-ubuntu-app
+# Modified by nlb (n-l-b.fr) to install on Ubuntu 18.04 TLS
+# Hope it works for you. 
+# 07/07/2018
+
+#Fail script on first error encountered
+set -e
+
+#Application/library versions built by this script.
+SUPERCOLLIDER_VERSION=3.9.1
+SC_PLUGINS_VERSION=3.9.0
+AUBIO_VERSION=c6ae035 #0.4.6
+OSMID_VERSION=391f35f789f18126003d2edf32902eb714726802
+
+#Internal definitions
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+SP_APP_SRC=${SCRIPT_DIR}
+SP_ROOT=${SP_APP_SRC}/../../../../
+OSMID_DIR=${SP_APP_SRC}/../../server/native/linux/osmid
+
+echo "This script has been tested on ubuntu 18.04 LTS."
+
+#Install dependencies for building supercollider, as well as qt5 and supporting libraries for gui
+sudo apt-get install -y \
+     g++ ruby ruby-dev pkg-config git build-essential libjack-jackd2-dev \
+     libsndfile1-dev libasound2-dev libavahi-client-dev libicu-dev \
+     libreadline6-dev libfftw3-dev libxt-dev libudev-dev cmake libboost-all-dev \
+     libqwt-qt5-dev libqt5scintilla2-dev libqt5svg5-dev qt5-qmake qt5-default \
+     qttools5-dev qttools5-dev-tools qtdeclarative5-dev libqt5webkit5-dev \
+     qtpositioning5-dev libqt5sensors5-dev qtmultimedia5-dev libffi-dev \
+     libqt5opengl5-dev curl python erlang-base
+
+### IF YOU HAVE PROBLEMS WITH qwt
+#cd $SP_APP_SRC/../../../../
+#wget 'http://downloads.sourceforge.net/project/qwt/qwt/6.1.2/qwt-6.1.2.tar.bz2'
+#tar -xf qwt-6.1.2.tar.bz2
+#cd qwt-6.1.2
+#/usr/lib/x86_64-linux-gnu/qt5/bin/qmake qwt.pro
+#make
+#sudo make install
+#sudo cp /usr/local/qwt-6.1.2/features/* /usr/lib/x86_64-linux-gnu/qt5/mkspecs/features/
+
+### IF YOU HAVE PROBLEMS WITH qscintilla2
+# cd $SP_APP_SRC/../../../../
+# wget 'http://sourceforge.net/projects/pyqt/files/QScintilla2/QScintilla-2.9.2/QScintilla_gpl-2.9.2.tar.gz'
+# tar -xf QScintilla_gpl-2.9.2.tar.gz
+# cd QScintilla_gpl-2.9.2/Qt4Qt5/
+# /usr/lib/x86_64-linux-gnu/qt5/bin/qmake qscintilla.pro
+# make
+# sudo make install
+
+#Build supercollider from source
+cd ${SP_ROOT}
+git clone https://github.com/supercollider/supercollider.git || true
+cd supercollider
+git fetch # In case we already had it cloned
+git checkout Version-${SUPERCOLLIDER_VERSION}
+git submodule init && git submodule update
+mkdir -p build
+cd build
+cmake -DSC_EL=no ..
+make
+sudo make install
+#This should install to /usr/local/
+
+#Build sc3 plugins and install to /usr/local/ so supercollider can find them
+cd ${SP_ROOT}
+git clone https://github.com/supercollider/sc3-plugins.git || true
+cd sc3-plugins
+git fetch # In case we already had it cloned
+git checkout Version-${SC_PLUGINS_VERSION}
+git submodule init && git submodule update
+cp -r external_libraries/nova-simd/* source/VBAPUGens
+mkdir -p build
+cd build
+cmake -DSC_PATH=/usr/local/include/SuperCollider -DCMAKE_INSTALL_PREFIX=/usr/local -DCMAKE_BUILD_TYPE=Release ..
+make
+sudo make install
+
+#Install libaubio (apt-get version is too old)
+cd ${SP_ROOT}
+git clone https://git.aubio.org/aubio/aubio/ || true
+cd aubio
+git fetch # In case we already had it cloned
+git checkout ${AUBIO_VERSION}
+make getwaf
+./waf configure
+./waf build
+sudo ./waf install
+
+#Install osmid (for MIDI support)
+cd ${SP_ROOT}
+git clone https://github.com/llloret/osmid.git || true
+cd osmid
+git fetch # In case we already had it cloned
+git checkout ${OSMID_VERSION}
+mkdir -p build
+cd build
+cmake ..
+make
+mkdir -p ${OSMID_DIR}
+install m2o o2m -t ${OSMID_DIR}
+
+#Build Erlang files
+cd ${SP_APP_SRC}/../../server/erlang
+#The current implementation of osc.erl uses Erlang features that require
+#at least Erlang 19.1 to be installed. 16.04 LTS is currently at 18.3.
+#If versions < 19.1 are installed, and we use the current code, the MIDI
+#implementation breaks because the Erlang OSC router is failing.
+ERLANG_VERSION=$(./print_erlang_version)
+if [ -e "osc.erl.orig" ]; then
+    # Handle, if the original file in the source tree ever gets updated.
+    rm osc.erl.orig
+    git checkout osc.erl
+fi
+if [[ "${ERLANG_VERSION}" < "19.1" ]]; then
+    echo "Found Erlang version < 19.1 (${ERLANG_VERSION})! Updating source code."
+    sed -i.orig 's|erlang:system_time(nanosecond)|erlang:system_time(nano_seconds)|' osc.erl
+fi
+erlc osc.erl
+erlc pi_server.erl
+
+#Build sonic-pi server extensions, documentation, and binary.
+cd ${SP_APP_SRC}
+../../server/ruby/bin/compile-extensions.rb
+../../server/ruby/bin/i18n-tool.rb -t
+cp -f ruby_help.tmpl ruby_help.h
+../../server/ruby/bin/qt-doc.rb -o ruby_help.h
+
+echo -e "${CYAN}Building sonic-pi binary...${NC}"
+lrelease SonicPi.pro
+qmake -qt=qt5 SonicPi.pro
+make
+

--- a/app/gui/qt/build-ubuntu-18-04
+++ b/app/gui/qt/build-ubuntu-18-04
@@ -16,7 +16,7 @@ OSMID_VERSION=391f35f789f18126003d2edf32902eb714726802
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 SP_APP_SRC=${SCRIPT_DIR}
 SP_ROOT=${SP_APP_SRC}/../../../../
-OSMID_DIR=${SP_APP_SRC}/../../server/native/linux/osmid
+OSMID_DIR=${SP_APP_SRC}/../../server/native/osmid
 
 echo "This script has been tested on ubuntu 18.04 LTS."
 

--- a/app/gui/qt/build-ubuntu-18-04
+++ b/app/gui/qt/build-ubuntu-18-04
@@ -1,10 +1,13 @@
+#!/usr/bin/env bash
+
 # Based on https://github.com/samaaron/sonic-pi/blob/master/app/gui/qt/build-ubuntu-app
 # Modified by nlb (n-l-b.fr) to install on Ubuntu 18.04 TLS
 # Hope it works for you. 
 # 07/07/2018
 
 #Fail script on first error encountered
-set -e
+set -euo pipefail
+IFS=$'\n\t'
 
 #Application/library versions built by this script.
 SUPERCOLLIDER_VERSION=3.9.1
@@ -127,7 +130,7 @@ cd ${SP_APP_SRC}
 cp -f ruby_help.tmpl ruby_help.h
 ../../server/ruby/bin/qt-doc.rb -o ruby_help.h
 
-echo -e "${CYAN}Building sonic-pi binary...${NC}"
+echo "Building sonic-pi binary..."
 lrelease SonicPi.pro
 qmake -qt=qt5 SonicPi.pro
 make


### PR DESCRIPTION
This is a slightly modified version of
https://github.com/nlebellier/autour-de-sonic-pi/blob/master/scripts/build-ubuntu-18-04 . It allowed me to run `master` on Ubuntu 18.04 with no errors!

In addition to this script, which fixes some dependencies and makes re-building a bit more resilient, I had to:
* Manually remove my previously cloned `aubio` checkout (it was complaining about the upstream git repo having been renamed I think)
* Switch `asdf` to use the system-python via `asdf global python system`, since the python3 version in my path was getting a build error for `aubio/waf`

I welcome testing (or simply a merge; since this is a new file it is pretty low-risk), though note that this won't help if you haven't gotten `jack` configured correctly. In my case, I was able to run sonic-pi v2.10 from the ubuntu repo without issue. Another thing to beware of is leftover ports being allocated from still-running supercollider and erlang (`beam.smp`) processes hanging around. I also tested this with ruby 2.3 and 2.5.1 without issue (but with a clean tree in-between).

This change _might_ help with #1913, #1892, #1971, #1805 (this was my core issue), #1809, #1752, maybe others.