### PR TITLE
Add missing flag for `apt-get install` which break the builds

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -126,7 +126,7 @@ for:
     - # Remove old versions of CMake if pre-installed
     - sudo apt-get purge -y --auto-remove cmake
     - # Add Kitware's apt repo (for newest CMake)
-    - sudo apt-get install apt-transport-https ca-certificates gnupg software-properties-common wget
+    - sudo apt-get install -y apt-transport-https ca-certificates gnupg software-properties-common wget
     - wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | sudo apt-key add -
     - sudo apt-add-repository 'deb https://apt.kitware.com/ubuntu/ bionic main'
     - sudo apt-get update


### PR DESCRIPTION
See https://ci.appveyor.com/project/samaaron/sonic-pi/builds/32898758/job/7i4f5vh75ugkootp for example