### PR TITLE
_WIN64 and _WIN32 are defined by the compiler

### DIFF
--- a/app/gui/qt/visualizer/server_shm.hpp
+++ b/app/gui/qt/visualizer/server_shm.hpp
@@ -95,14 +95,14 @@ public:
 	}
 
 private:
-#if defined(WIN64)
+#if defined(_WIN64)
 	// Note: this shared memory structure is 32 bytes on the SuperCollider side in 64 bit
 	// at least on a release build which is typically used.
 	// But! A string on windows (or any platform for that matter) does not guarantee that it will consume 32 bytes of memory.
 	// A debug build of windows has this structure bigger than 32 and breaks
 	uint8_t shmem_name[32];
 #else
-#if defined(WIN32)
+#if defined(_WIN32)
 	// ... and on Win32 a debug build has this north of 24, but SC has 24 
 	uint8_t shmem_name[24];
 #else


### PR DESCRIPTION
My 32 bit fix broke 64 bit.  I didn't realize that WIN64 is not defined by default by CMake, but _WIN64 and _WIN32 are defined by the compiler.