### PR TITLE
Fixes for some DPI issues

### DIFF
--- a/app/gui/qt/SonicPi.pro
+++ b/app/gui/qt/SonicPi.pro
@@ -47,7 +47,8 @@ win32 {
   include ( c:/Qwt-6.1.4/features/qwt.prf )
   LIBS += -lqscintilla2_qt5
   QMAKE_CXXFLAGS += -I$$(BOOST_ROOT)
-  DEFINES += _CRT_SECURE_NO_WARNINGS _WINSOCK_DEPRECATED_NO_WARNINGS BOOST_DATE_TIME_NO_LIB
+  # Remove Warnings during build and do not need data time lib
+  DEFINES += _CRT_SECURE_NO_WARNINGS _WINSOCK_DEPRECATED_NO_WARNINGS BOOST_DATE_TIME_NO_LIB _MATH_DEFINES_DEFINED
 }
 
 CODECFORSRC = UTF-8

--- a/app/gui/qt/dpi.h
+++ b/app/gui/qt/dpi.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <QGuiApplication>
+#include <QScreen>
+
+inline QSizeF GetDisplayScale()
+{
+    QSizeF scaleDpi = QSizeF(96.0f, 96.0f);
+    if (const QScreen* pScreen = QGuiApplication::primaryScreen())
+    {
+        scaleDpi.setWidth(pScreen->logicalDotsPerInchX());
+        scaleDpi.setHeight(pScreen->logicalDotsPerInchY());
+    }
+
+    return QSizeF(scaleDpi.width() / 96.0f, scaleDpi.height() / 96.0f);
+}
+
+inline QSize ScaleForDPI(const QSize& sz)
+{
+    auto scale = GetDisplayScale();
+    return QSize(scale.width() * sz.width(), scale.height() * sz.height());
+}
+
+inline QSize ScaleForDPI(int x, int y)
+{
+    auto scale = GetDisplayScale();
+    return QSize(scale.width() * x, scale.height() * y);
+}

--- a/app/gui/qt/mainwindow.cpp
+++ b/app/gui/qt/mainwindow.cpp
@@ -11,14 +11,10 @@
 // notice is included.
 //++
 
-
 // Standard stuff
 #include <iostream>
-#include <math.h>
 #include <sstream>
 #include <fstream>
-
-// Qt 5 only
 
 // Qt stuff
 #include <QDesktopWidget>
@@ -41,6 +37,7 @@
 #include <QBoxLayout>
 #include <QLabel>
 #include <QLineEdit>
+#include <QStyle>
 
 // QScintilla stuff
 #include <Qsci/qsciapis.h>
@@ -66,6 +63,8 @@
 #include "widgets/settingswidget.h"
 
 #include "utils/ruby_help.h"
+
+#include "dpi.h"
 
 using namespace oscpkt;// OSC specific stuff
 
@@ -725,7 +724,7 @@ void MainWindow::setupWindowStructure() {
     // hudWidget->setWidget(hudPane);
     // hudWidget->setObjectName("hud");
 
-    scopeWidget = new QDockWidget("",this);
+    scopeWidget = new QDockWidget(tr("Scope"),this);
     scopeWidget->setFocusPolicy(Qt::NoFocus);
     scopeWidget->setAllowedAreas(Qt::RightDockWidgetArea | Qt::BottomDockWidgetArea | Qt::TopDockWidgetArea);
     scopeWidget->setFeatures(QDockWidget::DockWidgetClosable | QDockWidget::DockWidgetMovable | QDockWidget::DockWidgetFloatable);
@@ -1805,9 +1804,9 @@ void MainWindow::toggleIcons() {
 
     if (piSettings->themeStyle == SonicPiTheme::DarkProMode ||
         piSettings->themeStyle == SonicPiTheme::LightProMode) {
-        toolBar->setIconSize(QSize(30, 30));
+        toolBar->setIconSize(ScaleForDPI(30, 30));
     } else {
-        toolBar->setIconSize(QSize(84.6, 30.0));
+        toolBar->setIconSize(ScaleForDPI(84.6,30));
     }
 }
 
@@ -2209,7 +2208,7 @@ void MainWindow::createInfoPane() {
     infoWidg->setLayout(infoLayout);
     infoWidg->setWindowFlags(Qt::Tool | Qt::WindowTitleHint | Qt::WindowCloseButtonHint | Qt::CustomizeWindowHint | Qt::WindowStaysOnTopHint);
     infoWidg->setWindowTitle(tr("Sonic Pi - Info"));
-    infoWidg->setFixedSize(660, 640);
+    infoWidg->setFixedSize(ScaleForDPI(660, 640));
 
     connect(infoWidg, SIGNAL(closed()), this, SLOT(about()));
 
@@ -2304,8 +2303,8 @@ void MainWindow::restoreWindows() {
     }
 
     docsplit->restoreState(settings.value("docsplitState").toByteArray());
-    bool visualizer = piSettings->show_scopes;
-   restoreState(settings.value("windowState").toByteArray());
+    //bool visualizer = piSettings->show_scopes;
+    restoreState(settings.value("windowState").toByteArray());
 //    restoreGeometry(settings.value("windowGeom").toByteArray());
 
 //    if (visualizer != piSettings->show_scopes) {
@@ -2538,7 +2537,6 @@ void MainWindow::addHelpPage(QListWidget *nameList,
     for(i = 0; i < len; i++) {
         QListWidgetItem *item = new QListWidgetItem(helpPages[i].title);
         item->setData(32, QVariant(helpPages[i].url));
-        item->setSizeHint(QSize(item->sizeHint().width(), 25));
         nameList->addItem(item);
         entry.entryIndex = nameList->count()-1;
 

--- a/app/gui/qt/model/sonicpitheme.cpp
+++ b/app/gui/qt/model/sonicpitheme.cpp
@@ -15,6 +15,9 @@
 #include "sonicpitheme.h"
 #include <QApplication>
 #include <iostream>
+
+#include "dpi.h"
+
 SonicPiTheme::SonicPiTheme(QObject *parent, QString customSettingsFilename, QString rootPath) : QObject(parent)
 {
 
@@ -861,6 +864,12 @@ QString SonicPiTheme::font(QString key){
 QString SonicPiTheme::getAppStylesheet() {
     QString appStyling = readFile(qt_app_theme_path);
 
+    // A hack to fix up for dpi
+    auto scale = GetDisplayScale();
+    appStyling = appStyling.replace("font-size: 10px", QString("font-size: %1px").arg(10 * scale.height()));
+    appStyling = appStyling.replace("font-size: 11px", QString("font-size: %1px").arg(11 * scale.height()));
+    appStyling = appStyling.replace("font-size: 14px", QString("font-size: %1px").arg(14 * scale.height()));
+
     QString windowColor = this->color("WindowBackground").name();
     QString windowForegroundColor = this->color("WindowForeground").name();
     QString paneColor = this->color("PaneBackground").name();
@@ -947,9 +956,9 @@ QString SonicPiTheme::getDocStylesheet() {
     return QString(
                 "QListWidget{"
                 "border: none;"
-                "font-size: 13px;"
+                "font-size: %1px;"
                 "font-family: none;"
-                "}");
+                "}").arg(13 * GetDisplayScale().height());
 }
 
 QString SonicPiTheme::getErrorStylesheet() {

--- a/app/gui/qt/theme/app.qss
+++ b/app/gui/qt/theme/app.qss
@@ -120,12 +120,12 @@ QDockWidget::title
     border: 0px;
     text-align: center;
     background: windowColor;
-    font-size 10px;
+    font-size: 10px;
 }
 
 QDockWidget
 {
-    font-size:10px;
+    font-size: 10px;
 }
 
  QToolTip

--- a/app/gui/qt/visualizer/server_shm.hpp
+++ b/app/gui/qt/visualizer/server_shm.hpp
@@ -76,6 +76,8 @@ public:
 
 	void set_control_bus(int bus, float value)
 	{
+        Q_UNUSED(bus);
+        Q_UNUSED(value);
 		// TODO: we need to set the control busses via a work queue
 	}
 


### PR DESCRIPTION
This is not a complete fix, but remedies most of the issues.

- Scale fonts by display scale; added helper to get the scaling

- A hack to fixup the font sizes in the stylesheet; a better fix is to
remove the style sheets and use palettes for colors.

- Also removed compile warnings seen on windows compile

- Removed setSizeHint from the context help tree.  This was slicing off
the text, and I believe that the font size will naturally set the size
of the tree elements anyway.