### PR TITLE
An example of how to draw in a Qt Window

### DIFF
--- a/app/gui/qt/CMakeLists.txt
+++ b/app/gui/qt/CMakeLists.txt
@@ -84,6 +84,8 @@ set(SOURCES
     ${APP_ROOT}/utils/sonicpiapis.cpp
     ${APP_ROOT}/widgets/sonicpilog.cpp
     ${APP_ROOT}/widgets/sonicpilog.h
+    ${APP_ROOT}/widgets/visualizer.cpp
+    ${APP_ROOT}/widgets/visualizer.h
     ${APP_ROOT}/utils/sonicpiapis.h
     ${APP_ROOT}/utils/ruby_help.h
     ${APP_ROOT}/model/settings.h

--- a/app/gui/qt/mainwindow.cpp
+++ b/app/gui/qt/mainwindow.cpp
@@ -59,6 +59,7 @@
 
 #include "widgets/sonicpilog.h"
 #include "widgets/infowidget.h"
+#include "widgets/visualizer.h"
 #include "model/settings.h"
 #include "widgets/settingswidget.h"
 
@@ -734,6 +735,12 @@ void MainWindow::setupWindowStructure() {
 
     connect(scopeWidget, SIGNAL(visibilityChanged(bool)), this, SLOT(scopeVisibilityChanged()));
 
+    visualizerWidget = new QDockWidget(tr("Visualizer"),this);
+    visualizerWidget->setFocusPolicy(Qt::NoFocus);
+    visualizerWidget->setAllowedAreas(Qt::RightDockWidgetArea | Qt::BottomDockWidgetArea | Qt::TopDockWidgetArea);
+    visualizerWidget->setFeatures(QDockWidget::DockWidgetClosable | QDockWidget::DockWidgetMovable | QDockWidget::DockWidgetFloatable);
+    visualizerWidget->setWidget(new Visualizer(scopeInterface));
+    addDockWidget(Qt::RightDockWidgetArea, visualizerWidget);
 
     outputWidget = new QDockWidget(tr("Log"), this);
     outputWidget->setFocusPolicy(Qt::NoFocus);

--- a/app/gui/qt/mainwindow.h
+++ b/app/gui/qt/mainwindow.h
@@ -295,6 +295,7 @@ signals:
         //  QTextBrowser *hudPane;
         QWidget *mainWidget;
         QDockWidget *scopeWidget;
+        QDockWidget *visualizerWidget;
         bool hidingDocPane;
         bool restoreDocPane;
 

--- a/app/gui/qt/visualizer/scope.h
+++ b/app/gui/qt/visualizer/scope.h
@@ -93,6 +93,7 @@ public:
   void scsynthBooted();
   void setColor(QColor c);
 
+  double* GetSamples() { return &sample[0][0]; };
 
 private slots:
   void drawLoop();

--- a/app/gui/qt/widgets/visualizer.cpp
+++ b/app/gui/qt/widgets/visualizer.cpp
@@ -15,6 +15,8 @@ Visualizer::Visualizer(Scope* pScope, QWidget* pParent)
 void Visualizer::paintEvent(QPaintEvent* paintEvent)
 {
     QPainter painter(this);
+    painter.setRenderHint(QPainter::RenderHint::HighQualityAntialiasing);
+
     auto rc = rect();
 
     int y = int(rc.height() / 2.0f);
@@ -33,6 +35,7 @@ void Visualizer::paintEvent(QPaintEvent* paintEvent)
     m_wavePointsRight.resize(rc.width());
     for (int x = 0; x < rc.width(); x++)
     {
+        // Should really smooth the samples here, but this is just a quick demo
         auto left = pData[int(double(x) * step)];
         auto right = pData[4096 + int(double(x) * step)];
         average += std::abs(left);
@@ -44,7 +47,7 @@ void Visualizer::paintEvent(QPaintEvent* paintEvent)
     
     // Draw a simple volume based on the samples, in the background
     average /= rc.width() * 2;
-    painter.fillRect(0, int(double(rc.height()) - average * yScale * 2), rc.width(),int(average * yScale * 2), Qt::blue);
+    painter.fillRect(0, int(double(rc.height()) - average * yScale * 4), rc.width(),int(average * yScale * 4), Qt::blue);
 
     // Draw the left/right stereo, different colors, overlayed
 

--- a/app/gui/qt/widgets/visualizer.cpp
+++ b/app/gui/qt/widgets/visualizer.cpp
@@ -1,0 +1,61 @@
+#include <QPainter>
+#include <QTimer>
+
+#include "visualizer.h"
+
+Visualizer::Visualizer(Scope* pScope, QWidget* pParent)
+    : QWidget(pParent),
+    m_pScope(pScope)
+{
+  QTimer *scopeTimer = new QTimer(this);
+  connect(scopeTimer, SIGNAL(timeout()), this, SLOT(drawLoop()));
+  scopeTimer->start(20);
+}
+    
+void Visualizer::paintEvent(QPaintEvent* paintEvent)
+{
+    QPainter painter(this);
+    auto rc = rect();
+
+    int y = int(rc.height() / 2.0f);
+    float yScale = (float)y;
+
+    // A crude sampling of the source data, with no bounds checking...
+    // and a nasty hack to extract the data from the scope (the data processing should be in a seperate thread somewhere).
+    double* pData = m_pScope->GetSamples();
+    double step = 4096 / double(rc.width());
+
+    double average = 0.0;
+
+    // Make a list of points; it's better to gather them and submit in a batch
+    // Here we are just drawing in pixel space
+    m_wavePointsLeft.resize(rc.width());
+    m_wavePointsRight.resize(rc.width());
+    for (int x = 0; x < rc.width(); x++)
+    {
+        auto left = pData[int(double(x) * step)];
+        auto right = pData[4096 + int(double(x) * step)];
+        average += std::abs(left);
+        average += std::abs(right);
+
+        m_wavePointsLeft[x] = QPoint(x, left * yScale + y);
+        m_wavePointsRight[x] = QPoint(x, right * yScale + y);
+    }
+    
+    // Draw a simple volume based on the samples, in the background
+    average /= rc.width() * 2;
+    painter.fillRect(0, int(double(rc.height()) - average * yScale * 2), rc.width(),int(average * yScale * 2), Qt::blue);
+
+    // Draw the left/right stereo, different colors, overlayed
+
+    painter.setPen(Qt::green);
+    painter.drawPolyline(&m_wavePointsLeft[0], m_wavePointsLeft.size());
+
+    painter.setPen(Qt::red);
+    painter.drawPolyline(&m_wavePointsRight[0], m_wavePointsRight.size());
+}
+
+void Visualizer::drawLoop()
+{
+    repaint();
+}

--- a/app/gui/qt/widgets/visualizer.h
+++ b/app/gui/qt/widgets/visualizer.h
@@ -1,0 +1,25 @@
+#include <QWidget>
+#include <QPoint>
+#include <vector>
+
+#include "scope.h"
+
+QT_FORWARD_DECLARE_CLASS(QPaintEvent)
+
+class Visualizer : public QWidget
+{
+    Q_OBJECT
+public:
+    Visualizer(Scope* pScope, QWidget* pParent = nullptr);
+
+protected:
+    virtual void paintEvent(QPaintEvent* painter) override;
+
+private slots:
+  void drawLoop();
+
+private:
+    Scope* m_pScope = nullptr;
+    std::vector<QPoint> m_wavePointsLeft;
+    std::vector<QPoint> m_wavePointsRight;
+};


### PR DESCRIPTION
Sam asked me about rendering into a Qt window.  This is a quick and
simple way to demo how it works.  It's just a window with an overriden
paint method.  It should be nice and fast.  With some effort and
cleanup, it would be easy to ditch Qwt and do a nice visualizer that did
various interesting things.

Note: to make this work I pull out the captured scope data, so that widget
needs to be enabled.  To properly do this, the data grabbing from
SC should be in its own class, probably on a thread.

The visualization itself is simply a stereo waveform and a blue box
which approximates amplitude; just to show a couple different ways to
draw.

![image](https://user-images.githubusercontent.com/120447/73297099-d4749780-4202-11ea-8ede-6a89352ad779.png)
