### PR TITLE
Set background of Scope panels via app.qss

### DIFF
--- a/app/gui/qt/theme/app.qss
+++ b/app/gui/qt/theme/app.qss
@@ -466,3 +466,9 @@ QScrollBar::add-page:vertical, QScrollBar::sub-page:vertical
 {
     background: none;
 }
+
+QWidget
+{
+    background: paneColor;
+}
+


### PR DESCRIPTION
The background uses now also the "paneColor",
so that it can be set via theme.properties