### PR TITLE
Docs - fix back-to-front compressor :slope_below docs

### DIFF
--- a/app/server/ruby/lib/sonicpi/synths/synthinfo.rb
+++ b/app/server/ruby/lib/sonicpi/synths/synthinfo.rb
@@ -6281,7 +6281,7 @@ end
 
           :slope_below =>
           {
-            :doc => "Slope of the amplitude curve below the threshold. A value of 1 means that the output of signals with amplitude below the threshold will be unaffected. Greater values will magnify and smaller values will attenuate the signal.",
+            :doc => "Slope of the amplitude curve below the threshold. A value of 1 means that the output of signals with amplitude below the threshold will be unaffected. Greater values will attenuate and smaller values will magnify the signal.",
             :validations => [],
             :modulatable => true
           },


### PR DESCRIPTION
Accidentally pushed this to my fork on the master branch 😛 never mind...

Based on the documentation available in Supercollider, it appears that
previously, the effect that values less than or greater than one had on the
:slope_below opt of Sonic Pi's :compressor fx was reversed. This has now been
fixed.

Should resolve the issue raised in https://github.com/samaaron/sonic-pi/issues/2374.