### PR TITLE
Add support for M-0 through M-9 hotkeys for tabs

### DIFF
--- a/app/gui/qt/mainwindow.cpp
+++ b/app/gui/qt/mainwindow.cpp
@@ -2015,6 +2015,16 @@ void MainWindow::updateAction(QAction *action, QShortcut *sc, QString tooltip,  
 void MainWindow::createShortcuts()
 {
     std::cout << "[GUI] - creating shortcuts" << std::endl;
+    new QShortcut(metaKey('0'), this, SLOT(tabSet0()));
+    new QShortcut(metaKey('1'), this, SLOT(tabSet1()));
+    new QShortcut(metaKey('2'), this, SLOT(tabSet2()));
+    new QShortcut(metaKey('3'), this, SLOT(tabSet3()));
+    new QShortcut(metaKey('4'), this, SLOT(tabSet4()));
+    new QShortcut(metaKey('5'), this, SLOT(tabSet5()));
+    new QShortcut(metaKey('6'), this, SLOT(tabSet6()));
+    new QShortcut(metaKey('7'), this, SLOT(tabSet7()));
+    new QShortcut(metaKey('8'), this, SLOT(tabSet8()));
+    new QShortcut(metaKey('9'), this, SLOT(tabSet9()));
     new QShortcut(shiftMetaKey('['), this, SLOT(tabPrev()));
     new QShortcut(shiftMetaKey(']'), this, SLOT(tabNext()));
     new QShortcut(QKeySequence("F8"), this, SLOT(reloadServerCode()));
@@ -2617,6 +2627,25 @@ void MainWindow::tabPrev() {
         index = tabs->count() - 1;
     else
         index--;
+    QMetaObject::invokeMethod(tabs, "setCurrentIndex", Q_ARG(int, index));
+}
+
+#define MAINWINDOW_TAB_SET(index) void MainWindow::tabSet ## index() { tabSet((index)); } 
+
+MAINWINDOW_TAB_SET(0)
+MAINWINDOW_TAB_SET(1)
+MAINWINDOW_TAB_SET(2)
+MAINWINDOW_TAB_SET(3)
+MAINWINDOW_TAB_SET(4)
+MAINWINDOW_TAB_SET(5)
+MAINWINDOW_TAB_SET(6)
+MAINWINDOW_TAB_SET(7)
+MAINWINDOW_TAB_SET(8)
+MAINWINDOW_TAB_SET(9)
+
+void MainWindow::tabSet(int index) {
+    /* Force index into tab range */
+    index = index % tabs->count();
     QMetaObject::invokeMethod(tabs, "setCurrentIndex", Q_ARG(int, index));
 }
 

--- a/app/gui/qt/mainwindow.h
+++ b/app/gui/qt/mainwindow.h
@@ -164,6 +164,7 @@ signals:
         void replaceLines(QString id, QString content, int first_line, int finish_line, int point_line, int point_index);
         void tabNext();
         void tabPrev();
+        void tabSet(int index);
         void helpContext();
         void resetErrorPane();
         void helpScrollUp();


### PR DESCRIPTION
Many modern IDEs and terminals have support for switching windows by using the M-0 through M-9 keys. This PR brings support for that to Sonic Pi. This may help with #962 by giving all users a way to switch workspaces more easily.

I tested an [earlier version of this branch vs. Sonic Pi last September](https://github.com/obscurerichard/sonic-pi/tree/dev-hotkeys-M-0-9), this branch and PR clean it up so that it should apply cleanly to master today.

This will need amendments to documentation and translations for those documentation changes to be fully ready.