### PR TITLE
Fix windows build due to fastosc change

### DIFF
--- a/app/gui/qt/win-prebuild.bat
+++ b/app/gui/qt/win-prebuild.bat
@@ -4,6 +4,7 @@ call external/build_externals.bat
 cd %~dp0
 copy external\build\aubio-prefix\src\Aubio-build\Release\libaubio-5.dll ..\..\server\native\ruby\bin
 rmdir /S /Q ..\..\server\ruby\vendor\ruby-aubio-prerelease
+rmdir /S /Q ..\..\server\ruby\vendor\fast_osc-1.2.1
 
 @echo "Copying osmid to the server"
 xcopy /Y /I /R /E external\build\osmid-prefix\src\osmid-build\Release\*.exe ..\..\server\native\osmid


### PR DESCRIPTION
This removes the fast osc from the vendor directory during prebuild, just as we do for the aubio gem.