### PR TITLE
GUI - add cutoff: to saw synth opt autocomplete list

### DIFF
--- a/app/server/ruby/lib/sonicpi/synths/synthinfo.rb
+++ b/app/server/ruby/lib/sonicpi/synths/synthinfo.rb
@@ -849,6 +849,15 @@ Also, note that audio in isn't yet supported on Raspberry Pi."
       def doc
         "A saw wave with a low pass filter. Great for using with FX such as the built in low pass filter (available via the cutoff arg) due to the complexity and thickness of the sound."
       end
+
+      def arg_defaults
+        super.merge({
+          cutoff: 100,
+          cutoff_slide: 0,
+          cutoff_slide_shape: 1,
+          cutoff_slide_curve: 0
+        })
+      end
     end
 
 


### PR DESCRIPTION
I've noticed before that the `cutoff` opt was never in the autocomplete list, but happened to pay more attention to this recently after seeing this in the Docs: 😂
 
![image](https://user-images.githubusercontent.com/10395940/58559736-55375a00-8256-11e9-9d0e-3a1a00f6852f.png)

This change also adds it to the opt table in the docs.