### PR TITLE
Add library libqt5opengl5-dev to fix build on Debian (see #2032).

### DIFF
--- a/INSTALL-LINUX.md
+++ b/INSTALL-LINUX.md
@@ -109,8 +109,8 @@ This information applies to Sonic Pi v3.1.0, but it **may** be useful informatio
     libreadline6-dev libfftw3-dev libxt-dev libudev-dev cmake libboost-dev
     libqwt-qt5-dev libqt5scintilla2-dev libqt5svg5-dev qt5-qmake qt5-default
     qttools5-dev qttools5-dev-tools qtdeclarative5-dev libqt5webkit5-dev
-    qtpositioning5-dev libqt5sensors5-dev qtmultimedia5-dev libffi-dev
-    curl python erlang-base`
+    qtpositioning5-dev libqt5sensors5-dev libqt5opengl5-dev qtmultimedia5-dev
+    libffi-dev curl python erlang-base`
 
 #### Ruby Server Extensions
 * **rugged** - For me, the compile-extensions script doesn't seem to successfully install rugged.

--- a/app/gui/qt/build-debian-app
+++ b/app/gui/qt/build-debian-app
@@ -48,9 +48,9 @@ sudo apt-get install -y \
      libreadline6-dev libfftw3-dev libxt-dev libudev-dev cmake libboost-dev \
      libqwt-qt5-dev libqt5scintilla2-dev libqt5svg5-dev qt5-qmake qt5-default \
      qttools5-dev qttools5-dev-tools qtdeclarative5-dev libqt5webkit5-dev \
-     qtpositioning5-dev libqt5sensors5-dev qtmultimedia5-dev libffi-dev \
+     qtpositioning5-dev libqt5sensors5-dev libqt5opengl5-dev qtmultimedia5-dev libffi-dev \
      curl python erlang-base
-					
+
 if [ "$installMethod" == "2" ]; then
 		echo -e "${CYAN}Installing checkinstall...${NC}"
 		sudo apt-get install checkinstall

--- a/app/gui/qt/build-rpi-app
+++ b/app/gui/qt/build-rpi-app
@@ -8,10 +8,10 @@ echo "We're working to make this script a one shot solution for all Linux platfo
 echo "Please direct rage and suggestions to Factoid in (https://gitter.im/samaaron/sonic-pi)"
 
 #Install dependencies for building supercollider, as well as qt5 and supporting libraries for gui
-#sudo apt-get install g++ ruby ruby-dev pkg-config git build-essential libjack-jackd2-dev libsndfile1-dev libasound2-dev libavahi-client-dev libicu-dev libreadline6-dev libfftw3-dev libxt-dev libudev-dev cmake libboost1.58-dev libqwt-qt5-dev libqt5scintilla2-dev libqt5svg5-dev qt5-qmake qt5-default qttools5-dev qttools5-dev-tools qtdeclarative5-dev libqt5webkit5-dev qtpositioning5-dev libqt5sensors5-dev qtmultimedia5-dev libffi-dev
+#sudo apt-get install g++ ruby ruby-dev pkg-config git build-essential libjack-jackd2-dev libsndfile1-dev libasound2-dev libavahi-client-dev libicu-dev libreadline6-dev libfftw3-dev libxt-dev libudev-dev cmake libboost1.58-dev libqwt-qt5-dev libqt5scintilla2-dev libqt5svg5-dev qt5-qmake qt5-default qttools5-dev qttools5-dev-tools qtdeclarative5-dev libqt5webkit5-dev qtpositioning5-dev libqt5sensors5-dev libqt5opengl5-dev qtmultimedia5-dev libffi-dev
 
 #QT Requirements for qwt and qscintilla
-sudo apt-get install qt5-default libqt5svg5-dev qttools5-dev qt5-qmake qt5-default qttools5-dev qttools5-dev-tools qtdeclarative5-dev libqt5webkit5-dev qtpositioning5-dev libqt5sensors5-dev qtmultimedia5-dev
+sudo apt-get install qt5-default libqt5svg5-dev qttools5-dev qt5-qmake qt5-default qttools5-dev qttools5-dev-tools qtdeclarative5-dev libqt5webkit5-dev qtpositioning5-dev libqt5sensors5-dev libqt5opengl5-dev qtmultimedia5-dev
 
 #Additional requirements for supercollider
 #sudo apt-get install cmake libsndfile1-dev libxt-dev libjack-jackd2-dev libudev-dev

--- a/app/gui/qt/build-ubuntu-zesty-app
+++ b/app/gui/qt/build-ubuntu-zesty-app
@@ -5,7 +5,7 @@ SP_APP_SRC=`pwd`
 echo "This script has been tested on ubuntu 17.04"
 
 #Install dependencies for building supercollider, as well as qt5 and supporting libraries for gui
-sudo apt-get install -y g++ ruby ruby-dev pkg-config git build-essential libjack-jackd2-dev libsndfile1-dev libasound2-dev libavahi-client-dev libicu-dev libreadline6-dev libfftw3-dev libxt-dev libudev-dev cmake libboost1.62-dev libqwt-qt5-dev libqt5scintilla2-dev libqt5svg5-dev qt5-qmake qt5-default qttools5-dev qttools5-dev-tools qtdeclarative5-dev libqt5webkit5-dev qtpositioning5-dev libqt5sensors5-dev qtmultimedia5-dev libffi-dev libaubio-dev supercollider-server sc3-plugins-server erlang-base
+sudo apt-get install -y g++ ruby ruby-dev pkg-config git build-essential libjack-jackd2-dev libsndfile1-dev libasound2-dev libavahi-client-dev libicu-dev libreadline6-dev libfftw3-dev libxt-dev libudev-dev cmake libboost1.62-dev libqwt-qt5-dev libqt5scintilla2-dev libqt5svg5-dev qt5-qmake qt5-default qttools5-dev qttools5-dev-tools qtdeclarative5-dev libqt5webkit5-dev qtpositioning5-dev libqt5sensors5-dev libqt5opengl5-dev qtmultimedia5-dev libffi-dev libaubio-dev supercollider-server sc3-plugins-server erlang-base
 
 #Build osmid from source for MIDI support and install it in SONICPI_DIR/app/server/native/linux/osmid
 cd ../../../
@@ -29,6 +29,6 @@ cd $SP_APP_SRC
 ../../server/ruby/bin/i18n-tool.rb -t
 cp -f ruby_help.tmpl ruby_help.h
 ../../server/ruby/bin/qt-doc.rb -o ruby_help.h
-lrelease SonicPi.pro 
-qmake -qt=qt5 SonicPi.pro 
+lrelease SonicPi.pro
+qmake -qt=qt5 SonicPi.pro
 make


### PR DESCRIPTION
Also added dependency for build-rpi-app and
build-ubuntu-zesty-app (but not tested); (Ubuntu builds already had it declared.)

Note: This does not address the problem I met with SonicPi.pro, since I am unsure about this matter.