### PR TITLE
AppVeyor: Skip commits only affecting Travis CI; fix an apt-get command

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,6 +11,11 @@ configuration:
 branches:
   only:
   - master
+  
+# Skip commits which only affect the following files
+skip_commits:
+    files:
+      - .travis.yml
 
 platform:
   - x64
@@ -126,7 +131,7 @@ for:
     - # Remove old versions of CMake if pre-installed
     - sudo apt-get purge -y --auto-remove cmake
     - # Add Kitware's apt repo (for newest CMake)
-    - sudo apt-get install apt-transport-https ca-certificates gnupg software-properties-common wget
+    - sudo apt-get install -y apt-transport-https ca-certificates gnupg software-properties-common wget
     - wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | sudo apt-key add -
     - sudo apt-add-repository 'deb https://apt.kitware.com/ubuntu/ bionic main'
     - sudo apt-get update


### PR DESCRIPTION
Looks like I forgot to auto confirm an apt-get install command using -y flag. :P