### PR TITLE
Cache resolving scale objects to improve memory performance

### DIFF
--- a/app/server/ruby/lib/sonicpi/chord.rb
+++ b/app/server/ruby/lib/sonicpi/chord.rb
@@ -121,7 +121,7 @@ module SonicPi
     def self.resolve_degree(degree, tonic, name, no_of_notes)
       name = name.to_s
       degree_int = Scale.resolve_degree_index(degree)
-      scale = Scale.new(tonic, name, 2)
+      scale = Scale.resolve_scale(tonic, name, 2)
       scale.notes.drop(degree_int).select.with_index{|_, i| i % 2 == 0}.take(no_of_notes)
     end
 

--- a/app/server/ruby/lib/sonicpi/lang/western_theory.rb
+++ b/app/server/ruby/lib/sonicpi/lang/western_theory.rb
@@ -687,21 +687,18 @@ play chrd  # the same chord as above, but using decimal number strings
 
 
 
-      def scale(tonic_or_name, *opts)
-        tonic = 0
-        name = :minor
-        if opts.size == 0
+      def scale(tonic_or_name, name_or_opts=nil, opts=nil)
+        if name_or_opts.nil? || name_or_opts.is_a?(Hash)
+          tonic = 0
           name = tonic_or_name
-        elsif (opts.size == 1) && opts[0].is_a?(Hash)
-          name = tonic_or_name
+          num_octaves = (name_or_opts.is_a?(Hash) && name_or_opts[:num_octaves]) || 1
         else
           tonic = tonic_or_name
-          name = opts.shift
+          name = name_or_opts
+          num_octaves = (opts.is_a?(Hash) && opts[:num_octaves]) || 1
         end
 
-        opts = resolve_synth_opts_hash_or_array(opts)
-        opts = {:num_octaves => 1}.merge(opts)
-        Scale.new(tonic, name,  opts[:num_octaves]).ring
+        Scale.resolve_scale(tonic, name, num_octaves).ring
       end
       doc name:          :scale,
       introduced:    Version.new(2,0,0),

--- a/app/server/ruby/lib/sonicpi/scale.rb
+++ b/app/server/ruby/lib/sonicpi/scale.rb
@@ -142,7 +142,7 @@ module SonicPi
     end
 
     def self.resolve_degree(degree, tonic, scale)
-      scale = Scale.new(tonic, scale)
+      scale = Scale.resolve_scale(tonic, scale, 1)
       augmentation = 0
       if not degree.is_a? Numeric
         degree = degree.to_s.downcase
@@ -165,6 +165,18 @@ module SonicPi
       end
       octave, index = resolve_degree_index(degree).divmod (scale.notes.length - 1)
       scale.notes[index] + octave * 12 + augmentation
+    end
+
+    @@scale_cache = Hash.new {|h, k| h[k] = Hash.new {|h2, k2| h2[k2] = {} } }
+
+    def self.resolve_scale(tonic, name, num_octaves)
+      tonic = tonic.is_a?(String) ? tonic.to_sym : tonic
+      name = name.is_a?(String) ? name.to_sym : name
+      cached = @@scale_cache[tonic][name][num_octaves]
+      return cached unless cached.nil?
+      scale = Scale.new(tonic, name, num_octaves)
+      @@scale_cache[tonic][name][num_octaves] = scale
+      scale
     end
 
     attr_reader :name, :tonic, :num_octaves, :notes


### PR DESCRIPTION
* Add `Scale.resolve_scale()` method to cache and return scale. 
* Use `Scale.resolve_scale()` in place of `Scale.new()`.

* Replace splat `*opts` in `scale()` method with explict list of params. Reduces memory allocation by not creating a new splat Array and new Hash in `scale()`.

* Memory profiling 2,400 calls to `scale()` with varying params showed above changes reduced memory allocation from:
```
Total allocated: 3.63 MB (37590 objects)
Total retained:  9.25 kB (61 objects)
```
* to:
```
Total allocated: 942.40 kB (20176 objects)
Total retained:  54.47 kB (493 objects) <- increase in retained memory due to cache
```