### PR TITLE
Fixed empty key when setting keybindings

### DIFF
--- a/app/gui/qt/widgets/sonicpiscintilla.cpp
+++ b/app/gui/qt/widgets/sonicpiscintilla.cpp
@@ -204,7 +204,7 @@ void SonicPiScintilla::addOtherKeyBinding(QSettings &qs, int cmd, int key)
 {
   mutex->lock();
   QString skey;
-  skey.asprintf("/Scintilla/keymap/c%d/alt", cmd);
+  QTextStream(&skey) << "/Scintilla/keymap/c" << cmd << "/alt";
   qs.setValue(skey, key);
   mutex->unlock();
 }
@@ -213,7 +213,7 @@ void SonicPiScintilla::addKeyBinding(QSettings &qs, int cmd, int key)
 {
   mutex->lock();
   QString skey;
-  skey.asprintf("/Scintilla/keymap/c%d/key", cmd);
+  QTextStream(&skey) << "/Scintilla/keymap/c" << cmd << "/key";
   qs.setValue(skey, key);
   mutex->unlock();
 }


### PR DESCRIPTION
Use of no longer recommended and static method caused empty key when adding new key bindings. 