### PR TITLE
Loosen time_warp check

### DIFF
--- a/app/server/ruby/lib/sonicpi/lang/core.rb
+++ b/app/server/ruby/lib/sonicpi/lang/core.rb
@@ -954,7 +954,7 @@ end"
           sleep_time = delta * orig_sleep_mul_w_density
           new_time = vt_orig + sleep_time
 
-          raise TimeTravelError, "Time travel error - a jump back of #{delta} is too far.\nSorry, although it would be amazing, you can't go back in time beyond the sched_ahead time of #{sat}" if (Time.now - sat) > new_time
+          raise TimeTravelError, "Time travel error - a jump back of #{delta} is too far.\nSorry, although it would be amazing, you can't go back in time beyond the sched_ahead time of #{sat}" if delta < 0 && (Time.now - sat) > new_time
 
           __change_time!(new_time)
           __system_thread_locals.set :sonic_pi_spider_beat, orig_beat + delta


### PR DESCRIPTION
Only check that time_warp doesn't go too far back in time when it's actually going back in time.

As it stands, when running with `use_real_time`, a `time_warp` of zero (or even a small __positive__ value) fails with a `TimeTravelError`. I think it should behave the same as if there was no `time_warp`.

I'm not too knowledgable on internals of Sonic Pi so this may well not be the best way to achieve this, so feel free to suggest changes/rewrite/ignore it.

If this is OK, it should fix #1926.