### PR TITLE
Use os:system_time() instead of erlang:system_time()

### DIFF
--- a/app/server/erlang/osc.erl
+++ b/app/server/erlang/osc.erl
@@ -84,7 +84,7 @@ test3() ->
 
 now() ->
     %% nanoseconds past epoc
-    erlang:system_time(nanosecond)/1000000000.
+    os:system_time(nanosecond)/1000000000.
 
 osc_time_to_local(Tsec) ->
     Native = trunc(Tsec*1000000000), %% 9 zeros


### PR DESCRIPTION
This ensures that the timestamps are better synced with Ruby and others,
avoiding cases where a message appears received slightly before it was sent.
The erlang:system_time() function guarantees monotonic time and also tries to
avoid sudden jumps in time if the OS clock jumps. Sonic Pi however just wants
the current OS clock as precisely as possible.