### PR TITLE
GUI - update scope kinds tooltip in preferences

### DIFF
--- a/app/gui/qt/widgets/settingswidget.cpp
+++ b/app/gui/qt/widgets/settingswidget.cpp
@@ -378,7 +378,7 @@ QGroupBox* SettingsWidget::createVisualizationPrefsTab() {
     show_scope_labels->setToolTip(tr("Toggle the visibility of the labels for the audio oscilloscopes"));
     show_scope_labels->setChecked(true);
     scope_box_kinds->setLayout(scope_box_kinds_layout);
-    scope_box_kinds->setToolTip(tr("The audio oscilloscope comes in three flavours which may\nbe viewed independently or all together:\n\nLissajous - illustrates the phase relationship between the left and right channels\nMono - shows a combined view of the left and right channels (using RMS)\nStereo - shows two independent scopes for left and right channels"));
+    scope_box_kinds->setToolTip(tr("The audio oscilloscope comes in several flavours which may\nbe viewed independently or all together:\n\nLissajous - illustrates the phase relationship between the left and right channels\nMirror Stereo - simple left/right composite wave, with left on top, right on bottom\nMono - shows a combined view of the left and right channels (using RMS)\nSpectrum - shows the sound frequencies as a spectrum, from low to high frequencies\nStereo - shows two independent scopes for left and right channels"));
     scope_box_layout->addWidget(show_scopes);
     scope_box_layout->addWidget(show_scope_labels);
     scope_box->setLayout(scope_box_layout);


### PR DESCRIPTION
Comments on the updated descriptions would be appreciated if necessary... (feel free to make changes yourself anyway Sam)

This adds the new scopes to the descriptions shown in the scope kinds section of
the visuals preferences tab.

![image](https://user-images.githubusercontent.com/10395940/75094731-fb877480-55c8-11ea-98e3-4d6d37c76cfe.png)

Once approved, this will fix #2259.