### PR TITLE
Update Erlang version in AppVeyor Ubuntu builds; add Erlang version info to INSTALL_LINUX.md

### DIFF
--- a/INSTALL-LINUX.md
+++ b/INSTALL-LINUX.md
@@ -17,7 +17,7 @@ On multiple distributions, there are Sonic Pi releases that you can install from
   _Note: This list may need refining and correcting._
   * Runtime Dependencies
       * Ruby (>= 2.4)
-      * Erlang
+      * Erlang (>= 21)
       * Supercollider scsynth (>= 3.9.1)
       * SC3-Plugins
       * jackd
@@ -31,7 +31,7 @@ On multiple distributions, there are Sonic Pi releases that you can install from
 
       **All the above, and:**
       * Git
-      * CMake
+      * CMake (>= 3.2)
       * Make
       * Ruby-dev
       * GCC (or Clang)
@@ -62,7 +62,7 @@ On multiple distributions, there are Sonic Pi releases that you can install from
   | Debian/Ubuntu |`sudo apt-get install ruby erlang-base libscsynth1 sc3-plugins libjack-jackd2-0 qt5-default libffi7 git cmake build-essential ruby-dev libqt5svg5-dev qttools5-dev qttools5-dev-tools qtdeclarative5-dev libqt5webkit5-dev qtpositioning5-dev libqt5sensors5-dev libqt5opengl5-dev qtmultimedia5-dev libffi-dev libjack-jackd2-dev libxt-dev libudev-dev libboost-dev libasound2-dev libavahi-client-dev libicu-dev libreadline6-dev libfftw3-dev libaubio5
 `| Currently all required Ruby gems are included the source; no gems need to be installed to the system. |
 
-  **Note about CMake**: On some distros you may need a newer version of CMake than the one that's available in the main package repository.
+  :information_source: **Note about CMake**: On some distros you may need a newer version of CMake than the one that's available in the main package repository. (CMake 2.3 or above is required)
 
   To install the newest version, you can:
   * Build it from source (download source code from CMake website)
@@ -90,8 +90,16 @@ On multiple distributions, there are Sonic Pi releases that you can install from
   ```
   * Install the Snap or pip package
 
-
   **See https://cmake.org/download/ for more info.**
+  
+  :information_source: **Note about Erlang**: On some distros, you may need a newer version of Erlang than the one that's available in the main package repository. (Erlang 21 or above is required)
+  
+  To install the newest version, you can:
+  * Build it from source (see https://github.com/erlang/otp)
+  * Download the latest binary package from the Erlang website
+  * Use [Kerl](https://github.com/kerl/kerl) to install Erlang
+  
+  **See https://www.erlang.org/downloads for more info.**
 
 ### 2. Clone the source code
 ```bash
@@ -123,11 +131,11 @@ On multiple distributions, there are Sonic Pi releases that you can install from
 
 ### Tips
 * If compile-extensions.rb fails, you can try installing the required gems with native extensions to the system:
-```bash
-  sudo gem install aubio sys-proctable fast_osc
-  sudo gem install rugged --version 0.27.1
-```
-If you get aubio related errors, try using the distro's libaubio5 package and make sure that the AUBIO_LIB environment variable is set to the path to the library
+  ```bash
+    sudo gem install aubio sys-proctable fast_osc
+    sudo gem install rugged --version 0.27.1
+  ```
+  If you get aubio related errors, try using the distro's libaubio5 package and make sure that the AUBIO_LIB environment variable is set to the path to the library
 
 * Error logs are written to ~/.sonic-pi/logs, and are useful to diagnose any startup problems.
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -80,8 +80,7 @@ for:
     # scripts that are called at very beginning, before repo cloning
     - date '+%Y-%m-%d %T %Z(UTC%z)'
     - cmake --version
-    - # Update Homebrew; cleanup cache; output details about Homebrew's config; and check brew & print any warnings (for debugging)
-    - brew update
+    - # Cleanup homebrew cache; output details about Homebrew's config; and check brew & print any warnings (for debugging)
     - brew cleanup
     - brew config
     - brew doctor || true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -138,8 +138,8 @@ for:
     - sudo apt-get purge -y --auto-remove erlang
     - cd ~
     - git clone https://github.com/erlang/otp.git
-    - git checkout OTP-22.3
     - cd otp
+    - git checkout OTP-22.3
     - ./otp_build autoconf
     - ./configure
     - make

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -135,6 +135,16 @@ for:
     - sudo apt-get install -y git build-essential cmake ruby ruby-dev erlang-base
     - sudo apt-get install -y qt5-default libqt5svg5-dev qttools5-dev qttools5-dev-tools qtdeclarative5-dev libqt5webkit5-dev qtpositioning5-dev libqt5sensors5-dev libqt5opengl5-dev qtmultimedia5-dev
     - sudo apt-get install -y libjack-jackd2-dev libasound2-dev libavahi-client-dev libicu-dev libreadline6-dev libfftw3-dev libxt-dev libudev-dev libboost-dev libffi-dev
+    - # Remove Erlang 20 and install Erlang 22 (21 or above is required)
+    - sudo apt-get purge -y --auto-remove erlang
+    - cd ~
+    - git clone https://github.com/erlang/otp.git
+    - git checkout OTP-22.3
+    - cd otp
+    - ./otp_build autoconf
+    - ./configure
+    - make
+    - make install
     - # Install prerequisite ruby gems
     - sudo gem install bundler
   build_script:


### PR DESCRIPTION
* AppVeyor: Install Erlang 22.3 in Ubuntu build (not available in distro repos)
* Update INSTALL_LINUX.md with version info about Erlang and CMake