### PR TITLE
Changes to reduce memory allocation

### DIFF
--- a/app/server/ruby/lib/sonicpi/chord.rb
+++ b/app/server/ruby/lib/sonicpi/chord.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 #--
 # This file is part of Sonic Pi: http://sonic-pi.net
 # Full project source: https://github.com/samaaron/sonic-pi
@@ -101,9 +102,7 @@ module SonicPi
 
       all_chords_lookup = all_chords.inject({}) do |res, chord_intervals|
         k, v = *chord_intervals
-
-        res[k] = v
-        res[k.to_s] = v
+        res[k.to_sym] = v
         res
       end
 
@@ -116,7 +115,7 @@ module SonicPi
       return all_chords, all_chords_lookup, all_chords_names.sort
     end.call
 
-    attr_reader :name, :tonic, :notes, :num_octaves
+    attr_reader :tonic, :notes, :num_octaves
 
     def self.resolve_degree(degree, tonic, name, no_of_notes)
       name = name.to_s
@@ -127,7 +126,7 @@ module SonicPi
 
     def initialize(tonic, name, num_octaves=1)
       num_octaves = 1 unless num_octaves
-      name = name.to_s
+      name = name.to_sym
       intervals = CHORD_LOOKUP[name]
       raise "Unknown chord name: #{name.inspect}" unless intervals
 
@@ -145,6 +144,10 @@ module SonicPi
       @notes = res
       @num_octaves = num_octaves
       super(res)
+    end
+
+    def name
+      @name.to_s
     end
 
     def to_s

--- a/app/server/ruby/lib/sonicpi/cueevent.rb
+++ b/app/server/ruby/lib/sonicpi/cueevent.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 #--
 # This file is part of Sonic Pi: http://sonic-pi.net
 # Full project source: https://github.com/samaaron/sonic-pi
@@ -19,6 +20,10 @@ module SonicPi
     include Comparable
 
     attr_reader :time, :time_r, :priority, :thread_id, :delta, :beat, :bpm, :path, :val, :meta, :split_path, :path_size
+
+    @@path_cache = Hash.new
+    @@split_path_cache = Hash.new
+
     def initialize(time, priority, thread_id, delta, beat, bpm, path, val, meta={})
       @time = time
       @time_r = time.to_r
@@ -29,17 +34,19 @@ module SonicPi
       @bpm = bpm.to_f
 
       if path.is_a?(Symbol)
-        @path = "/cue/#{path}".strip.freeze
+        @path = @@path_cache[path] || @@path_cache[path] = "/cue/#{path}".strip.freeze
       else
-        path = path.to_s
-        path = "/#{path}" unless path.start_with?("/")
-        @path = path.strip.freeze
+        @path = @@path_cache.fetch(path) do |k|
+          path = path.to_s
+          path = "/#{path}" unless path.start_with?("/")
+          @@path_cache[k] = path.strip.freeze
+        end
       end
 
       raise EmptyPathError, "CueEvent must have a valid path. Got: #{@path}" if @path == "/"
       @val = val.__sp_make_thread_safe
       @meta = meta.__sp_make_thread_safe
-      @split_path = @path[1..-1].split("/")
+      @split_path = @@split_path_cache[path] || @@split_path_cache[path] = @path[1..-1].split("/")
       @path_size = @split_path.size
     end
 

--- a/app/server/ruby/lib/sonicpi/group.rb
+++ b/app/server/ruby/lib/sonicpi/group.rb
@@ -35,7 +35,7 @@ module SonicPi
           # could be sent - however, this won't cause any issues as the
           # node won't run on_destroyed handlers multiple times and the
           # default /n_end handlers remove themselves.
-          @comms.async_event "/n_end/#{pn.id}", {}
+          @comms.async_event ['/n_end/', pn.id], {}
         end
       end
     end

--- a/app/server/ruby/lib/sonicpi/incomingevents.rb
+++ b/app/server/ruby/lib/sonicpi/incomingevents.rb
@@ -52,8 +52,8 @@ module SonicPi
       prom.get(5)
     end
 
-    def async_add_handlers(*args)
-      @event_queue << [:async_add_multiple, args]
+    def async_add_handlers(args_list)
+      @event_queue << [:async_add_multiple, args_list]
     end
 
     def async_add_handler(handle, key, &block)
@@ -176,8 +176,8 @@ module SonicPi
       action, content = @event_queue.pop
       case action
       when :async_add_multiple
-        content.each do |c|
-          q_insert_handler(*c)
+        content.each do |handle, key, block|
+          q_insert_handler(handle, key, block)
         end
       when :async_event
         q_handle_event(*content)

--- a/app/server/ruby/lib/sonicpi/node.rb
+++ b/app/server/ruby/lib/sonicpi/node.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 #--
 # This file is part of Sonic Pi: http://sonic-pi.net
 # Full project source: https://github.com/samaaron/sonic-pi
@@ -31,21 +32,30 @@ module SonicPi
       @state = :pending
       @info = info
       r = rand.to_s
-      @killed_event_key  = "/sonicpi/node/killed#{id}-#{r}"
-      @paused_event_key  = "/sonicpi/node/paused#{id}-#{r}"
-      @started_event_key = "/sonicpi/node/started#{id}-#{r}"
-      @created_event_key = "/sonicpi/node/created#{id}-#{r}"
-      @moved_event_key = "/sonicpi/node/moved#{id}-#{r}"
-      add_event_handlers
+      id_s = id.to_s
+      @killed_event_key  = "/sonicpi/node/killed#{id_s}-#{r}"
+      @paused_event_key  = "/sonicpi/node/paused#{id_s}-#{r}"
+      @started_event_key = "/sonicpi/node/started#{id_s}-#{r}"
+      @created_event_key = "/sonicpi/node/created#{id_s}-#{r}"
+      @moved_event_key = "/sonicpi/node/moved#{id_s}-#{r}"
 
+      @n_end = ['/n_end/', id]
+      @n_on = ['/n_on/', id]
+      @n_go = ['/n_go/', id]
+      @n_move = ['/n_move/', id]
+      @n_off = ['/n_off/', id]
+
+      add_event_handlers
     end
 
     def add_event_handlers
-      @comms.async_add_event_handlers(["/n_end/#{id}", @killed_event_key,  method(:handle_n_end)],
-                                      ["/n_on/#{id}",  @started_event_key, method(:handle_n_on)],
-                                      ["/n_go/#{id}",  @created_event_key, method(:handle_n_go)],
-                                      ["/n_move/#{id}",@moved_event_key,   method(:handle_n_move)],
-                                      ["/n_off/#{id}", @paused_event_key,  method(:handle_n_off)])
+      @comms.async_add_event_handlers([
+                                      [@n_end, @killed_event_key,  method(:handle_n_end)],
+                                      [@n_on,  @started_event_key, method(:handle_n_on)],
+                                      [@n_go,  @created_event_key, method(:handle_n_go)],
+                                      [@n_move,@moved_event_key,   method(:handle_n_move)],
+                                      [@n_off, @paused_event_key,  method(:handle_n_off)]
+                                      ])
     end
 
     def stats
@@ -112,7 +122,7 @@ module SonicPi
     def move(new_group, pos=nil, now=false, &blk)
       if blk
         key = "/sonicpi/node/moved/#{self.id}/#{rand.to_s}"
-        @comms.add_event_handler("/n_move/#{id}", key) do |payload|
+        @comms.add_event_handler(@n_move, key) do |payload|
           _, target_node = *payload
           if target_node.to_i == new_group.to_i
             blk.call
@@ -300,11 +310,11 @@ module SonicPi
         @group = nil
       end
       [:remove_handlers,
-        [ ["/n_go/#{@id}",  @created_event_key],
-          ["/n_off/#{@id}", @paused_event_key],
-          ["/n_on/#{@id}",  @started_event_key],
-          ["/n_move/#{@id}",@moved_event_key],
-          ["/n_end/#{@id}", @killed_event_key]]]
+        [ [@n_go,  @created_event_key],
+          [@n_off, @paused_event_key],
+          [@n_on,  @started_event_key],
+          [@n_move,@moved_event_key],
+          [@n_end, @killed_event_key]]]
 
     end
   end

--- a/app/server/ruby/lib/sonicpi/note.rb
+++ b/app/server/ruby/lib/sonicpi/note.rb
@@ -64,10 +64,10 @@ module SonicPi
 
     MIDI_NOTE_RE = /\A:?(([a-gA-G])([sSbBfF]?))([-]?[0-9]*)\Z/
 
-    @@notes_cache = {}
+    @@notes_cache = Hash.new
 
-    @@midi_string_cache = Hash.new {|h, k| h[k] = {} }
-    @@midi_to_note_cache = {}
+    @@midi_string_cache = Hash.new {|h, k| h[k] = Hash.new }
+    @@midi_to_note_cache = Hash.new
 
     def self.resolve_note(n, o=nil)
       raise Exception.new("resolve_note argument must be a valid note. Got nil.") if(n.nil?)

--- a/app/server/ruby/lib/sonicpi/osc/udp_client.rb
+++ b/app/server/ruby/lib/sonicpi/osc/udp_client.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 #--
 # This file is part of Sonic Pi: http://sonic-pi.net
 # Full project source: https://github.com/samaaron/sonic-pi

--- a/app/server/ruby/lib/sonicpi/osc/udp_server.rb
+++ b/app/server/ruby/lib/sonicpi/osc/udp_server.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 #--
 # This file is part of Sonic Pi: http://sonic-pi.net
 # Full project source: https://github.com/samaaron/sonic-pi

--- a/app/server/ruby/lib/sonicpi/scsynthexternal.rb
+++ b/app/server/ruby/lib/sonicpi/scsynthexternal.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 #--
 # This file is part of Sonic Pi: http://sonic-pi.net
 # Full project source: https://github.com/samaaron/sonic-pi
@@ -118,21 +119,21 @@ module SonicPi
 
       @osc_server.add_global_method do |address, args, info|
         case address
-        when "/n_end"
+        when '/n_end'
           id = args[0].to_i
-          @events.async_event "/n_end/#{id}", args
-        when "/n_off"
+          @events.async_event ['/n_end/', id], args
+        when '/n_off'
           id = args[0].to_i
-          @events.async_event "/n_off/#{id}", args
-        when "/n_on"
+          @events.async_event ['/n_off/', id], args
+        when '/n_on'
           id = args[0].to_i
-          @events.async_event "/n_on/#{id}", args
-        when "/n_go"
+          @events.async_event ['/n_on/', id], args
+        when '/n_go'
           id = args[0].to_i
-          @events.async_event "/n_go/#{id}", args
-        when "/n_move"
+          @events.async_event ['/n_go/', id], args
+        when '/n_move'
           id = args[0].to_i
-          @events.async_event "/n_move/#{id}", args
+          @events.async_event ['/n_move/', id], args
         else
           @events.async_event address, args
         end

--- a/app/server/ruby/lib/sonicpi/server.rb
+++ b/app/server/ruby/lib/sonicpi/server.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 #--
 # This file is part of Sonic Pi: http://sonic-pi.net
 # Full project source: https://github.com/samaaron/sonic-pi
@@ -322,6 +323,7 @@ module SonicPi
       end
     end
 
+    @@normalised_args_cache = Hash.new
 
     def trigger_synth(position, group, synth_name, args_h, info=nil, now=false, t_minus_delta=false)
       pos_code = @position_codes[position]
@@ -346,7 +348,8 @@ module SonicPi
 
       normalised_args = []
       args_h.each do |k,v|
-        normalised_args << k.to_s << v.to_f
+        k = @@normalised_args_cache[k] || @@normalised_args_cache[k] = k.to_s
+        normalised_args << k << v.to_f
       end
 
       if now
@@ -644,8 +647,8 @@ module SonicPi
       @scsynth.send_at(ts, *args)
     end
 
-    def async_add_event_handlers(*args)
-      @osc_events.async_add_handlers(*args)
+    def async_add_event_handlers(args_list)
+      @osc_events.async_add_handlers(args_list)
     end
 
     def add_event_handler(handle, key, &block)

--- a/app/server/ruby/lib/sonicpi/util.rb
+++ b/app/server/ruby/lib/sonicpi/util.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 #--
 # This file is part of Sonic Pi: http://sonic-pi.net
 # Full project source: https://github.com/samaaron/sonic-pi


### PR DESCRIPTION
Used memory profiling, while both sending MIDI note on/off messages to a MIDI device and playing synth notes, to identify memory allocation hotpots.

Include `# frozen_string_literal: true` at the top of files where we want strings to be immutable/frozen by default.

Use caching to reduce memory allocation.

Use array keys in `async_event` handler map instead of string concatenation keys, to reduce memory allocation.

For a buffer being profiled, changes reduced memory allocated from:
```
Total allocated: 16.67 MB (105,906 objects)
Total retained:  92.13 kB (942 objects)
```
to:
```
Total allocated: 15.56 MB (77,723 objects)
Total retained:  77.64 kB (616 objects)
```