### PR TITLE
Docs - Update synth design document

### DIFF
--- a/SYNTH_DESIGN.md
+++ b/SYNTH_DESIGN.md
@@ -3,24 +3,35 @@
 The sounds you hear in Sonic Pi are all produced by the SuperCollider
 synthesis engine. These synths and effects have to be defined beforehand
 in a special kind of binary file called a `synthdef`.  The built in
-synthdefs are loaded up on boot so they are ready to trigger. All the
-`synthdef`s that ship with Sonic Pi are designed in a Clojure based
-library called [Overtone](https://overtone.github.io). You can find the
-existing synth designs in the folder
+synthdefs are loaded up on boot so they are ready to trigger.
+
+Synthdefs are ultimately compiled from source code into binary files,
+but there are two main ways you can do this. You can either use the
+Clojure based library called [Overtone](https://overtone.github.io),
+or directly use SuperCollider's own language instead).
+
+[Using **Overtone** to design and compile your synths](#overtone)<br/>
+[Using **SuperCollider** to design and compile your synths](#supercollider)
+
+All of the synthdefs that currently ship with Sonic Pi were designed in
+Overtone. You can find the existing synth designs in the folder
 
 ```
 etc/synthdefs/designs/sonic_pi/synths/
 ```
 
-If you wish to contribute synths to Sonic Pi then they need to be in
-this format. However, it is also very easy to write and trigger your own
-synthdefs in SuperCollider language if you are already familiar with
-that.
+**_Please note however_**, that for new synth designs _that are intended to
+be distributed with Sonic Pi_, source code written with Overtone is now
+considered deprecated and only designs written in SuperCollider language
+will be accepted. As such, the instructions for using Overtone
+still work, but if you are considering submitting a new synth design for
+distribution with Sonic Pi, please [create your synth with SuperCollider
+directly](#supercollider).
 
 
 ## Synth design constraints
 
-Also if you want your synth to work with Sonic Pi's automatic stereo
+If you want your synth to work with Sonic Pi's automatic stereo
 sound infrastructure *you need to ensure your synth outputs a stereo
 signal* to an audio bus with an index specified by a synth arg named
 `out_bus`.
@@ -29,7 +40,11 @@ Additionally, your synth must self-terminate at some point - Sonic Pi
 will *not* tidy up zombied synths.
 
 
-## Editing the synthdefs
+<a name="overtone"/>
+
+## Using **Overtone** to design and compile your synths
+
+### Editing the synthdefs
 
 You'll need the following to be able to compile the synths yourself
 
@@ -48,7 +63,7 @@ the Sonic Pi synthdefs folder to the locations it looks in when requiring Clojur
   ;; make sure the path points to your installation of Sonic Pi
 ```
 
-### Starting a REPL
+#### Starting a REPL
 
 `cd` into the Overtone folder and run
 
@@ -62,7 +77,7 @@ Make a note of the port number that nREPL starts on
 nREPL server started on port 49223 ...
 ```
 
-### Connecting the editor to the REPL and booting Overtone
+#### Connecting the editor to the REPL and booting Overtone
 
 If you're using `vim` and `vim-fireplace`:
 
@@ -84,7 +99,7 @@ If you're using `emacs`
   * Navigate back into the Sonic Pi folder and open `etc/synthdefs/designs/sonic_pi/synths/core.clj`
   * Evaluate the namespace as you normally would for Clojure in emacs
 
-## The synth design file
+### The synth design file
 
 Taking the example of a basic synth lets have a look at what the bits are doing
 
@@ -118,13 +133,13 @@ is used for documentation.
 By evaluating the whole form this should cause all the files to be saved
 to the correct places.
 
-## Compiling your synths using SuperCollider
+<a name="supercollider"/>
 
-If you're just experimenting or wishing to build your own synthdefs and
-already know SuperCollider, there's no need to use Overtone. Simply
-define your synth and use the writeDefFile command to store the compiled
-synthdef into a directory of your choice. You can then dynamically load
-your synthdefs with the `load_synthdefs` fn.
+## Using **SuperCollider** to design and compile your synths
+
+Simply define your synth with SuperCollider's built in language, and use
+the writeDefFile command to store the compiled synthdef into a directory
+of your choice. You can then dynamically load your synthdefs with the `load_synthdefs` fn.
 
 
     (


### PR DESCRIPTION
Following [discussions on in_thread](https://in-thread.sonic-pi.net/t/sp-as-code-library-synths-creation/1648), I felt it was time to update the synth design document a little: our preference for the type of source code we want new SynthDefs to be designed in is SuperCollider language. The synth design document is now updated to reflect this.