### PR TITLE
Improve CMake build compatibility on Linux

### DIFF
--- a/app/gui/qt/CMakeLists.txt
+++ b/app/gui/qt/CMakeLists.txt
@@ -40,7 +40,9 @@ set(CMAKE_PREFIX_PATH $ENV{QT_INSTALL_LOCATION})
 set(QT_TOOLS_DIR $ENV{QT_INSTALL_LOCATION}/bin)
 set_property(GLOBAL PROPERTY AUTOMOC_FOLDER Automoc)
 set_property(GLOBAL PROPERTY AUTOGEN_TARGETS_FOLDER Automoc)
-find_package(Qt5 COMPONENTS Core Widgets Gui Concurrent Network Opengl PrintSupport Xml Svg REQUIRED)
+
+find_package(Qt5 COMPONENTS Core Widgets Gui Concurrent Network OpenGL PrintSupport Xml Svg REQUIRED)
+find_package(Threads REQUIRED)
 
 add_subdirectory(external)
 
@@ -68,7 +70,7 @@ set(EDITOR_SOURCES
     ${APP_ROOT}/widgets/sonicpiscintilla.h
     )
 
-set (QT_SOURCES
+set(QT_SOURCES
     ${APP_ROOT}/widgets/infowidget.cpp
     ${APP_ROOT}/widgets/settingswidget.cpp
     ${APP_ROOT}/mainwindow.cpp
@@ -79,7 +81,7 @@ set (QT_SOURCES
     ${APP_ROOT}/widgets/settingswidget.h
     )
 
-set(SOURCES 
+set(SOURCES
     ${APP_ROOT}/visualizer/scope.cpp
     ${APP_ROOT}/visualizer/scope.h
     ${APP_ROOT}/visualizer/scope_buffer.hpp
@@ -104,7 +106,7 @@ SET(RESOURCES
 set(ALL_SOURCES ${OSC_SOURCES} ${QT_SOURCES} ${SOURCES} ${EDITOR_SOURCES})
 
 # Create the Qt version of the app
-add_executable (${APP_NAME} WIN32 ${ALL_SOURCES} ${RESOURCES}) # Win32 ignored on non-windows
+add_executable(${APP_NAME} WIN32 ${ALL_SOURCES} ${RESOURCES}) # Win32 ignored on non-windows
 set_property(TARGET ${APP_NAME} PROPERTY POSITION_INDEPENDENT_CODE ON) # Qt requires this?
 target_include_directories(${APP_NAME}
     PRIVATE
@@ -129,10 +131,17 @@ target_link_libraries(${APP_NAME}
     Qt5::Widgets
     Qt5::OpenGL
     Qt5::Concurrent
-    Qt5::Network)
+    Qt5::Network
+    Threads::Threads)
 
-# Workaround Qt + MSVC 19 compile issue in release build.
-target_compile_options(${APP_NAME} PRIVATE $<$<CXX_COMPILER_ID:MSVC>:/wd4005 /W3 /D_CRT_SECURE_NO_WARNINGS /D_WINSOCK_DEPRECATED_NO_WARNINGS /DBOOST_DATE_TIME_NO_LIB>)
+# Compile options and OS specific libraries
+if(WIN32)
+    # Workaround Qt + MSVC 19 compile issue in release build.
+    target_compile_options(${APP_NAME} PRIVATE $<$<CXX_COMPILER_ID:MSVC>:/wd4005 /W3 /D_CRT_SECURE_NO_WARNINGS /D_WINSOCK_DEPRECATED_NO_WARNINGS /DBOOST_DATE_TIME_NO_LIB>)
+elseif(UNIX)
+    # Link librt
+    target_link_libraries(${APP_NAME} PRIVATE rt)
+endif()
 
 # Deploy Qt binaries to the output on windows
 if(WIN32)
@@ -151,10 +160,10 @@ if(WIN32)
 endif() # Win32
 
 # Make convenient source groups in the IDE
-source_group (SonicPi FILES ${SOURCES})
-source_group (Osc FILES ${OSC_SOURCES})
-source_group (Scintilla FILES ${EDITOR_SOURCES})
-source_group (Qt FILES ${QT_SOURCES})
+source_group(SonicPi FILES ${SOURCES})
+source_group(Osc FILES ${OSC_SOURCES})
+source_group(Scintilla FILES ${EDITOR_SOURCES})
+source_group(Qt FILES ${QT_SOURCES})
 
 source_group(Qt\\AutoMoc FILES ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_automoc.cpp ) 
 source_group(Qt\\AutoMoc REGULAR_EXPRESSION "(mocs_*|qrc_.*|QtAwesome.*)" ) 

--- a/app/gui/qt/config.bat
+++ b/app/gui/qt/config.bat
@@ -1,6 +1,10 @@
 set CURRENT_DIR=%CD%
+
+echo "Creating build directory..."
 mkdir build > nul
+
+echo "Generating project files..."
 cd build
 cmake -G "Visual Studio 16 2019" -A x64 ..\
-cd "%CURRENT_DIR%"
 
+cd "%CURRENT_DIR%"

--- a/app/gui/qt/config.bat
+++ b/app/gui/qt/config.bat
@@ -1,9 +1,9 @@
 set CURRENT_DIR=%CD%
 
-echo "Creating build directory..."
+@echo "Creating build directory..."
 mkdir build > nul
 
-echo "Generating project files..."
+@echo "Generating project files..."
 cd build
 cmake -G "Visual Studio 16 2019" -A x64 ..\
 

--- a/app/gui/qt/config.sh
+++ b/app/gui/qt/config.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -e # Quit script on error
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+echo "Creating build directory..."
+mkdir -p "${SCRIPT_DIR}/build"
+
+echo "Generating makefiles..."
+cd "${SCRIPT_DIR}/build"
+cmake -G "Unix Makefiles" ..
+
+cd "${SCRIPT_DIR}"

--- a/app/gui/qt/external/QScintilla-2.11.4/CMakeLists.txt
+++ b/app/gui/qt/external/QScintilla-2.11.4/CMakeLists.txt
@@ -282,7 +282,7 @@ target_compile_definitions(QScintilla PRIVATE -D_CRT_SECURE_NO_WARNINGS)
 # Disable warnings
 if(WIN32)
     target_compile_options(QScintilla PRIVATE /wd4099 /wd4005 /wd4554 /wd4101 /wd4700 /wd5038 /wd4267 /wd4996)
-elseif(LINUX)
+elseif(${CMAKE_SYSTEM_NAME} MATCHES Linux)
     target_compile_options(QScintilla
     PRIVATE
         -Wno-reorder

--- a/app/gui/qt/prebuild.bat
+++ b/app/gui/qt/prebuild.bat
@@ -2,9 +2,12 @@ cd %~dp0
 
 rmdir /S /Q ..\..\server\ruby\vendor\ruby-aubio-prerelease
 
+echo "Translating tutorial..."
 ..\..\server\native\ruby\bin\ruby ../../server/ruby/bin/i18n-tool.rb -t
+
+echo "Generating docs for the Qt GUI..."
 copy /Y utils\ruby_help.tmpl utils\ruby_help.h
 ..\..\server\native\ruby\bin\ruby ../../server/ruby/bin/qt-doc.rb -o utils/ruby_help.h
 
-REM Do the language translation
+echo "Updating GUI translation files..."
 forfiles /p lang /s /m *.ts /c "cmd /c %QT_INSTALL_LOCATION%/bin/lrelease @file"

--- a/app/gui/qt/prebuild.bat
+++ b/app/gui/qt/prebuild.bat
@@ -2,12 +2,12 @@ cd %~dp0
 
 rmdir /S /Q ..\..\server\ruby\vendor\ruby-aubio-prerelease
 
-echo "Translating tutorial..."
+@echo "Translating tutorial..."
 ..\..\server\native\ruby\bin\ruby ../../server/ruby/bin/i18n-tool.rb -t
 
-echo "Generating docs for the Qt GUI..."
+@echo "Generating docs for the Qt GUI..."
 copy /Y utils\ruby_help.tmpl utils\ruby_help.h
 ..\..\server\native\ruby\bin\ruby ../../server/ruby/bin/qt-doc.rb -o utils/ruby_help.h
 
-echo "Updating GUI translation files..."
+@echo "Updating GUI translation files..."
 forfiles /p lang /s /m *.ts /c "cmd /c %QT_INSTALL_LOCATION%/bin/lrelease @file"

--- a/app/gui/qt/prebuild.sh
+++ b/app/gui/qt/prebuild.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -e # Quit script on error
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+rm -r "${SCRIPT_DIR}/../../server/ruby/vendor/ruby-aubio-prerelease" | true
+
+echo "Translating tutorial..."
+ruby "${SCRIPT_DIR}/../../server/ruby/bin/i18n-tool.rb" -t
+
+echo "Generating docs for the Qt GUI..."
+cp "${SCRIPT_DIR}/utils/ruby_help.tmpl" "${SCRIPT_DIR}/utils/ruby_help.h"
+ruby "${SCRIPT_DIR}/../../server/ruby/bin/qt-doc.rb" -o "${SCRIPT_DIR}/utils/ruby_help.h"
+
+echo "Updating GUI translation files..."
+lrelease "${SCRIPT_DIR}"/lang/*.ts


### PR DESCRIPTION
This PR contains some changes to improve compatibility of the cmake build on Linux. :) Hopefully this doesn't affect Windows build compatibility.
* Add Threads to the link libraries, and librt to the link libs on UNIX only
* Make config.sh and prebuild.sh
* Update config.bat and prebuild.bat with more info messages
* Fix app/gui/qt/external/QScintilla-2.11.4/CMakeLists.txt so it detects Linux properly