### PR TITLE
Add keyboard shortcuts to switch to tab directly

### DIFF
--- a/app/gui/qt/mainwindow.cpp
+++ b/app/gui/qt/mainwindow.cpp
@@ -2095,6 +2095,16 @@ void MainWindow::createShortcuts()
     std::cout << "[GUI] - creating shortcuts" << std::endl;
     new QShortcut(shiftMetaKey('['), this, SLOT(tabPrev()));
     new QShortcut(shiftMetaKey(']'), this, SLOT(tabNext()));
+    new QShortcut(shiftMetaKey('0'), this, SLOT(tab0()));
+    new QShortcut(shiftMetaKey('1'), this, SLOT(tab1()));
+    new QShortcut(shiftMetaKey('2'), this, SLOT(tab2()));
+    new QShortcut(shiftMetaKey('3'), this, SLOT(tab3()));
+    new QShortcut(shiftMetaKey('4'), this, SLOT(tab4()));
+    new QShortcut(shiftMetaKey('5'), this, SLOT(tab5()));
+    new QShortcut(shiftMetaKey('6'), this, SLOT(tab6()));
+    new QShortcut(shiftMetaKey('7'), this, SLOT(tab7()));
+    new QShortcut(shiftMetaKey('8'), this, SLOT(tab8()));
+    new QShortcut(shiftMetaKey('9'), this, SLOT(tab9()));
     new QShortcut(QKeySequence("F8"), this, SLOT(reloadServerCode()));
     new QShortcut(QKeySequence("F9"), this, SLOT(toggleButtonVisibility()));
     new QShortcut(shiftMetaKey('B'), this, SLOT(toggleButtonVisibility()));
@@ -2780,6 +2790,24 @@ void MainWindow::tabPrev() {
     else
         index--;
     QMetaObject::invokeMethod(tabs, "setCurrentIndex", Q_ARG(int, index));
+}
+
+// Need to do it this way because of Qt's slot mechanism
+void MainWindow::tab0() { tabN(0); }
+void MainWindow::tab1() { tabN(1); }
+void MainWindow::tab2() { tabN(2); }
+void MainWindow::tab3() { tabN(3); }
+void MainWindow::tab4() { tabN(4); }
+void MainWindow::tab5() { tabN(5); }
+void MainWindow::tab6() { tabN(6); }
+void MainWindow::tab7() { tabN(7); }
+void MainWindow::tab8() { tabN(8); }
+void MainWindow::tab9() { tabN(9); }
+
+void MainWindow::tabN(int index) {
+    if (index < tabs->count()){
+        QMetaObject::invokeMethod(tabs, "setCurrentIndex", Q_ARG(int, index));
+    }
 }
 
 void MainWindow::setLineMarkerinCurrentWorkspace(int num) {

--- a/app/gui/qt/mainwindow.h
+++ b/app/gui/qt/mainwindow.h
@@ -166,6 +166,17 @@ signals:
         void replaceLines(QString id, QString content, int first_line, int finish_line, int point_line, int point_index);
         void tabNext();
         void tabPrev();
+        void tab0();
+        void tab1();
+        void tab2();        
+        void tab3();
+        void tab4();
+        void tab5();
+        void tab6();
+        void tab7();
+        void tab8();
+        void tab9();
+        void tabN(int n);
         void helpContext();
         void resetErrorPane();
         void helpScrollUp();

--- a/etc/doc/tutorial/B.02-Shortcut-Cheatsheet.md
+++ b/etc/doc/tutorial/B.02-Shortcut-Cheatsheet.md
@@ -23,6 +23,10 @@ Windows/Linux or *Cmd* on Mac):
 * `M-p`     - Toggle Preferences
 * `M-{`     - Switch buffer to the left
 * `M-}`     - Switch buffer to the right
+* `S-M-0`   - Switch to buffer 0
+* `S-M-1`   - Switch to buffer 1
+* ...
+* `S-M-9`   - Switch to buffer 9
 * `M-+`     - Increase text size of current buffer
 * `M--`     - Decrease text size of current buffer
 


### PR DESCRIPTION
With this, you can use C-M-0 to C-M-9 to switch to a tab directly. I find this very convenient to move through the interface quickly.