### PR TITLE
Fix macOS build

### DIFF
--- a/app/gui/qt/CMakeLists.txt
+++ b/app/gui/qt/CMakeLists.txt
@@ -144,7 +144,7 @@ if(WIN32)
     target_compile_options(${APP_NAME} PRIVATE $<$<CXX_COMPILER_ID:MSVC>:/wd4005 /W3 /D_CRT_SECURE_NO_WARNINGS /D_WINSOCK_DEPRECATED_NO_WARNINGS /DBOOST_DATE_TIME_NO_LIB>)
     target_compile_options(${APP_NAME} PRIVATE "$<$<CONFIG:DEBUG>:-DTRACY_ENABLE=1>")
     target_compile_options(${APP_NAME} PRIVATE "$<$<CONFIG:RELWITHDEBINFO>:-DTRACY_ENABLE=1>")
-elseif(UNIX)
+elseif(UNIX AND NOT (${CMAKE_SYSTEM_NAME} MATCHES Darwin))
     # Link librt
     target_link_libraries(${APP_NAME} PRIVATE rt)
 endif()


### PR DESCRIPTION
I was trying to build Sonic Pi on my Mac using the cmake build, and ran into a problem linking against librt. A bit of Googling seemed to indicate that it is not necessary on macOS, and removing it from the build allowed it to complete.
