### PR TITLE
DPI Fixes Part 2

### DIFF
--- a/app/gui/qt/main.cpp
+++ b/app/gui/qt/main.cpp
@@ -22,11 +22,15 @@
 #include "mainwindow.h"
 
 #include "widgets/sonicpilog.h"
+
 int main(int argc, char *argv[])
 {
 #ifndef Q_OS_MAC
   Q_INIT_RESOURCE(SonicPi);
 #endif
+  QApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
+  QApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+  QApplication::setAttribute(Qt::AA_DontShowIconsInMenus, true);
 
   QApplication app(argc, argv);
 
@@ -49,8 +53,6 @@ int main(int argc, char *argv[])
   app.setStyle("gtk");
 
 #ifdef Q_OS_MAC
-  app.setAttribute( Qt::AA_UseHighDpiPixmaps );
-  app.setAttribute(Qt::AA_DontShowIconsInMenus, true);
   QMainWindow* splashWindow = new QMainWindow(0, Qt::FramelessWindowHint);
   QLabel* imageLabel = new QLabel();
   splashWindow->setAttribute( Qt::WA_TranslucentBackground);

--- a/app/gui/qt/visualizer/scope.cpp
+++ b/app/gui/qt/visualizer/scope.cpp
@@ -23,11 +23,6 @@
 #include <qwt_text_label.h>
 #include <cmath>
 #include <set>
-#if (QT_VERSION >= 0x050400) || !defined(Q_OS_LINUX)
-  // enable OpenGL rendering on all platforms except Raspberry Pi
-  // which is assumed to be Linux + Qt 4
-  #include <qwt_plot_glcanvas.h>
-#endif
 
 ScopeBase::ScopeBase( const QString& name, const QString& title, int scsynthPort, QWidget* parent ) : QWidget(parent), name(name), title(title), scsynthPort(scsynthPort), defaultShowX(true), defaultShowY(true), plot(QwtText(name),this)
 {
@@ -83,14 +78,6 @@ void ScopeBase::refresh( )
 
 ScopePanel::ScopePanel( const QString& name, const QString& title, int scsynthPort, double* sample_x, double* sample_y, int num_samples, QWidget* parent ) : ScopeBase(name,title,scsynthPort,parent)
 {
-
-#if defined(Q_OS_WIN)
-  // enable OpenGL rendering on all platforms except Raspberry Pi
-  // and Mac (as there are docking/undockign issues to be resolved)
-
-  plot.setCanvas( new QwtPlotGLCanvas() );
-#endif
-
 #if QWT_VERSION >= 0x60100
   plot_curve.setPaintAttribute( QwtPlotCurve::PaintAttribute::FilterPoints );
 #endif


### PR DESCRIPTION
My previous attempt at using auto scaling failed because the scopes were
broken.  Digging into this, I found that only on windows, the scope was
trying to use an old-style OpenGL Canvas (on windows only).  This is
most likely not DPI friendly, and I bet there is no performance
difference to using it (the docs suggest it is for better customization,
not speed).  Using the same canvas as on Mac, everything works well.

This fixes the toolbar icons, the menu text (I removed the icons, as in
Mac), the startup splash screen, and the error dialog.

One oddness: In Dark/Pro Dark modes it is hard to see the 'close'
buttons on the doc panels.  I think this is a style choice though, not a
DPI issue.  I suspect a color: white is missing somewhere in the dark
themes.

This fix will need checking on Mac and Low DPI to ensure there are no
odd behaviors; it should be OK though.

![image](https://user-images.githubusercontent.com/120447/73135702-10f69680-403d-11ea-9511-b14bfd3183f2.png)
