### PR TITLE
Fix synth_name for SynthViolin

### DIFF
--- a/app/server/ruby/lib/sonicpi/synths/synthinfo.rb
+++ b/app/server/ruby/lib/sonicpi/synths/synthinfo.rb
@@ -1898,7 +1898,7 @@ Also, note that audio in isn't yet supported on Raspberry Pi."
       end
 
       def synth_name
-        "synth_violin"
+        "blade"
       end
 
       def doc


### PR DESCRIPTION
I get an unknown synth error when I try to use "synth_violin". I believe blade is the correct synth_name for this class. 