### PR TITLE
libqt5opengl5-dev debian dependency

### DIFF
--- a/app/gui/qt/build-debian-app
+++ b/app/gui/qt/build-debian-app
@@ -46,7 +46,7 @@ sudo apt-get install -y \
      g++ ruby ruby-dev pkg-config git build-essential libjack-jackd2-dev \
      libsndfile1-dev libasound2-dev libavahi-client-dev libicu-dev \
      libreadline6-dev libfftw3-dev libxt-dev libudev-dev cmake libboost-dev \
-     libqwt-qt5-dev libqt5scintilla2-dev libqt5svg5-dev qt5-qmake qt5-default \
+     libqwt-qt5-dev libqt5opengl5-dev libqt5scintilla2-dev libqt5svg5-dev qt5-qmake qt5-default \
      qttools5-dev qttools5-dev-tools qtdeclarative5-dev libqt5webkit5-dev \
      qtpositioning5-dev libqt5sensors5-dev qtmultimedia5-dev libffi-dev \
      curl python erlang-base


### PR DESCRIPTION
I needed to install this package to be able to compile (on debian Buster)