### PR TITLE
Update 05.6-Variables.md

### DIFF
--- a/etc/doc/tutorial/05.6-Variables.md
+++ b/etc/doc/tutorial/05.6-Variables.md
@@ -139,15 +139,15 @@ only be used locally within a thread. For example, *don't do this*:
 ```
 a = (ring 6, 5, 4, 3, 2, 1)
 
-live_loop :shuffled do
-  a = a.shuffle
-  sleep 0.5
-end
-
 live_loop :sorted do
   a = a.sort
   sleep 0.5
   puts "sorted: ", a
+end
+
+live_loop :shuffled do
+  a = a.shuffle
+  sleep 0.5
 end
 ```
 


### PR DESCRIPTION
Example live loops are referenced in the wrong order; "the first live loop" and "the second live loop".  This proposal swaps their position within the code example.