### PR TITLE
Fix with/use_merged_*_defaults

### DIFF
--- a/app/server/ruby/lib/sonicpi/lang/midi.rb
+++ b/app/server/ruby/lib/sonicpi/lang/midi.rb
@@ -142,8 +142,8 @@ end
         raise "use_merged_midi_defaults does not work with a block. Perhaps you meant with_midi_defaults" if block
         current_defs = __thread_locals.get(:sonic_pi_mod_midi_defaults)
         args_h = resolve_synth_opts_hash_or_array(args)
-        merged_defs = (current_defs || {}).merge(args_h)
-        __thread_locals.set :sonic_pi_mod_midi_defaults, SonicPi::Core::SPMap.new(merged_defs)
+        merged_defs = (current_defs || SonicPi::Core::SPMap.new).merge(args_h)
+        __thread_locals.set :sonic_pi_mod_midi_defaults, merged_defs
       end
       doc name:          :use_merged_midi_defaults,
           introduced:    Version.new(3,0,0),
@@ -174,8 +174,8 @@ midi_note_on :e2 # Sends MIDI :e2 note_on to channel 1 on port \"foo\".
         current_defs = __thread_locals.get(:sonic_pi_mod_midi_defaults)
 
         args_h = resolve_synth_opts_hash_or_array(args)
-        merged_defs = (current_defs || {}).merge(args_h)
-        __thread_locals.set :sonic_pi_mod_midi_defaults, SonicPi::Core::SPMap.new(merged_defs)
+        merged_defs = (current_defs || SonicPi::Core::SPMap.new).merge(args_h)
+        __thread_locals.set :sonic_pi_mod_midi_defaults, merged_defs
         res = block.call
         __thread_locals.set :sonic_pi_mod_midi_defaults, current_defs
         res

--- a/app/server/ruby/lib/sonicpi/lang/sound.rb
+++ b/app/server/ruby/lib/sonicpi/lang/sound.rb
@@ -1386,8 +1386,8 @@ play 47, amp: 0.5",
         raise "use_merged_synth_defaults does not work with a block. Perhaps you meant with_merged_synth_defaults" if block
         current_defs = __thread_locals.get(:sonic_pi_mod_sound_synth_defaults)
         args_h = resolve_synth_opts_hash_or_array(args)
-        merged_defs = (current_defs || {}).merge(args_h)
-        __thread_locals.set :sonic_pi_mod_sound_synth_defaults, SonicPi::Core::SPMap.new(merged_defs)
+        merged_defs = (current_defs || SonicPi::Core::SPMap.new).merge(args_h)
+        __thread_locals.set :sonic_pi_mod_sound_synth_defaults, merged_defs
       end
       doc name:          :use_merged_synth_defaults,
           introduced:    Version.new(2,0,0),
@@ -1422,8 +1422,8 @@ play 50 #=> Plays note 50 with amp 0.7, cutoff 80 and pan -1"]
         current_defs = __thread_locals.get(:sonic_pi_mod_sound_synth_defaults)
 
         args_h = resolve_synth_opts_hash_or_array(args)
-        merged_defs = (current_defs || {}).merge(args_h)
-        __thread_locals.set :sonic_pi_mod_sound_synth_defaults, SonicPi::Core::SPMap.new(merged_defs)
+        merged_defs = (current_defs || SonicPi::Core::SPMap.new).merge(args_h)
+        __thread_locals.set :sonic_pi_mod_sound_synth_defaults, merged_defs
         res = block.call
         __thread_locals.set :sonic_pi_mod_sound_synth_defaults, current_defs
         res
@@ -1512,8 +1512,8 @@ sample :loop_amen  # plays amen break with a cutoff of 90 and defaults for rest 
         raise "use_merged_sample_defaults does not work with a block. Perhaps you meant with_merged_sample_defaults" if block
         current_defs = __thread_locals.get(:sonic_pi_mod_sound_sample_defaults)
         args_h = resolve_synth_opts_hash_or_array(args)
-        merged_defs = (current_defs || {}).merge(args_h)
-        __thread_locals.set :sonic_pi_mod_sound_sample_defaults, SonicPi::Core::SPMap.new(merged_defs)
+        merged_defs = (current_defs || SonicPi::Core::SPMap.new).merge(args_h)
+        __thread_locals.set :sonic_pi_mod_sound_sample_defaults, merged_defs
       end
       doc name:          :use_merged_sample_defaults,
           introduced:    Version.new(2,9,0),
@@ -1575,8 +1575,8 @@ sample :loop_amen  # plays amen break with a cutoff of 70 and amp is 0.5 again a
         raise "with_merged_sample_defaults must be called with a do/end block. Perhaps you meant use_merged_sample_defaults" unless block
         current_defs = __thread_locals.get(:sonic_pi_mod_sound_sample_defaults)
         args_h = resolve_synth_opts_hash_or_array(args)
-        merged_defs = (current_defs || {}).merge(args_h)
-        __thread_locals.set :sonic_pi_mod_sound_sample_defaults, SonicPi::Core::SPMap.new(merged_defs)
+        merged_defs = (current_defs || SonicPi::Core::SPMap.new).merge(args_h)
+        __thread_locals.set :sonic_pi_mod_sound_sample_defaults, merged_defs
         res = block.call
         __thread_locals.set :sonic_pi_mod_sound_sample_defaults, current_defs
         res


### PR DESCRIPTION
The `use_merged_*_defaults` and `with_merged_*_defaults` fns all fail when there are existing defaults in force. To reproduce, just run:
```ruby
use_synth_defaults amp: 2
use_merged_synth_defaults amp: 1
```
and you get an error:
```
Runtime Error: [buffer 1, line 2] - ArgumentError
Thread death!
 odd number of arguments for Hash

/Applications/Sonic Pi.app/Contents/Resources/app/server/ruby/core.rb:339:in `[]'
/Applications/Sonic Pi.app/Contents/Resources/app/server/ruby/core.rb:339:in `initialize'
/Applications/Sonic Pi.app/Contents/Resources/app/server/ruby/lib/sonicpi/lang/sound.rb:1390:in `new'
/Applications/Sonic Pi.app/Contents/Resources/app/server/ruby/lib/sonicpi/lang/sound.rb:1390:in `use_merged_synth_defaults'
```
With the same results for the `sample` and `midi` versions of these fns, and the `with_` variants.

It looks like this is caused because the values are always converted to an SPMap before being set, but when there are existing values they are already in an SPMap, and the SPMap constructor is not expecting another SPMap as an argument.