### PR TITLE
Fix for crash when hitting WIN+/

### DIFF
--- a/app/gui/qt/external/QScintilla-2.11.4/Qt4Qt5/InputMethod.cpp
+++ b/app/gui/qt/external/QScintilla-2.11.4/Qt4Qt5/InputMethod.cpp
@@ -237,7 +237,7 @@ QVariant QsciScintillaBase::inputMethodQuery(Qt::InputMethodQuery query) const
         {
             char fontName[64];
             int style = SendScintilla(SCI_GETSTYLEAT, pos);
-            int len = SendScintilla(SCI_STYLEGETFONT, style, (sptr_t)fontName);
+            int len = SendScintilla(SCI_STYLEGETFONT, style, (void*)fontName);
             int size = SendScintilla(SCI_STYLEGETSIZE, style);
             bool italic = SendScintilla(SCI_STYLEGETITALIC, style);
             int weight = SendScintilla(SCI_STYLEGETBOLD, style) ? QFont::Bold : -1;
@@ -264,7 +264,7 @@ QVariant QsciScintillaBase::inputMethodQuery(Qt::InputMethodQuery query) const
             textRange.chrg = charRange;
             textRange.lpstrText = buffer.data();
 
-            SendScintilla(SCI_GETTEXTRANGE, 0, (sptr_t)&textRange);
+            SendScintilla(SCI_GETTEXTRANGE, 0, (void*)&textRange);
 
             return bytesAsText(buffer.constData());
         }
@@ -272,7 +272,7 @@ QVariant QsciScintillaBase::inputMethodQuery(Qt::InputMethodQuery query) const
         case Qt::ImCurrentSelection:
         {
             QVarLengthArray<char,1024> buffer(SendScintilla(SCI_GETSELTEXT));
-            SendScintilla(SCI_GETSELTEXT, 0, (sptr_t)buffer.data());
+            SendScintilla(SCI_GETSELTEXT, 0, (void*)buffer.data());
 
             return bytesAsText(buffer.constData());
         }


### PR DESCRIPTION
This triggers some kind of special mode in the Qt Scintilla layer.
Short story is that it was converting a 64 bit pointer to a 32 bit long,
meaning that the memory at the far end of the message was invalid.

The rest of the code calls this GETTEXT message without the cast to
sptr_t (which is the problem), so I've done the same by casting to (void*)