### PR TITLE
Fix for non-windows compilers

### DIFF
--- a/app/gui/qt/visualizer/scope.h
+++ b/app/gui/qt/visualizer/scope.h
@@ -22,6 +22,7 @@
 #include <memory>
 #include <string>
 #include <thread>
+#include <mutex>
 #include <visualizer/server_shm.hpp>
 
 #include "kiss_fft/kiss_fft.h"


### PR DESCRIPTION
Include the <mutex> header in scope.h