### PR TITLE
RPi builds don't use extra-ugens folder now.

### DIFF
--- a/app/server/ruby/lib/sonicpi/scsynthexternal.rb
+++ b/app/server/ruby/lib/sonicpi/scsynthexternal.rb
@@ -413,7 +413,7 @@ module SonicPi
                     "-o", "2",
                     "-z", block_size.to_s,
                     "-c", "128",
-                    "-U", "/usr/lib/SuperCollider/plugins:#{native_path}/extra-ugens/",
+                    "-U", "/usr/lib/SuperCollider/plugins",
                     "-b", num_buffers_for_current_os.to_s,
                     "-B", "127.0.0.1")
 


### PR DESCRIPTION
Builds for Buster will use packages supercollider-server and sc3-plugins and retrieve plugin data without extra-ugens folder which gives an error in logs if not setup, which is confusing. No native supercollider folder needed at all.