### PR TITLE
Fix Linux install instructions for Ubuntu 20.04

### DIFF
--- a/INSTALL-LINUX.md
+++ b/INSTALL-LINUX.md
@@ -59,7 +59,8 @@ On multiple distributions, there are Sonic Pi releases that you can install from
 
   | Distribution | System Packages | Ruby Gems |
   |---|---|---|
-  | Debian/Ubuntu |`sudo apt-get install ruby erlang-base libscsynth1 sc3-plugins libjack-jackd2 qt5-default libffi git cmake build-essential ruby-dev libqt5svg5-dev qttools5-dev qttools5-dev-tools qtdeclarative5-dev libqt5webkit5-dev qtpositioning5-dev libqt5sensors5-dev libqt5opengl5-dev qtmultimedia5-dev libffi-dev libjack-jackd2-dev libxt-dev libudev-dev libboost-dev libasound2-dev libavahi-client-dev libicu-dev libreadline6-dev libfftw3-dev libaubio5`| Currently all required Ruby gems are included the source; no gems need to be installed to the system. |
+  | Debian/Ubuntu |`sudo apt-get install ruby erlang-base libscsynth1 sc3-plugins libjack-jackd2-0 qt5-default libffi7 git cmake build-essential ruby-dev libqt5svg5-dev qttools5-dev qttools5-dev-tools qtdeclarative5-dev libqt5webkit5-dev qtpositioning5-dev libqt5sensors5-dev libqt5opengl5-dev qtmultimedia5-dev libffi-dev libjack-jackd2-dev libxt-dev libudev-dev libboost-dev libasound2-dev libavahi-client-dev libicu-dev libreadline6-dev libfftw3-dev libaubio5
+`| Currently all required Ruby gems are included the source; no gems need to be installed to the system. |
 
   **Note about CMake**: On some distros you may need a newer version of CMake than the one that's available in the main package repository.
 
@@ -102,11 +103,11 @@ On multiple distributions, there are Sonic Pi releases that you can install from
 ```bash
     cd app/gui/qt
 
-    ./unix-prebuild.sh
-    # Note: If you want to build & bundle libaubio with Sonic Pi
-    # instead of using the distro's package,
-    # add the --build-aubio option to the above command, like so:
-    # ./unix-prebuild.sh --build-aubio
+    ./unix-prebuild.sh --build-aubio
+    # Note: If you don't want to build & bundle libaubio with Sonic Pi
+    # and instead use the distro's package,
+    # remove the --build-aubio option in the above command, like so:
+    # ./unix-prebuild.sh
 
     ./unix-config.sh
 


### PR DESCRIPTION
Just tested on a fresh 20.04 install, looks like 2 packages have changed name, and the `libaubio` package doesn't work.