### PR TITLE
Cache resolving note objects to improve memory performance

### DIFF
--- a/app/server/ruby/lib/sonicpi/lang/western_theory.rb
+++ b/app/server/ruby/lib/sonicpi/lang/western_theory.rb
@@ -632,11 +632,13 @@ end"
 
 
 
-      def note_info(n, *args)
+      def note_info(n, args=nil)
         raise Exception.new("note_info argument must be a valid note. Got nil.") if(n.nil?)
+
+        return SonicPi::Note.resolve_note(n) if(args.nil?)
+
         args_h = resolve_synth_opts_hash_or_array(args)
-        octave = args_h[:octave]
-        SonicPi::Note.new(n, octave)
+        SonicPi::Note.resolve_note(n, args_h[:octave])
       end
       doc name:          :note_info,
       introduced:    Version.new(2,0,0),


### PR DESCRIPTION
* Add a `Note.resolve_note` method that returns note from cache, or creates note. 
* Cache note object keyed by `midi_string`.
* Cache `midi_string` keyed by `n`, `octave` params.
* With current implementation `resolve_note(60)` returns same note object instance as a call to `resolve_note(:C)` or `resolve_note(:C4)`.
* Use `resolve_note` inside `note_info` and `resolve_midi_note_without_octave` to reduce memory allocated on repeated calls with same params.

* Change `note_info` params from `(n, *args)` to `(n, args=nil)`, to avoid Hash `args` being unnecessarily splat into an Array. Prevents creating a new Array on splat and then creating a new Hash in the call to `resolve_synth_opts_hash_or_array(args)`. This reduces memory allocation.

* Profiled memory calling `note_info` for 7 scale note param combinations 2,400 times (e.g. 4 notes per beat * 120 bpm * 5 minutes). 
* The above changes reduced memory allocated from `3.54 MB (54,495 objects)` down to `251.03 kB (5,785 objects)`. Profiled cache size is relatively small at `12.11 kB`.