### PR TITLE
Docs - Fix typo in sample hpf docs

### DIFF
--- a/app/server/ruby/lib/sonicpi/synths/synthinfo.rb
+++ b/app/server/ruby/lib/sonicpi/synths/synthinfo.rb
@@ -3211,7 +3211,7 @@ Steal This Sound,  Mitchell Sigman"
 
           :hpf =>
           {
-            :doc => "High pass filter cutoff value. A MIDI note representing the lowest frequencies allowed to be present in the sound. A high value like 100 makes the sound thin and whispy, a low value like 40 makes removes just the lower bass components of the sound.",
+            :doc => "High pass filter cutoff value. A MIDI note representing the lowest frequencies allowed to be present in the sound. A high value like 100 makes the sound thin and whispy, a low value like 40 removes just the lower bass components of the sound.",
             :validations => [v_positive(:hpf), v_less_than(:hpf, 119)],
             :modulatable => true,
             :midi => true


### PR DESCRIPTION
Also, a question:
The commit that introduced the change to the `:hpf` docs mentioned:

> The :hpf now checks to ensure it's no higher than 119

However, the corresponding validator created for this specifies:
`v_less_than(:hpf, 119)`

So, strictly speaking, these do not match - which of the two should be updated?