### PR TITLE
Extend functionality of degree function

### DIFF
--- a/app/server/ruby/lib/sonicpi/lang/sound.rb
+++ b/app/server/ruby/lib/sonicpi/lang/sound.rb
@@ -3575,13 +3575,16 @@ puts note_info(:C, octave: 2)
       doc name:           :degree,
           introduced:         Version.new(2,1,0),
           summary:            "Convert a degree into a note",
-          doc:                "For a given scale and tonic it takes a symbol/string/number and resolves it to a midi note. The degree can be either a decimal number or a roman numeral (if it's a string or symbol), and may optionally be prefixed an augmentation (`a`/`d` for an augmented/diminished interval, `aa`/`dd` for double augmented/diminished or `p` for a perfect (unchanged) interval). E.g. `:i`, `'ii'`, `:III`, `:Aiv`,`:d5`, `'13'`.",
+          doc:                "For a given scale and tonic it takes a symbol/string/number and resolves it to a midi note. The degree can be either a decimal number or a roman numeral (if it's a string or symbol), and may optionally be prefixed an augmentation (`a`/`d` for an augmented/diminished interval, `aa`/`dd` for double augmented/diminished or `p` for a perfect (unchanged) interval).",
           args:               [[:degree, :symbol_or_number], [:tonic, :symbol], [:scale, :symbol]],
           accepts_block:      false,
           examples:           [%Q{
-play degree(:ii, :D3, :major)
-play degree(2, :C3, :minor)
-}]
+play degree(:iii, :D3, :major) # major third up from :D3
+play degree(3, :C3, :minor) # minor third up from :C3
+play degree('d5', :B3, :major) # diminished fifth up from :B3
+},
+                               "play [:i, :iii, :v, :dvii, :dix, :Axi, :xiii].map {|d| (degree d, :Fs, :major)} # play an F# 13+11-9 chord, using roman numeral symbols",
+                               "play ['1', '3', '5', 'd7', 'd9', 'A11', '13'].map {|d| (degree d, :Fs, :major)} # the same chord as above, but using decimal number strings"]
 
 
 

--- a/app/server/ruby/lib/sonicpi/lang/sound.rb
+++ b/app/server/ruby/lib/sonicpi/lang/sound.rb
@@ -3583,8 +3583,20 @@ play degree(:iii, :D3, :major) # major third up from :D3
 play degree(3, :C3, :minor) # minor third up from :C3
 play degree('d5', :B3, :major) # diminished fifth up from :B3
 },
-                               "play [:i, :iii, :v, :dvii, :dix, :Axi, :xiii].map {|d| (degree d, :Fs, :major)} # play an F# 13+11-9 chord, using roman numeral symbols",
-                               "play ['1', '3', '5', 'd7', 'd9', 'A11', '13'].map {|d| (degree d, :Fs, :major)} # the same chord as above, but using decimal number strings"]
+                               %q{
+chrd = []
+[:i, :iii, :v, :dvii, :dix, :Axi, :xiii].each do |d|  # for each degree in the chord
+  chrd.append (degree d, :Fs, :major)  # add the corresponding note
+end
+play chrd  # play an F# 13+11-9 chord, using roman numeral symbols
+},
+                               %Q{
+chrd = []
+['1', '3', '5', 'd7', 'd9', 'A11', '13'].each do |d|
+  chrd.append (degree d, :Fs, :major)
+end
+play chrd  # the same chord as above, but using decimal number strings
+}]
 
 
 

--- a/app/server/ruby/lib/sonicpi/lang/sound.rb
+++ b/app/server/ruby/lib/sonicpi/lang/sound.rb
@@ -3575,7 +3575,7 @@ puts note_info(:C, octave: 2)
       doc name:           :degree,
           introduced:         Version.new(2,1,0),
           summary:            "Convert a degree into a note",
-          doc:                "For a given scale and tonic it takes a symbol `:i`, `:ii`, `:iii`, `:iv`,`:v`, `:vi`, `:vii` or a number `1`-`7` and resolves it to a midi note.",
+          doc:                "For a given scale and tonic it takes a symbol/string/number and resolves it to a midi note. The degree can be either a decimal number or a roman numeral (if it's a string or symbol), and may optionally be prefixed an augmentation (`a`/`d` for an augmented/diminished interval, `aa`/`dd` for double augmented/diminished or `p` for a perfect (unchanged) interval). E.g. `:i`, `'ii'`, `:III`, `:Aiv`,`:d5`, `'13'`.",
           args:               [[:degree, :symbol_or_number], [:tonic, :symbol], [:scale, :symbol]],
           accepts_block:      false,
           examples:           [%Q{

--- a/app/server/ruby/lib/sonicpi/scale.rb
+++ b/app/server/ruby/lib/sonicpi/scale.rb
@@ -163,7 +163,7 @@ module SonicPi
           degree = degree[1..-1]
         end
       end
-      octave, index = resolve_degree_index(degree).divmod scale.notes.length
+      octave, index = resolve_degree_index(degree).divmod (scale.notes.length - 1)
       scale.notes[index] + octave * 12 + augmentation
     end
 

--- a/app/server/ruby/lib/sonicpi/scale.rb
+++ b/app/server/ruby/lib/sonicpi/scale.rb
@@ -98,37 +98,73 @@ module SonicPi
            blues_major:        [2, 1, 1, 3, 2, 3],
            blues_minor:        [3, 2, 1, 1, 3, 2]}}.call
 
-    # Zero indexed for CS compatibility
-    DEGREES = {:i    => 0,
-               :ii   => 1,
-               :iii  => 2,
-               :iv   => 3,
-               :v    => 4,
-               :vi   => 5,
-               :vii  => 6,
-               :viii => 7,
-               :ix   => 8,
-               :x    => 9,
-               :xi   => 10,
-               :xii  => 11}
+    ROMAN_DIGITS = {
+      'I' => 1,
+      'V' => 5,
+      'X' => 10,
+      'L' => 50,
+      'C' => 100,
+      'D' => 500,
+      'M' => 1000
+    }
 
-    def self.resolve_degree_index(degree)
-      if degree.is_a?(Numeric) && degree <= 0
-        raise InvalidDegreeError, "Invalid scale degree #{degree.inspect}, if scale degree is a number it must be greater than 0"
-      elsif idx = DEGREES[degree]
-        return idx
-      elsif degree.is_a? Numeric
-        return degree - 1
-      else
-        raise InvalidDegreeError, "Invalid scale degree #{degree.inspect}, expecting #{DEGREES.keys.join ','} or a number"
+    def self.from_roman(numeral)
+      return nil unless /^M{0,4}(CM|CD|D?C{0,4})(XC|XL|L?X{0,4})(IX|IV|V?I{0,4})$/i === numeral.to_s
+      vals = numeral.to_s.upcase.split('').map {|c| ROMAN_DIGITS[c]}
+      result = 0
+      i = 0
+      while i < vals.length
+        if i < vals.length - 1 && vals[i + 1] > vals[i]
+          result += vals[i + 1] - vals[i]
+          i += 2
+        else
+          result += vals[i]
+          i += 1
+        end
       end
+      result
     end
 
+    def self.resolve_degree_index(degree)
+      if degree.is_a? Numeric
+        num = degree
+      else
+        begin
+          num = Integer(degree.to_s)
+        rescue ArgumentError
+          num = from_roman degree
+        end
+      end
+      if num.nil? || num <= 0
+        raise InvalidDegreeError, "Invalid scale degree #{degree.inspect}, scale degree must be a valid number or roman numeral greater than 0"
+      end
+      num - 1
+    end
 
     def self.resolve_degree(degree, tonic, scale)
       scale = Scale.new(tonic, scale)
-      index = resolve_degree_index(degree)
-      scale.notes[index]
+      augmentation = 0
+      if not degree.is_a? Numeric
+        degree = degree.to_s.downcase
+        if degree.start_with? 'p'
+          augmentation = 0
+          degree = degree[1..-1]
+        elsif degree.start_with? 'aa'
+          augmentation = 2
+          degree = degree[2..-1]
+        elsif degree.start_with? 'a'
+          augmentation = 1
+          degree = degree[1..-1]
+        elsif degree.start_with? 'dd'
+          augmentation = -2
+          degree = degree[2..-1]
+        elsif degree.start_with? 'd'
+          augmentation = -1
+          degree = degree[1..-1]
+        end
+      end
+      octave, index = resolve_degree_index(degree).divmod scale.notes.length
+      scale.notes[index] + octave * 12 + augmentation
     end
 
     attr_reader :name, :tonic, :num_octaves, :notes

--- a/app/server/ruby/test/test_scale.rb
+++ b/app/server/ruby/test/test_scale.rb
@@ -39,10 +39,17 @@ module SonicPi
       assert_equal(57, Scale.resolve_degree(:i, :A3, :minor))
       assert_equal(60, Scale.resolve_degree(:iii, :A3, :minor))
       assert_equal(61, Scale.resolve_degree(:iii, :A3, :major))
+      assert_equal(60, Scale.resolve_degree(:diii, :A3, :major))
+      assert_equal(61, Scale.resolve_degree(:Aiii, :A3, :minor))
 
       assert_equal(57, Scale.resolve_degree(1, :A3, :minor))
       assert_equal(60, Scale.resolve_degree(3, :A3, :minor))
       assert_equal(61, Scale.resolve_degree(3, :A3, :major))
+      assert_equal(60, Scale.resolve_degree('d3', :A3, :major))
+      assert_equal(61, Scale.resolve_degree('A3', :A3, :minor))
+
+      assert_equal(69, Scale.resolve_degree(:viii, :A3, :minor))
+      assert_equal(81, Scale.resolve_degree(:xv, :A3, :minor))
     end
 
     def test_degree_invalid


### PR DESCRIPTION
Extend the `degree` function to:
- allow degrees larger than one octave, such as a [thirteenth](https://en.wikipedia.org/wiki/Thirteenth)
- allow [augmented and diminished](https://en.wikipedia.org/wiki/Interval_(music)#Augmented_and_diminished) degrees by prefixing with an `a`/`d`, and doubly augmented/diminished with `aa`/ `dd`, as well `p` for perfect intervals, for completeness.
- allow numeric strings/symbols as well as roman numerals, so you can use `'d5'`/`:d5` as well as `:dv` for diminished 5th

The documentation will also need updating, but I wanted to check if this looks reasonable first.