### PR TITLE
Docs - Fix multi-line run_code example

### DIFF
--- a/app/server/ruby/lib/sonicpi/lang/core.rb
+++ b/app/server/ruby/lib/sonicpi/lang/core.rb
@@ -490,7 +490,7 @@ run_file \"~/path/to/sonic-pi-code.rb\" #=> will run the contents of this file"]
 run_code \"sample :ambi_lunar_land\" #=> will play the :ambi_lunar_land sample",
 
         "# Works with any amount of code:
-run_code \"8.times do\nplay 60\nsleep 1\nend # will play 60 8 times"]
+run_code \"8.times do\nplay 60\nsleep 1\nend\" # will play 60 8 times"]
 
 
       def eval_file(path)


### PR DESCRIPTION
If you copy and paste the second example in the run_code docs, you get a
run-time error. This is because the example is missing a closing double-quote,
which has now been added.