### PR TITLE
Make help shortcut focus content instead of tab bar

### DIFF
--- a/app/gui/qt/mainwindow.cpp
+++ b/app/gui/qt/mainwindow.cpp
@@ -778,10 +778,10 @@ void MainWindow::setupWindowStructure() {
     docsCentral->setMovable(false);
     docsCentral->setTabPosition(QTabWidget::South);
     QShortcut *left = new QShortcut(Qt::Key_Left, docsCentral);
-    left->setContext(Qt::WidgetShortcut);
+    left->setContext(Qt::WidgetWithChildrenShortcut);
     connect(left, SIGNAL(activated()), this, SLOT(docPrevTab()));
     QShortcut *right = new QShortcut(Qt::Key_Right, docsCentral);
-    right->setContext(Qt::WidgetShortcut);
+    right->setContext(Qt::WidgetWithChildrenShortcut);
     connect(right, SIGNAL(activated()), this, SLOT(docNextTab()));
 
     docPane = new QTextBrowser;

--- a/app/gui/qt/mainwindow.cpp
+++ b/app/gui/qt/mainwindow.cpp
@@ -3009,7 +3009,6 @@ void MainWindow::focusHelpListing() {
   docWidget->show();
   updatePrefsIcon();
   docsCentral->showNormal();
-  docsCentral->currentWidget()->setFocusPolicy(Qt::StrongFocus);
   docsCentral->currentWidget()->setFocus();
   docsCentral->raise();
   docsCentral->setVisible(true);

--- a/app/gui/qt/mainwindow.cpp
+++ b/app/gui/qt/mainwindow.cpp
@@ -777,6 +777,12 @@ void MainWindow::setupWindowStructure() {
     docsCentral->setTabsClosable(false);
     docsCentral->setMovable(false);
     docsCentral->setTabPosition(QTabWidget::South);
+    QShortcut *left = new QShortcut(Qt::Key_Left, docsCentral);
+    left->setContext(Qt::WidgetShortcut);
+    connect(left, SIGNAL(activated()), this, SLOT(docPrevTab()));
+    QShortcut *right = new QShortcut(Qt::Key_Right, docsCentral);
+    right->setContext(Qt::WidgetShortcut);
+    connect(right, SIGNAL(activated()), this, SLOT(docNextTab()));
 
     docPane = new QTextBrowser;
     QSizePolicy policy = docPane->sizePolicy();
@@ -2705,6 +2711,18 @@ void MainWindow::helpScrollDown() {
     helpLists[section]->setCurrentRow(entry);
 }
 
+void MainWindow::docPrevTab() {
+    int section = docsCentral->currentIndex();
+    if (section > 0)
+        docsCentral->setCurrentIndex(section - 1);
+}
+
+void MainWindow::docNextTab() {
+    int section = docsCentral->currentIndex();
+    if (section < docsCentral->count() - 1)
+        docsCentral->setCurrentIndex(section + 1);
+}
+
 void MainWindow::docScrollUp() {
     docPane->verticalScrollBar()->triggerAction(QAbstractSlider::SliderSingleStepSub);
 }
@@ -2991,8 +3009,8 @@ void MainWindow::focusHelpListing() {
   docWidget->show();
   updatePrefsIcon();
   docsCentral->showNormal();
-  docsCentral->setFocusPolicy(Qt::StrongFocus);
-  docsCentral->setFocus();
+  docsCentral->currentWidget()->setFocusPolicy(Qt::StrongFocus);
+  docsCentral->currentWidget()->setFocus();
   docsCentral->raise();
   docsCentral->setVisible(true);
   docsCentral->activateWindow();

--- a/app/gui/qt/mainwindow.h
+++ b/app/gui/qt/mainwindow.h
@@ -168,6 +168,8 @@ signals:
         void resetErrorPane();
         void helpScrollUp();
         void helpScrollDown();
+        void docPrevTab();
+        void docNextTab();
         void docScrollUp();
         void docScrollDown();
         void updateFullScreenMode();


### PR DESCRIPTION
Also add keyboard shortcuts so that the left and right arrows continue to move between tabs.
This should hopefully implement what was suggested [here](https://github.com/samaaron/sonic-pi/commit/6152d17722371cb0f7dfbcd58e1b9359eafb6611#commitcomment-37880262).

~~Note: I haven't got the build working yet, so this is still untested: DON'T MERGE IT YET!~~