### PR TITLE
Add starting and stopping xcompmgr on Raspberry Pi

### DIFF
--- a/app/server/ruby/bin/sonic-pi-server.rb
+++ b/app/server/ruby/bin/sonic-pi-server.rb
@@ -35,6 +35,12 @@ require 'memoist'
 
 include SonicPi::Util
 
+#start xcompmgr if using Raspberry Pi: enables transparency to work
+if os==:raspberry
+  STDOUT.puts  "starting xcompmgr for RaspberryPi transparency"
+  xcompmgr_pid = spawn "exec xcompmgr",:err => "/dev/null" 
+end
+
 ## This is where the server starts....
 STDOUT.puts "Sonic Pi server booting..."
 
@@ -323,6 +329,11 @@ at_exit do
     gui.send("/exited")
   rescue Errno::EPIPE => e
     STDOUT.puts "GUI not listening."
+  end
+  #stop xcompmgr if on RaspberryPi
+  if os == :raspberry
+    STDOUT.puts "killing xcompmgr pid #{xcompmgr_pid}"
+    Process.kill(9, xcompmgr_pid)
   end
   STDOUT.puts "Goodbye :-)"
 end


### PR DESCRIPTION
On Raspbian Buster you need to start xcompmgr so that Qt commands to vary the opacity of the main window work.
The binary is executed as the server is started, and is closed again at exit. There is an instance running already set up at boot time but it odes not seem to be accessible to Qt. Hence this needs to be done. There are some error messages from xcompmgr but they don't affect the operation required and are sent to /dev/null. The mods have been checked on macOS to make sure they are not invoked.