### PR TITLE
AppVeyor: Run Erlang `make install` as root on Ubuntu build

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -143,7 +143,7 @@ for:
     - ./otp_build autoconf
     - ./configure
     - make
-    - make install
+    - sudo make install
     - # Install prerequisite ruby gems
     - sudo gem install bundler
   build_script:


### PR DESCRIPTION
In #2370 I forgot to put sudo before `make install`! Oops!