### PR TITLE
Correct error with QSize parameters

### DIFF
--- a/app/gui/qt/mainwindow.cpp
+++ b/app/gui/qt/mainwindow.cpp
@@ -349,8 +349,8 @@ void MainWindow::loadToolBarIcons() {
   // load up icons into memory
   std::cout << "[GUI] - initialising toolbar icons" << std::endl;
 
-  QSize pro_size = QSize(30.0, 30.0);
-  QSize def_size = QSize(84.6, 30.0);
+  QSize pro_size = QSize(30, 30);
+  QSize def_size = QSize(85, 30);
 
   pro_run_icon = QIcon();
   pro_run_icon.addFile(":/images/toolbar/pro/run.png", pro_size);


### PR DESCRIPTION
Commit #82624de7c17f23841142d302c50e8e0f7c4e40b8 inroduced QSave function but used floating point parameters which produced an exception error. Change these to integers.