### PR TITLE
Style non-native file dialogs

### DIFF
--- a/app/gui/qt/model/sonicpitheme.cpp
+++ b/app/gui/qt/model/sonicpitheme.cpp
@@ -904,6 +904,7 @@ QString SonicPiTheme::getAppStylesheet() {
     QString selectionForegroundColor = this->color("SelectionForeground").name();
     QString selectionBackgroundColor = this->color("SelectionBackground").name();
     QString errorBackgroundColor = this->color("ErrorBackground").name();
+    QString baseColor = this->color("Base").name();
 
     appStyling.replace("fixedWidthFont", "\"Hack\"");
 
@@ -940,7 +941,8 @@ QString SonicPiTheme::getAppStylesheet() {
         .replace("menuBarColor", menuBarColor)
         .replace("selectionForegroundColor", selectionForegroundColor)
         .replace("selectionBackgroundColor", selectionBackgroundColor)
-        .replace("errorBackgroundColor", errorBackgroundColor);
+        .replace("errorBackgroundColor", errorBackgroundColor)
+        .replace("baseColor", baseColor);
 
     return appStyling;
 }

--- a/app/gui/qt/theme/app.qss
+++ b/app/gui/qt/theme/app.qss
@@ -30,6 +30,7 @@ Available Style Colours:
 - menuTextColor
 - menuSelectedColor
 - menuSelectedTextColor
+- menuBarColor
 - selectionForegroundColor
 - selectionBackgroundColor
 - errorBackgroundColor
@@ -420,4 +421,16 @@ QScrollBar::add-page:horizontal, QScrollBar::sub-page:horizontal {
 
 QScrollBar::add-page:vertical, QScrollBar::sub-page:vertical {
     background: none;
+}
+
+QFileDialog QHeaderView, QFileDialog QHeaderView::section {
+    background: baseColor;
+    color: menuTextColor;
+}
+
+QFileDialog QLineEdit {
+    background: tabColor;
+    color: tabTextColor;
+    border: none;
+    padding: 1px 18px 1px 3px;
 }


### PR DESCRIPTION
This updates the style of the Qt file dialogs that are used on linux OS's, since
previously the text in parts of these dialogs was almost invisible. They're now
fixed.
An issue that still remains is that in the dark theme, if a scroll bar is needed
in the file dialog, it merges into the file details panel as that has the same
colour for its background. A decision may need to be made about whether or not
to change this in some manner.

Also in this change, I've also added in 'menuBarColor' to the comments
describing the list of customisable theme components, since I missed that last
time.

Here is the native file dialog on Windows:
![image](https://user-images.githubusercontent.com/10395940/68378476-24edd300-0187-11ea-9a35-148d57f6c440.png)


Here is the current state of the Qt file dialog as in this change, when using the dark theme:
![image](https://user-images.githubusercontent.com/10395940/68378504-2cad7780-0187-11ea-93a3-563097182a09.png)

The only thing that I’m still not sure about is how to relate the style of the scroll bar and the background colour of the tree browser and file details table. You’ll notice that the dark grey scroll bar button merges into the background colour of the file details table - so, we could either change the background colour of the tree browser/file details table, or the scroll bar button.

Comparing the QFileDialog to the rest of the places in the app that may have a scroll bar, it appears that the background color of whatever the scroll bars are attached to is usually black (such as the log panel as seen here) -
![image](https://user-images.githubusercontent.com/10395940/68378546-4222a180-0187-11ea-973b-68931384ef3d.png)

So in that regard, it would seem consistent to make the background of the QFileDialog’s tree browser and file details table black.
