### PR TITLE
update new location of sonic-pi build

### DIFF
--- a/bin/sonic-pi
+++ b/bin/sonic-pi
@@ -17,4 +17,4 @@ eval $(dbus-launch --auto-syntax)
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-$DIR/../app/gui/qt/sonic-pi
+$DIR/../app/gui/qt/build/sonic-pi


### PR DESCRIPTION
Using new cmake build sonic-pi on linux is now built in a build folder in app/qt. This change allows easy access to run it.