### PR TITLE
Fix the `on:` opt when playing chords

### DIFF
--- a/app/server/ruby/lib/sonicpi/lang/sound.rb
+++ b/app/server/ruby/lib/sonicpi/lang/sound.rb
@@ -4460,7 +4460,7 @@ Also, if you wish your synth to work with Sonic Pi's automatic stereo sound infr
         notes.each do |note|
           if note
             args_h[:note] = note
-            nodes << trigger_synth(synth_name, args_h, cg, info)
+            nodes << trigger_synth(synth_name, args_h.dup, cg, info)
           end
         end
         cg.sub_nodes = nodes


### PR DESCRIPTION
Previously, when passing the `on:` opt in an args hash to a chord playing
function (play, synth, etc etc) this args hash was commonly being associated
with every note in the chord. However, when a synth node was created for each
note in the chord, the `on:` opt was being deleted from the args hash; meaning
that after the first note's synth was created, all further notes in the chord
didn't have any `on:` opt and thus by default were audibly triggered.

We now avoid this problem by making sure the args hash is duplicated for each
note in the chord, rather than being directly reused.

Fixes #2074