### PR TITLE
Replace unused variable v to _v

### DIFF
--- a/app/server/ruby/lib/sonicpi/chord.rb
+++ b/app/server/ruby/lib/sonicpi/chord.rb
@@ -82,7 +82,7 @@ module SonicPi
         :m               => minor,
         :major7          => major7,
         :dom7            => dom7,
-        "7"               => dom7,
+        "7"              => dom7,
         :M7              => major7,
         :minor7          => minor7,
         :m7              => minor7,
@@ -108,7 +108,7 @@ module SonicPi
       end
 
       all_chords_names = all_chords.inject([]) do |res, chord_intervals|
-        k, v = *chord_intervals
+        k, _v = *chord_intervals
         res << k.to_s
         res
       end


### PR DESCRIPTION
Remove Warning of unused variable.

```
$ cd app/server/ruby
$ ruby -w lib/sonicpi/chord.rb
lib/sonicpi/chord.rb:111: warning: assigned but unused variable - v
```