### PR TITLE
GUI - Update the menu bar and menu bar item colours

### DIFF
--- a/app/gui/qt/model/sonicpitheme.cpp
+++ b/app/gui/qt/model/sonicpitheme.cpp
@@ -274,6 +274,7 @@ QMap<QString, QString> SonicPiTheme::lightTheme(){
     themeSettings["MenuText"] = dt_darkgrey;
     themeSettings["MenuSelected"] = dt_pink;
     themeSettings["MenuSelectedText"] = dt_white;
+    themeSettings["MenuBar"] = dt_lightgrey;
 
     themeSettings["Foreground"]                      = theme_fg;
     themeSettings["Background"]                      = dt_white;
@@ -474,6 +475,7 @@ QMap<QString, QString> SonicPiTheme::darkTheme(){
     themeSettings["MenuText"] = dt_lightgrey;
     themeSettings["MenuSelected"] = dt_pink;
     themeSettings["MenuSelectedText"] = dt_white;
+    themeSettings["MenuBar"] = dt_darkgrey;
 
     themeSettings["Foreground"]                      = dt_lightgrey;
     themeSettings["Background"]                      = dt_black;
@@ -677,6 +679,7 @@ QMap<QString, QString> SonicPiTheme::highContrastTheme(){
     themeSettings["MenuText"] = dt_darkgrey;
     themeSettings["MenuSelected"] = dt_pink;
     themeSettings["MenuSelectedText"] = dt_white;
+    themeSettings["MenuBar"] = dt_white;
 
     themeSettings["Foreground"]                      = theme_fg;
     themeSettings["Background"]                      = dt_white;
@@ -896,6 +899,7 @@ QString SonicPiTheme::getAppStylesheet() {
     QString menuTextColor = this->color("MenuText").name();
     QString menuSelectedColor = this->color("MenuSelected").name();
     QString menuSelectedTextColor = this->color("MenuSelectedText").name();
+    QString menuBarColor = this->color("MenuBar").name();
 
     QString selectionForegroundColor = this->color("SelectionForeground").name();
     QString selectionBackgroundColor = this->color("SelectionBackground").name();
@@ -933,6 +937,7 @@ QString SonicPiTheme::getAppStylesheet() {
         .replace("menuTextColor", menuTextColor)
         .replace("menuSelectedColor", menuSelectedColor)
         .replace("menuSelectedTextColor", menuSelectedTextColor)
+        .replace("menuBarColor", menuBarColor)
         .replace("selectionForegroundColor", selectionForegroundColor)
         .replace("selectionBackgroundColor", selectionBackgroundColor)
         .replace("errorBackgroundColor", errorBackgroundColor);

--- a/app/gui/qt/theme/app.qss
+++ b/app/gui/qt/theme/app.qss
@@ -152,6 +152,20 @@ QMenu:selected{
     color: menuSelectedTextColor;
 }
 
+QMenuBar {
+    background: menuBarColor;
+}
+
+QMenuBar::item {
+    background: menuColor;
+    color: menuTextColor;
+}
+
+QMenuBar::item:selected {
+    background: menuSelectedColor;
+    color: menuSelectedTextColor;
+}
+
 QMainWindow::separator{
     border: 1px solid windowBorderColor;
 }


### PR DESCRIPTION
This change makes menu items in the menu bar more visible. (Previously, the menu items were all but invisible until hovered over, and even then were not very visible).

Here are some screenshots for reference:
Light theme:
![light theme](https://user-images.githubusercontent.com/10395940/68268473-4bc9dd80-0091-11ea-80b9-9bd3a0514004.png)

Dark theme:
![dark theme](https://user-images.githubusercontent.com/10395940/68268475-4e2c3780-0091-11ea-82f4-3401320234b4.png)

High contrast theme:
![high contrast theme](https://user-images.githubusercontent.com/10395940/68268482-54baaf00-0091-11ea-914e-a5e88d0f5f94.png)

