### PR TITLE
Nit: `set` logging

### DIFF
--- a/app/server/ruby/lib/sonicpi/lang/core.rb
+++ b/app/server/ruby/lib/sonicpi/lang/core.rb
@@ -125,7 +125,7 @@ module SonicPi
         @register_cue_event_lambda.call(t, p, i, d, b, m, cue_path, val, __current_sched_ahead_time)
 
         unless __thread_locals.get(:sonic_pi_suppress_cue_logging)
-          unless val
+          if val.nil?
             __delayed_highlight_message "#{prefix} #{k.inspect}"
           else
             if is_list_like?(val)


### PR DESCRIPTION
The log message for `set` only prints the value if it is truthy, which means that `nil` and `false` are indistinguishable. Would it be better to only suppress `nil` like this? I also find it a bit clearer, the double negative of `unless`...`else` was slightly confusing for me.