### PR TITLE
Erlang server processes don't need to print idling messages anymore

### DIFF
--- a/app/server/erlang/pi_server_api.erl
+++ b/app/server/erlang/pi_server_api.erl
@@ -26,9 +26,6 @@
 -define(APPLICATION, pi_server).
 -define(SERVER, ?MODULE).
 
-%% time between idling messages
--define(IDLE_TIME, 60000).
-
 %% Bundles whose delay time is not greater than NODELAY_LIMIT
 %% are forwarded directly without starting a timer.
 -define(NODELAY_LIMIT, 1).
@@ -140,9 +137,6 @@ loop(State) ->
                                   ?MODULE, [], State);
         Any ->
             log("API Server got unexpected message: ~p~n", [Any]),
-            ?MODULE:loop(State)
-    after ?IDLE_TIME ->
-            debug(2, "api process idling~n", []),
             ?MODULE:loop(State)
     end.
 

--- a/app/server/erlang/pi_server_cue.erl
+++ b/app/server/erlang/pi_server_cue.erl
@@ -27,9 +27,6 @@
 -define(APPLICATION, pi_server).
 -define(SERVER, ?MODULE).
 
-%% time between idling messages
--define(IDLE_TIME, 60000).
-
 -import(pi_server_util,
         [log/1, log/2, debug/2, debug/3, debug/4]).
 
@@ -160,10 +157,6 @@ loop(State) ->
                                   ?MODULE, [], State);
         Any ->
 	    log("Cue Server got unexpected message: ~p~n", [Any]),
-	    ?MODULE:loop(State)
-
-    after ?IDLE_TIME ->
-	    debug(2, "cue server idling~n", []),
 	    ?MODULE:loop(State)
     end.
 


### PR DESCRIPTION
@karlsson This drops those idling debug messages completely.