### PR TITLE
Fix hang of starting up ruby tasks

### DIFF
--- a/app/server/ruby/lib/sonicpi/util.rb
+++ b/app/server/ruby/lib/sonicpi/util.rb
@@ -611,7 +611,7 @@ module SonicPi
 
     def register_process(pid)
       pid = spawn "'#{ruby_path}' '#{File.join(server_bin_path, 'task-register.rb')}' #{pid}"
-      Process.wait pid
+      Process.waitpid(pid, Process::WNOHANG)
     end
 
     def kill_and_deregister_process(pid)


### PR DESCRIPTION
Ruby server hang on startup during registering o2m and m2o tasks.
Unfortunately this does not fix #2393 but at least make sure that server started correctly, and as such looks like issues somewhere in the reporing of the server to GUI