### PR TITLE
Add missing -y option to apt-get install

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -126,7 +126,7 @@ for:
     - # Remove old versions of CMake if pre-installed
     - sudo apt-get purge -y --auto-remove cmake
     - # Add Kitware's apt repo (for newest CMake)
-    - sudo apt-get install apt-transport-https ca-certificates gnupg software-properties-common wget
+    - sudo apt-get install -y apt-transport-https ca-certificates gnupg software-properties-common wget
     - wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | sudo apt-key add -
     - sudo apt-add-repository 'deb https://apt.kitware.com/ubuntu/ bionic main'
     - sudo apt-get update


### PR DESCRIPTION
If it is missing, builds might fail if the console asks for confirmation