### PR TITLE
Add keyboard shortcuts to switch to tab directly

### DIFF
--- a/app/gui/qt/mainwindow.cpp
+++ b/app/gui/qt/mainwindow.cpp
@@ -2499,6 +2499,7 @@ void MainWindow::readSettings() {
     piSettings->show_scopes = settings.value("prefs/scope/show-scopes", true).toBool();
     piSettings->show_scope_labels = settings.value("prefs/scope/show-labels", false).toBool();
     piSettings->show_cues = settings.value("prefs/show_cues", true).toBool();
+    piSettings->goto_buffer_shortcuts = settings.value("prefs/goto_buffer_shortcuts", false).toBool();
     QString styleName = settings.value("prefs/theme", "").toString();
     piSettings->themeStyle = theme->themeNameToStyle(styleName);
 
@@ -2545,6 +2546,7 @@ void MainWindow::writeSettings()
     settings.setValue("prefs/scope/show-labels", piSettings->show_scope_labels );
     settings.setValue("prefs/scope/show-scopes", piSettings->show_scopes );
     settings.setValue("prefs/show_cues", piSettings->show_cues);
+    settings.setValue("prefs/goto_buffer_shortcuts", piSettings->goto_buffer_shortcuts);
     settings.setValue("prefs/theme", theme->themeStyleToName(piSettings->themeStyle));
 
     for ( auto name : piSettings->scope_names ) {
@@ -2793,6 +2795,9 @@ void MainWindow::tabPrev() {
 }
 
 void MainWindow::tabGoto(int index) {
+    if (!piSettings->goto_buffer_shortcuts)
+        return;    
+
     if (index < tabs->count())
         QMetaObject::invokeMethod(tabs, "setCurrentIndex", Q_ARG(int, index));
 }

--- a/app/gui/qt/mainwindow.cpp
+++ b/app/gui/qt/mainwindow.cpp
@@ -2095,6 +2095,16 @@ void MainWindow::createShortcuts()
     std::cout << "[GUI] - creating shortcuts" << std::endl;
     new QShortcut(shiftMetaKey('['), this, SLOT(tabPrev()));
     new QShortcut(shiftMetaKey(']'), this, SLOT(tabNext()));
+    connect(new QShortcut(shiftMetaKey('1'), this), &QShortcut::activated, [this](){ tabGoto(1); });
+    connect(new QShortcut(shiftMetaKey('2'), this), &QShortcut::activated, [this](){ tabGoto(2); });
+    connect(new QShortcut(shiftMetaKey('3'), this), &QShortcut::activated, [this](){ tabGoto(3); });
+    connect(new QShortcut(shiftMetaKey('4'), this), &QShortcut::activated, [this](){ tabGoto(4); });
+    connect(new QShortcut(shiftMetaKey('5'), this), &QShortcut::activated, [this](){ tabGoto(5); });
+    connect(new QShortcut(shiftMetaKey('6'), this), &QShortcut::activated, [this](){ tabGoto(6); });
+    connect(new QShortcut(shiftMetaKey('7'), this), &QShortcut::activated, [this](){ tabGoto(7); });
+    connect(new QShortcut(shiftMetaKey('8'), this), &QShortcut::activated, [this](){ tabGoto(8); });
+    connect(new QShortcut(shiftMetaKey('9'), this), &QShortcut::activated, [this](){ tabGoto(9); });
+    connect(new QShortcut(shiftMetaKey('0'), this), &QShortcut::activated, [this](){ tabGoto(0); });
     new QShortcut(QKeySequence("F8"), this, SLOT(reloadServerCode()));
     new QShortcut(QKeySequence("F9"), this, SLOT(toggleButtonVisibility()));
     new QShortcut(shiftMetaKey('B'), this, SLOT(toggleButtonVisibility()));
@@ -2780,6 +2790,11 @@ void MainWindow::tabPrev() {
     else
         index--;
     QMetaObject::invokeMethod(tabs, "setCurrentIndex", Q_ARG(int, index));
+}
+
+void MainWindow::tabGoto(int index) {
+    if (index < tabs->count())
+        QMetaObject::invokeMethod(tabs, "setCurrentIndex", Q_ARG(int, index));
 }
 
 void MainWindow::setLineMarkerinCurrentWorkspace(int num) {

--- a/app/gui/qt/mainwindow.h
+++ b/app/gui/qt/mainwindow.h
@@ -166,6 +166,7 @@ signals:
         void replaceLines(QString id, QString content, int first_line, int finish_line, int point_line, int point_index);
         void tabNext();
         void tabPrev();
+        void tabGoto(int index);
         void helpContext();
         void resetErrorPane();
         void helpScrollUp();

--- a/app/gui/qt/model/settings.h
+++ b/app/gui/qt/model/settings.h
@@ -31,6 +31,7 @@ public:
     bool show_buttons;
     bool show_tabs;
     bool full_screen;
+    bool goto_buffer_shortcuts;
     bool print_output;
     bool clear_output_on_run;
     bool log_cues;

--- a/app/gui/qt/widgets/settingswidget.cpp
+++ b/app/gui/qt/widgets/settingswidget.cpp
@@ -269,8 +269,8 @@ QGroupBox* SettingsWidget::createEditorPrefsTab() {
     editor_display_box->setToolTip(tr("Configure editor display options."));
     QGroupBox *editor_look_feel_box = new QGroupBox(tr("Look and Feel"));
     editor_look_feel_box->setToolTip(tr("Configure editor look and feel."));
-    QGroupBox *automation_box = new QGroupBox(tr("Automation"));
-    automation_box->setToolTip(tr("Configure automation features."));
+    QGroupBox *automation_box = new QGroupBox(tr("Automation / Misc"));
+    automation_box->setToolTip(tr("Configure automation and other features."));
 
     auto_indent_on_run = new QCheckBox(tr("Auto-align"));
     auto_indent_on_run->setToolTip(tr("Automatically align code on Run"));
@@ -293,6 +293,8 @@ QGroupBox* SettingsWidget::createEditorPrefsTab() {
     show_tabs->setToolTip(tr("Toggle visibility of the buffer selection tabs."));
     full_screen = new QCheckBox(tr("Full screen"));
     full_screen->setToolTip(tooltipStrShiftMeta('F', tr("Toggle full screen mode.")));
+    goto_buffer_shortcuts = new QCheckBox(tr("Go to buffer shortcuts"));
+    goto_buffer_shortcuts->setToolTip(tr("Use C-M-0 .. C-M-9 to go to buffer directly"));
 
     colourModeButtonGroup = new QButtonGroup(this);
     lightModeCheck = new QCheckBox(tr("Light"));
@@ -327,6 +329,7 @@ QGroupBox* SettingsWidget::createEditorPrefsTab() {
 
     automation_box_layout->addWidget(auto_indent_on_run);
     automation_box_layout->addWidget(full_screen);
+    automation_box_layout->addWidget(goto_buffer_shortcuts);
     automation_box->setLayout(automation_box_layout);
 
     QGroupBox *debug_box = new QGroupBox(tr("Logging"));
@@ -597,6 +600,7 @@ void SettingsWidget::updateSettings() {
     piSettings->show_buttons = show_buttons->isChecked();
     piSettings->show_tabs = show_tabs->isChecked();
     piSettings->full_screen = full_screen->isChecked();
+    piSettings->goto_buffer_shortcuts = goto_buffer_shortcuts->isChecked();
     piSettings->print_output = print_output->isChecked();
     piSettings->clear_output_on_run = clear_output_on_run->isChecked();
     piSettings->log_cues = log_cues->isChecked();
@@ -636,6 +640,7 @@ void SettingsWidget::settingsChanged() {
     show_buttons->setChecked(piSettings->show_buttons);
     show_tabs->setChecked(piSettings->show_tabs);
     full_screen->setChecked(piSettings->full_screen);
+    goto_buffer_shortcuts->setChecked(piSettings->goto_buffer_shortcuts);
     print_output->setChecked(piSettings->print_output);
     clear_output_on_run->setChecked(piSettings->clear_output_on_run);
     log_cues->setChecked(piSettings->log_cues);
@@ -679,6 +684,7 @@ void SettingsWidget::connectAll() {
     connect(show_buttons, SIGNAL(clicked()), this, SLOT(updateSettings()));
     connect(show_tabs, SIGNAL(clicked()), this, SLOT(updateSettings()));
     connect(full_screen, SIGNAL(clicked()), this, SLOT(updateSettings()));
+    connect(goto_buffer_shortcuts, SIGNAL(clicked()), this, SLOT(updateSettings()));
     connect(print_output, SIGNAL(clicked()), this, SLOT(updateSettings()));
     connect(clear_output_on_run, SIGNAL(clicked()), this, SLOT(updateSettings()));
     connect(log_cues, SIGNAL(clicked()), this, SLOT(updateSettings()));

--- a/app/gui/qt/widgets/settingswidget.h
+++ b/app/gui/qt/widgets/settingswidget.h
@@ -96,6 +96,7 @@ private:
     QCheckBox *show_line_numbers;
     QCheckBox *auto_indent_on_run;
     QCheckBox *full_screen;
+    QCheckBox* goto_buffer_shortcuts;
     QCheckBox *show_log;
     QCheckBox *show_cues;
     QCheckBox *show_buttons;

--- a/etc/doc/tutorial/B.02-Shortcut-Cheatsheet.md
+++ b/etc/doc/tutorial/B.02-Shortcut-Cheatsheet.md
@@ -23,6 +23,10 @@ Windows/Linux or *Cmd* on Mac):
 * `M-p`     - Toggle Preferences
 * `M-{`     - Switch buffer to the left
 * `M-}`     - Switch buffer to the right
+* `S-M-0`   - Switch to buffer 0
+* `S-M-1`   - Switch to buffer 1
+* ...
+* `S-M-9`   - Switch to buffer 9
 * `M-+`     - Increase text size of current buffer
 * `M--`     - Decrease text size of current buffer
 


### PR DESCRIPTION
With this, you can move to a tab directly using C-M-0 to C-M-9. I find this very useful to move quickly around the interface.