### PR TITLE
sync: consistently sync to contemporary cues

### DIFF
--- a/app/server/ruby/test/lang/core/test_cue_sync.rb
+++ b/app/server/ruby/test/lang/core/test_cue_sync.rb
@@ -107,5 +107,164 @@ module SonicPi
       end
     end
 
+    def test_loose_thread_order
+      @lang.run do
+        assert_equal 0, vt
+
+        # Sync in early thread
+        in_thread do
+          assert_equal 0, vt
+          sync :foo
+          assert_equal 0, vt
+        end
+
+        in_thread do
+          # Cue in the middle thread
+          cue :foo
+          sleep 0.1
+          cue :foo
+        end
+
+        # Sync in late thread
+        in_thread do
+          assert_equal 0, vt
+          sync :foo
+          assert_equal 0, vt
+        end
+
+        # Sync in main thread
+        assert_equal 0, vt
+        sync :foo
+        assert_equal 0, vt
+      end
+    end
+
+    def test_sync_no_sleep
+      @lang.run do
+        assert_equal 0, vt
+
+        in_thread do
+          # A live loop with no sleeps and only syncs will functionally act as
+          # if it was attempting to sync multiple times at the same beat:
+          #
+          # live_loop :foo do
+          #   sync :bar
+          #   sample :bd_haus
+          # end
+          #
+          # So a cue must only trigger a sync once on a given thread.
+          sync :foo
+          sync :foo
+          assert_equal 0.2, vt
+        end
+
+        2.times do
+          sleep 0.1
+          cue :foo
+        end
+      end
+    end
+
+    def test_sync_rational_sleeps
+      @lang.run do
+        assert_equal 0, vt
+
+        in_thread do
+          30.times do
+            sleep 0.01
+            sync :foo
+          end
+          assert_equal 0.3, vt
+        end
+
+        # 3 sleeps of 0.01/3 seconds would tend to trigger ever so slightly
+        # earlier than 0.01 seconds so unless slack is given, the sync may be
+        # delayed to the next cue. 
+        (30 * (3 + 1)).times do
+          sleep 0.01 / 3
+          cue :foo
+        end
+      end
+    end
+
+    def test_determinism
+      @lang.run do
+        seeds = []
+
+        # Repeat experiment a few times to get new threads.
+        5.times do
+          3.times do
+            seeds << Random.new_seed
+          end
+        end
+
+        # Random sleeps based on the seeds.
+        def rsleep(prng)
+          case prng.rand(3)
+          when 0
+          when 1
+            sleep 0.01
+          when 2
+            sleep 0.05
+          end
+        end
+
+        while seeds do
+          # 3 threads - 2 generating cues and 1 syncing to them.
+          seed1 = seeds.pop
+          seed2 = seeds.pop
+          seed3 = seeds.pop
+
+          # Try the same combination of seeds twice.
+          results = []
+          2.times do
+            start = vt
+
+            # Cue generators run while this is set.
+            set :go, true
+
+            in_thread do
+              prng1 = Random.new(seed1)
+              while get :go do
+                rsleep(prng1)
+                cue :foo
+              end
+            end
+
+            in_thread do
+              result = []
+              prng2 = Random.new(seed2)
+              25.times do
+                rsleep(prng2)
+                sync :foo
+                timing = vt - start
+                # Sometimes the timing is off in the order of ~1e-17 seconds.
+                # I assume due to floating point instability.
+                result << timing.round(6)
+              end
+              # Send all the sync timings
+              cue :result, result
+            end
+
+            in_thread do
+              prng3 = Random.new(seed3)
+              while get :go do
+                rsleep(prng3)
+                cue :foo
+              end
+            end
+
+            results << (sync :result)
+            # Stop the cue generators and give them time finish.
+            set :go, false
+            sleep 0.1
+          end
+
+          assert_equal results[0], results[1]
+        end
+
+      end
+    end
+
   end
 end

--- a/app/server/ruby/test/test_event_history.rb
+++ b/app/server/ruby/test/test_event_history.rb
@@ -419,9 +419,9 @@ module SonicPi
       n1 = "/foo/bar/baz"
       m = 60
       history.set(0, 0, i, 1, 0, m, n1, [:baz0])
-      history.set(1, 0, i, 1, 0, m, n1, [:baz1])
-      history.set(2, 0, i, 1, 0, m, n1, [:baz2])
-      assert_equal [:baz1], history.sync(0, 0, i, 1, 0, m, n1).val
+      history.set(1, 0, i, 1, 1, m, n1, [:baz1])
+      history.set(2, 0, i, 1, 2, m, n1, [:baz2])
+      assert_equal [:baz1], history.sync(0.1, 0, i, 1, 0.1, m, n1).val
     end
 
     def test_sync_w_matchers


### PR DESCRIPTION
This change alters the behavior of cue/sync to not depend on the
execution order of threads. As a result, a cue will consistently trigger
a sync (exactly once) even if they happen at the same time.

Currently cue/sync matching requires that the cue to have been emitted
later than the sync that is waiting for it. This behavior neatly avoids
undeterministic behavior due to races but also makes it complicated to
reason about whether a particular cue would trigger a sync or not.

Specifically, a cue triggering a sync depends on the thread execution
order which while following consistent rules is non-trivial to determine
in the middle of a live coding session.

Consider these two threads:

```ruby
in_thread do
  sync :foo
  puts beat
end

in_thread do
  cue :foo
  sleep 0.1
  cue :foo
end
```

Executing in the order above, the puts will emit a `0.0`. If the order of
threads is switched, the puts will emit a `0.1`.

A more practical situation involves syncing up live loops that sleep the
same amount of time internally:

```ruby
live_loop :click do
  sleep 1
end

live_loop :music do
  sync :click
  4.times do
    play :a4
    sleep 0.25
  end
end
```

Contrary to intuition, the `:music` loop will skip execution every other
beat. Admittedly, there are ways to work around this but they are all
awkward in one way or another.

With this change, both examples above work the same (intuitive) way
irrespective of the order they appear in the buffer and in case of
live_loop, the order in which they are written and run in the live
coding session. That is, the in_thread example will always output `0.0`
and the `:music` loop will always trigger every beat.

See this thread for more discussion, examples and workarounds being
employed:

https://in-thread.sonic-pi.net/t/synchronization-between-sync-and-sleep/2429