### PR TITLE
OTP-appify the Erlang code

### DIFF
--- a/app/gui/qt/unix-prebuild.sh
+++ b/app/gui/qt/unix-prebuild.sh
@@ -29,7 +29,7 @@ ruby "${SCRIPT_DIR}/../../server/ruby/bin/compile-extensions.rb"
 
 echo "Compiling erlang files..."
 cd "${SCRIPT_DIR}/../../server/erlang"
-erlc osc.erl pi_server.erl
+erlc osc.erl pi_server.erl pi_server_api.erl pi_server_cue.erl pi_server_tracker.erl pi_server_util.erl pi_server_sup.erl l pi_server_app.erl
 cd "${SCRIPT_DIR}"
 
 echo "Translating tutorial..."

--- a/app/gui/qt/unix-prebuild.sh
+++ b/app/gui/qt/unix-prebuild.sh
@@ -29,7 +29,7 @@ ruby "${SCRIPT_DIR}/../../server/ruby/bin/compile-extensions.rb"
 
 echo "Compiling erlang files..."
 cd "${SCRIPT_DIR}/../../server/erlang"
-erlc osc.erl pi_server.erl pi_server_api.erl pi_server_cue.erl pi_server_tracker.erl pi_server_util.erl pi_server_sup.erl l pi_server_app.erl
+erlc *.erl
 cd "${SCRIPT_DIR}"
 
 echo "Translating tutorial..."

--- a/app/server/erlang/pi_server.app
+++ b/app/server/erlang/pi_server.app
@@ -1,0 +1,21 @@
+%% This is an -*- erlang -*- file.
+{application, pi_server,
+ [{description, "Sonic Pi Server"},
+  {vsn, ""},
+  {modules, [pi_server,
+             pi_server_app,
+             pi_server_sup,
+             osc
+            ]},
+  {registered,[]},
+  {mod,{pi_server_app,[]}},
+  {env, [{enabled, true},
+         {in_port, 4560},    % sane defaults for the ports
+         {api_port, 51240},
+         {cue_host, {127,0,0,1}},
+         {cue_port, 51235},
+         {internal, true}
+        ]},
+  {applications, [kernel,stdlib,sasl]}
+ ]
+}.

--- a/app/server/erlang/pi_server.erl
+++ b/app/server/erlang/pi_server.erl
@@ -12,42 +12,15 @@
 %% notice is included.
 %% ++
 
--export([start/1]).
+-export([start/0]).
 
-%% Just run pi_server:start() in a separate shell
+-define(APPLICATION, pi_server).
 
 
-cue_server_host() ->
-    {127, 0, 0, 1}.
-
-start([ARGVAPIPort, ARGVInPort, ARGVCuePort|_T]) ->
-    A = atom_to_list(ARGVAPIPort),
-    {Port, _Rest} = string:to_integer(A),
-
-    B = atom_to_list(ARGVInPort),
-    {InPort, _Rest} = string:to_integer(B),
-
-    C = atom_to_list(ARGVCuePort),
-    {CuePort, _Rest} = string:to_integer(C),
-
-    CueHost = cue_server_host(),
-
-    Internal = true,
-
-    Enabled = false,
-
-    io:format("~n"
-              "+--------------------------------------+~n"
-              "    This is the Sonic Pi IO Server      ~n"
-              "       Powered by Erlang ~p             ~n"
-              "                                        ~n"
-              "       API listening on port ~p         ~n"
-              "        Incoming OSC on port ~p         ~n"
-              "  OSC cue forwarding to ~p              ~n"
-              "                     on port ~p         ~n"
-              "+--------------------------------------+~n~n~n",
-              [erlang:system_info(otp_release), Port, InPort, CueHost, CuePort]),
-
-    CuePid = pi_server_cue:start(InPort, CueHost, CuePort, Internal, Enabled),
-    pi_server_api:start(Port, CuePid),
+%% API for launching as an OTP application from the command line
+%% "erl -pi_server api_port $API_PORT in_port $IN_PORT cue_port $CUE_PORT \
+%%      -s pi_server start"
+start() ->
+    %% note that this will dispatch using the 'mod' entry in pi_server.app
+    {ok, _} = application:ensure_all_started(?APPLICATION),
     ok.

--- a/app/server/erlang/pi_server_api.erl
+++ b/app/server/erlang/pi_server_api.erl
@@ -14,10 +14,10 @@
 
 -module(pi_server_api).
 
--export([start_link/0]).
+-export([start_link/1]).
 
 %% internal
--export([init/1, loop/1]).
+-export([init/2, loop/1]).
 
 %% sys module callbacks
 -export([system_continue/3, system_terminate/4, system_code_change/4,
@@ -73,12 +73,12 @@
 
 
 %% supervisor compliant start function
-start_link() ->
+start_link(CueServer) ->
     %% synchronous start of the child process
-    proc_lib:start_link(?MODULE, init, [self()]).
+    proc_lib:start_link(?MODULE, init, [self(), CueServer]).
 
 
-init(Parent) ->
+init(Parent, CueServer) ->
     register(?SERVER, self()),
     APIPort = application:get_env(?APPLICATION, api_port, undefined),
     io:format("~n"
@@ -99,7 +99,7 @@ init(Parent) ->
           [try erlang:port_info(APISocket) catch _:_ -> undefined end]),
     State = #{parent => Parent,
               api_socket => APISocket,
-              cue_server => pi_server_cue:server_name(),
+              cue_server => CueServer,
               tag_map => #{}
              },
     loop(State).

--- a/app/server/erlang/pi_server_app.erl
+++ b/app/server/erlang/pi_server_app.erl
@@ -1,0 +1,27 @@
+%% Application startup - entry point from pi_server.app
+
+-module(pi_server_app).
+
+-behaviour(application).
+
+%% Callbacks
+-export([start/2, stop/1, prep_stop/1, config_change/3]).
+
+
+%% Application behaviour callbacks
+
+start(_Type, _StartArgs) ->
+    %% launches the top level supervisor
+    pi_server_sup:start_link().
+
+prep_stop(State) ->
+    %% handles any preparations before the processes are stopped
+    State.
+
+stop(_FinalState) ->
+    %% handles any cleanup after the processes have been stopped
+    ok.
+
+config_change(_Changed, _New, _Removed) ->
+    %% handles actions needed on configuration change
+    ok.

--- a/app/server/erlang/pi_server_sup.erl
+++ b/app/server/erlang/pi_server_sup.erl
@@ -1,0 +1,52 @@
+%% Application supervision tree
+
+-module(pi_server_sup).
+
+-behaviour(supervisor).
+
+%% API
+-export([start_link/0]).
+
+%% Supervisor callbacks
+-export([init/1]).
+
+
+-define(APPLICATION, pi_server).
+
+-define(SERVER, ?MODULE).
+
+
+%% ------------------------------------------------------------------------
+%% API for use from the application module (pi_server_app.erl)
+
+start_link() ->
+    Name = ?SERVER,
+    Module = ?MODULE,
+    Args = [],
+    supervisor:start_link({local, Name}, Module, Args).
+
+
+%% ------------------------------------------------------------------------
+%% Callbacks for supervisor
+%%
+%% NOTE: it is important that this code cannot fail, because that
+%% would prevent the application from even being started.
+
+init(_Args) ->
+    %% Use rest_for_one since the api server requires the cue server.
+    %% Try to keep going even if we restart up to 50 times per 30 seconds.
+    SupFlags = #{strategy => rest_for_one,
+                 intensity => 50,
+                 period => 30000},
+
+    %% Specifies the worker processes to run under the supervisor
+    ChildSpecs = [
+                  #{id => pi_server_cue,
+                    start => {pi_server_cue, start_link, []}
+                   },
+                  #{id => pi_server_api,
+                    start => {pi_server_api, start_link, []}
+                   }
+                 ],
+
+    {ok, {SupFlags, ChildSpecs}}.

--- a/app/server/erlang/pi_server_sup.erl
+++ b/app/server/erlang/pi_server_sup.erl
@@ -33,6 +33,8 @@ start_link() ->
 %% would prevent the application from even being started.
 
 init(_Args) ->
+    CueServer = pi_server_cue:server_name(),
+
     %% Use rest_for_one since the api server requires the cue server.
     %% Try to keep going even if we restart up to 50 times per 30 seconds.
     SupFlags = #{strategy => rest_for_one,
@@ -45,7 +47,7 @@ init(_Args) ->
                     start => {pi_server_cue, start_link, []}
                    },
                   #{id => pi_server_api,
-                    start => {pi_server_api, start_link, []}
+                    start => {pi_server_api, start_link, [CueServer]}
                    }
                  ],
 

--- a/app/server/erlang/pi_server_tracker.erl
+++ b/app/server/erlang/pi_server_tracker.erl
@@ -52,9 +52,7 @@ loop(Tag, Map) ->
             ?MODULE:loop(Tag, Map1);
         {flush, all} ->
             debug("forget all timers tagged \"~s\" ~n", [Tag]),
-            lists:foreach(fun (Ref) ->
-                                  erlang:cancel_timer(Ref, [{async, true}])
-                          end,
+            lists:foreach(fun cancel_timer/1,
                           maps:keys(Map)),
             ?MODULE:loop(Tag, #{});
         {flush, Time} ->
@@ -65,7 +63,7 @@ loop(Tag, Map) ->
                      fun (R, M) ->
                              T = maps:get(R, M),
                              if T > Time ->
-                                     erlang:cancel_timer(R, [{async, true}]),
+                                     cancel_timer(R),
                                      maps:remove(R, M);
                                 true ->
                                      M
@@ -75,3 +73,8 @@ loop(Tag, Map) ->
                      Map),
             ?MODULE:loop(Tag, Map1)
     end.
+
+cancel_timer(Ref) ->
+    %% cancel a timer without waiting and without checking the result
+    erlang:cancel_timer(Ref, [{async, true},{info,false}]),
+    ok.

--- a/app/server/ruby/lib/sonicpi/studio.rb
+++ b/app/server/ruby/lib/sonicpi/studio.rb
@@ -74,9 +74,9 @@ module SonicPi
 
     def __erl_mut_start_erlang
       return @erlang_pid if @erlang_pid
-      # Start Erlang
+      # Start Erlang (initially with cue forwarding disabled)
       begin
-        erlang_cmd = __exec_path("#{erlang_boot_path} +C multi_time_warp -noshell -pz \"#{erlang_server_path}\" -s pi_server start #{@erlang_port} #{@osc_cues_port} #{@server_port}")
+        erlang_cmd = __exec_path("#{erlang_boot_path} +C multi_time_warp -noshell -pz \"#{erlang_server_path}\" -pi_server api_port #{@erlang_port} in_port #{@osc_cues_port} cue_port #{@server_port} enabled false -s pi_server start")
         STDOUT.puts erlang_cmd
         @erlang_pid = spawn erlang_cmd, out: erlang_log_path, err: erlang_log_path
         register_process(@erlang_pid)


### PR DESCRIPTION
Turns the Erlang server into a proper OTP Application with supervision.
(To minimize latency, this doesn't use standard gen_server processes. Instead, we implement our own "special processes" that comply with the OTP framework; see http://erlang.org/doc/design_principles/spec_proc.html#special-processes for details.)

@karlsson Do take a look! I've tried this using Observer, shooting down processes which get restarted on the fly while Sonic Pi is playing Midi without losing a beat. Pretty nice.

Also fixes #2344 (adding two more files).