### PR TITLE
Fixes to make windows build easier

### DIFF
--- a/app/gui/qt/SonicPi.pro
+++ b/app/gui/qt/SonicPi.pro
@@ -44,12 +44,10 @@ macx {
 
 # Windows only
 win32 {
-  include ( c:/qwt-6.1.3/features/qwt.prf )
-  LIBS += -lqscintilla2
-  QMAKE_CXXFLAGS += -Ic:/boost_1_61_0
-#  QMAKE_CXXFLAGS += /WX
-  QMAKE_LFLAGS += /LIBPATH:C:\boost_1_61_0\bin.v2\libs\date_time\build\msvc-12.0\release\link-static\threading-multi
-  DEFINES += _CRT_SECURE_NO_WARNINGS _WINSOCK_DEPRECATED_NO_WARNINGS
+  include ( c:/Qwt-6.1.4/features/qwt.prf )
+  LIBS += -lqscintilla2_qt5
+  QMAKE_CXXFLAGS += -I$$(BOOST_ROOT)
+  DEFINES += _CRT_SECURE_NO_WARNINGS _WINSOCK_DEPRECATED_NO_WARNINGS BOOST_DATE_TIME_NO_LIB
 }
 
 CODECFORSRC = UTF-8
@@ -154,7 +152,7 @@ RC_FILE = SonicPi.rc
 ICON = images/app.icns
 
 win32 {
-  install_qsci.files = $$[QT_INSTALL_LIBS]\qscintilla2.dll
+  install_qsci.files = $$[QT_INSTALL_LIBS]\qscintilla2_qt5.dll
   install_qsci.path = release
 
   install_bat.files = sonic-pi.bat

--- a/app/gui/qt/SonicPi.qrc
+++ b/app/gui/qt/SonicPi.qrc
@@ -93,33 +93,33 @@
         <file>images/logo-smaller-dark.png</file>
         <file>images/logo.txt</file>
         <file>images/in_thread_screen.png</file>
-        <file>images/tutorial/sample.png</file>
-        <file>images/tutorial/env-attack-release.png</file>
-        <file>images/tutorial/env-attack-decay-sustain-release.png</file>
-        <file>images/tutorial/env-attack-sustain-release.png</file>
-        <file>images/tutorial/env-long-attack-short-release.png</file>
-        <file>images/tutorial/env-release.png</file>
-        <file>images/tutorial/env-short-attack-short-release.png</file>
-        <file>images/tutorial/env-decay-level.png</file>
-        <file>images/tutorial/env-decay-level-2.png</file>
-        <file>images/tutorial/GUI.png</file>
 
-        <file>images/tutorial/articles/A.05-acid-bass/tb303-design.png</file>
-        <file>images/tutorial/articles/A.06-minecraft/Musical-Minecraft-0-small.png</file>
-        <file>images/tutorial/articles/A.06-minecraft/Musical-Minecraft-1-small.png</file>
-        <file>images/tutorial/articles/A.06-minecraft/Musical-Minecraft-2-small.png</file>
-        <file>images/tutorial/articles/A.07-bizet/habanera.png</file>
-        <file>images/tutorial/articles/A.07-bizet/notes.png</file>
-        <file>images/tutorial/articles/A.07-bizet/habanera2.png</file>
-        <file>images/tutorial/articles/A.08-minecraft-vj/minecraft-vj-0-small.png</file>
-        <file>images/tutorial/articles/A.08-minecraft-vj/minecraft-vj-1-small.png</file>
-        <file>images/tutorial/articles/A.02-live-coding/sam-aaron-live-coding.png</file>
-        <file>images/tutorial/articles/A.12-sample-slicing/amen_slice.png</file>
-        <file>images/tutorial/articles/A.14-amplitude-modulation/slicer_control_waves.png</file>
-        <file>images/tutorial/articles/A.14-amplitude-modulation/slicer_phase_durations.png</file>
+        <file>../../../etc/doc/images/tutorial/sample.png</file>
+        <file>../../../etc/doc/images/tutorial/env-attack-release.png</file>
+        <file>../../../etc/doc/images/tutorial/env-attack-decay-sustain-release.png</file>
+        <file>../../../etc/doc/images/tutorial/env-attack-sustain-release.png</file>
+        <file>../../../etc/doc/images/tutorial/env-long-attack-short-release.png</file>
+        <file>../../../etc/doc/images/tutorial/env-release.png</file>
+        <file>../../../etc/doc/images/tutorial/env-short-attack-short-release.png</file>
+        <file>../../../etc/doc/images/tutorial/env-decay-level.png</file>
+        <file>../../../etc/doc/images/tutorial/env-decay-level-2.png</file>
+        <file>../../../etc/doc/images/tutorial/GUI.png</file>
+        <file>../../../etc/doc/images/tutorial/articles/A.05-acid-bass/tb303-design.png</file>
+        <file>../../../etc/doc/images/tutorial/articles/A.06-minecraft/Musical-Minecraft-0-small.png</file>
+        <file>../../../etc/doc/images/tutorial/articles/A.06-minecraft/Musical-Minecraft-1-small.png</file>
+        <file>../../../etc/doc/images/tutorial/articles/A.06-minecraft/Musical-Minecraft-2-small.png</file>
+        <file>../../../etc/doc/images/tutorial/articles/A.07-bizet/habanera.png</file>
+        <file>../../../etc/doc/images/tutorial/articles/A.07-bizet/notes.png</file>
+        <file>../../../etc/doc/images/tutorial/articles/A.07-bizet/habanera2.png</file>
+        <file>../../../etc/doc/images/tutorial/articles/A.08-minecraft-vj/minecraft-vj-0-small.png</file>
+        <file>../../../etc/doc/images/tutorial/articles/A.08-minecraft-vj/minecraft-vj-1-small.png</file>
+        <file>../../../etc/doc/images/tutorial/articles/A.02-live-coding/sam-aaron-live-coding.png</file>
+        <file>../../../etc/doc/images/tutorial/articles/A.12-sample-slicing/amen_slice.png</file>
+        <file>../../../etc/doc/images/tutorial/articles/A.14-amplitude-modulation/slicer_control_waves.png</file>
+        <file>../../../etc/doc/images/tutorial/articles/A.14-amplitude-modulation/slicer_phase_durations.png</file>
 
-        <file>images/tutorial/articles/A.20-creative-coding-in-the-classroom/jylda-small.png</file>
-        <file>images/tutorial/articles/A.20-creative-coding-in-the-classroom/convo-small.png</file>
+        <file>../../../etc/doc/images/tutorial/articles/A.20-creative-coding-in-the-classroom/jylda-small.png</file>
+        <file>../../../etc/doc/images/tutorial/articles/A.20-creative-coding-in-the-classroom/convo-small.png</file>
 
         <file>images/coreteam/samaaron.png</file>
         <file>images/coreteam/josephwilk.png</file>

--- a/app/gui/qt/win-build-app.bat
+++ b/app/gui/qt/win-build-app.bat
@@ -1,8 +1,8 @@
 cd %~dp0
 
 ..\..\server\native\ruby\bin\ruby ../../server/ruby/bin/i18n-tool.rb -t
-copy /Y ruby_help.tmpl ruby_help.h
-..\..\server\native\ruby\bin\ruby ../../server/ruby/bin/qt-doc.rb -o ruby_help.h
+copy /Y utils\ruby_help.tmpl utils\ruby_help.h
+..\..\server\native\ruby\bin\ruby ../../server/ruby/bin/qt-doc.rb -o utils/ruby_help.h
 
 @IF ERRORLEVEL==9009 goto :noruby
 @IF ERRORLEVEL==1 goto :docfail


### PR DESCRIPTION
- Use a BOOST_ROOT environment variable to point to your boost folder
(removed the hard-wired path in the makefile)

- Don't require the boost date/time library - it isn't needed; just the
headers are enough to build.

- Fix the path to ruby_help

- Fix the Scintilla name for version qt5

- Add relative paths to the tutorial/images folder, instead of making a
link.  Saves having to delete and remake the link on checkout.