### PR TITLE
udate jackd boot for RPi and Linux

### DIFF
--- a/app/server/ruby/lib/sonicpi/scsynthexternal.rb
+++ b/app/server/ruby/lib/sonicpi/scsynthexternal.rb
@@ -384,7 +384,7 @@ module SonicPi
       puts "Booting on Raspberry Pi"
       begin
         asoundrc = File.read(Dir.home + "/.asoundrc")
-        audio_card = (asoundrc.match(/pcm.!default\s+{[^}]+\n\s+card\s+([0-9]+)/m))[1]
+        audio_card = (asoundrc.match(/pcm.output\s+{[^}]+\n\s+card\s+([0-9]+)/m))[1]
       rescue
         audio_card = "0"
       end
@@ -393,7 +393,8 @@ module SonicPi
       if `ps cax | grep jackd`.split(" ").first.nil?
         #Jack not running - start a new instance
         puts "Jackd not running on system. Starting..."
-        jack_pid = spawn "jackd -R -p 32 -d alsa -d hw:#{audio_card} -n 3 -p 2048 -o2 -r 44100& "
+       jackCmd="jackd -R -p 32 -d alsa -d hw:#{audio_card} -n 3 -p 2048 -o2 -r 44100 "
+        jack_pid = spawn "exec #{jackCmd}"
         register_process jack_pid
       else
         puts "Jackd already running. Not starting another server..."
@@ -419,8 +420,8 @@ module SonicPi
 
       `jack_connect SuperCollider:out_1 system:playback_1`
       `jack_connect SuperCollider:out_2 system:playback_2`
-      # `jack_connect SuperCollider:in_1 system_capture_1`
-      # `jack_connect SuperCollider:in_2 system_capture_2`
+      `jack_connect SuperCollider:in_1 system_capture_1`
+      `jack_connect SuperCollider:in_2 system_capture_2`
 
       sleep 3
     end
@@ -432,7 +433,8 @@ module SonicPi
       if `ps cax | grep jackd`.split(" ").first.nil?
         #Jack not running - start a new instance
         puts "Jackd not running on system. Starting..."
-        jack_pid = ("jackd -R -T -p 32 -d alsa -n 3 -p 2048 -r 44100& ")
+        jackCmd = "jackd -R -T -p 32 -d alsa -n 3 -p 2048 -r 44100"
+        jack_pid = spawn  "exec #{jackCmd}"
         register_process jack_pid
       else
         puts "Jackd already running. Not starting another server..."


### PR DESCRIPTION
Latest Buster on RPi uses differe .asoundrc Updated check for soundcard to use pcm.output instead of pcm.!default.
Also for both RPi and Linux the wrong pid value was stored, and need to use spawn exec... to get the right one.Similar to commit #1976 which corrected this for m2o and o2m boot in studio.rb
Also connected input ports for RPi, so they work if there is an input device. Error in log if not, but still runs.

I've tested the RPi changes, but don't have suitable setup to test Linux changes, if someone else can check that.