### PR TITLE
Resuscitate Freesound?

### DIFF
--- a/app/server/ruby/lib/sonicpi/lang/sound.rb
+++ b/app/server/ruby/lib/sonicpi/lang/sound.rb
@@ -14,6 +14,8 @@ require 'tmpdir'
 require 'fileutils'
 require 'thread'
 require 'net/http'
+require 'multi_json'
+require 'uri'
 require_relative "../blanknode"
 require_relative "../chainnode"
 require_relative "../fxnode"
@@ -4168,7 +4170,7 @@ If you wish your synth to work with Sonic Pi's automatic stereo sound infrastruc
         cache_dir = home_dir + '/freesound/'
         ensure_dir(cache_dir)
 
-        cache_file = cache_dir + "freesound-" + id.to_s + ".wav"
+        cache_file = cache_dir + "freesound-" + id.to_s + ".ogg"
 
         return cache_file if File.exists?(cache_file)
 
@@ -4176,21 +4178,35 @@ If you wish your synth to work with Sonic Pi's automatic stereo sound infrastruc
 
         in_thread(name: "download_freesound_#{id}".to_sym) do
           # API key borrowed from Overtone
-          apiURL = 'http://www.freesound.org/api/sounds/' + id.to_s + '/serve/?api_key=47efd585321048819a2328721507ee23'
+          apiURL = "http://freesound.org/apiv2/sounds/#{id}/?" +
+                   URI::encode_www_form(:fields => 'previews',
+                                        :token => '47efd585321048819a2328721507ee23')
 
           resp = Net::HTTP.get_response(URI(apiURL))
           case resp
           when Net::HTTPSuccess then
-            if not resp['Content-Disposition'] =~ /\.wav\"$/ then
-              raise 'Only WAV freesounds are supported, sorry!'
+            if resp['Content-Type'] != 'application/json' then
+              raise "Unexpected info content type for freesound #{id}: " + resp['Content-Type']
             end
 
-            open(cache_file, 'wb') do |file|
-              file.write(resp.body)
+            downloadURL = MultiJson.load(resp.body)['previews']['preview-hq-ogg']
+
+            resp = Net::HTTP.get_response(URI(downloadURL))
+            case resp
+            when Net::HTTPSuccess then
+              if resp['Content-Type'] != 'audio/ogg' then
+                raise "Unexpected download content type for freesound #{id}: " + resp['Content-Type']
+              end
+
+              open(cache_file, 'wb') do |file|
+                file.write(resp.body)
+              end
+              __info "Freesound #{id} loaded and ready to fire!"
+            else
+              __info "Failed to download freesound #{id}: " + resp.value
             end
-            __info "Freesound #{id} loaded and ready to fire!"
           else
-            __info "Failed to download freesound #{id}: " + resp.value
+            __info "Failed to get download info for freesound #{id}: " + resp.value
           end
         end
         return nil

--- a/app/server/ruby/lib/sonicpi/lang/sound.rb
+++ b/app/server/ruby/lib/sonicpi/lang/sound.rb
@@ -4034,47 +4034,6 @@ If you wish your synth to work with Sonic Pi's automatic stereo sound infrastruc
         __thread_locals.set(:sonic_pi_mod_sound_current_synth_name, name)
       end
 
-      def freesound_path(id)
-        cache_dir = home_dir + '/freesound/'
-        ensure_dir(cache_dir)
-
-        cache_file = cache_dir + "freesound-" + id.to_s + ".wav"
-
-        return cache_file if File.exists?(cache_file)
-
-        __info "Caching freesound #{id}..."
-
-        in_thread(name: "download_freesound_#{id}".to_sym) do
-          # API key borrowed from Overtone
-          apiURL = 'http://www.freesound.org/api/sounds/' + id.to_s + '/serve/?api_key=47efd585321048819a2328721507ee23'
-
-          resp = Net::HTTP.get_response(URI(apiURL))
-          case resp
-          when Net::HTTPSuccess then
-            if not resp['Content-Disposition'] =~ /\.wav\"$/ then
-              raise 'Only WAV freesounds are supported, sorry!'
-            end
-
-            open(cache_file, 'wb') do |file|
-              file.write(resp.body)
-            end
-            __info "Freesound #{id} loaded and ready to fire!"
-          else
-            __info "Failed to download freesound #{id}: " + resp.value
-          end
-        end
-        return nil
-      end
-      doc name:          :freesound_path,
-          introduced:    Version.new(2,1,0),
-          summary:       "Return local path for sound from freesound.org",
-          doc:           "Download and cache a sample by ID from freesound.org. Returns path as string if cached. If not cached, returns nil and starts a background thread to download the sample.",
-          args:          [[:id, :number]],
-          opts:          nil,
-          accepts_block: false,
-          examples:      ["
-puts freesound(250129)    # preloads a freesound and prints its local path, such as '/home/user/.sonic_pi/freesound/250129.wav'"]
-
       def scale_time_args_to_bpm!(args_h, info, force_add = true)
         # some of the args in args_h need to be scaled to match the
         # current bpm. Check in info to see if that's necessary and if
@@ -4204,6 +4163,47 @@ puts freesound(250129)    # preloads a freesound and prints its local path, such
       def sample_find_candidates(*args)
         @sample_loader.find_candidates(*args)
       end
+
+      def freesound_path(id)
+        cache_dir = home_dir + '/freesound/'
+        ensure_dir(cache_dir)
+
+        cache_file = cache_dir + "freesound-" + id.to_s + ".wav"
+
+        return cache_file if File.exists?(cache_file)
+
+        __info "Caching freesound #{id}..."
+
+        in_thread(name: "download_freesound_#{id}".to_sym) do
+          # API key borrowed from Overtone
+          apiURL = 'http://www.freesound.org/api/sounds/' + id.to_s + '/serve/?api_key=47efd585321048819a2328721507ee23'
+
+          resp = Net::HTTP.get_response(URI(apiURL))
+          case resp
+          when Net::HTTPSuccess then
+            if not resp['Content-Disposition'] =~ /\.wav\"$/ then
+              raise 'Only WAV freesounds are supported, sorry!'
+            end
+
+            open(cache_file, 'wb') do |file|
+              file.write(resp.body)
+            end
+            __info "Freesound #{id} loaded and ready to fire!"
+          else
+            __info "Failed to download freesound #{id}: " + resp.value
+          end
+        end
+        return nil
+      end
+      doc name:          :freesound_path,
+          introduced:    Version.new(2,1,0),
+          summary:       "Return local path for sound from freesound.org",
+          doc:           "Download and cache a sample by ID from freesound.org. Returns path as string if cached. If not cached, returns nil and starts a background thread to download the sample.",
+          args:          [[:id, :number]],
+          opts:          nil,
+          accepts_block: false,
+          examples:      ["
+puts freesound(250129)    # preloads a freesound and prints its local path, such as '/home/user/.sonic_pi/freesound/250129.wav'"]
 
       def freesound(id, *opts)
         path = freesound_path(id)

--- a/app/server/ruby/lib/sonicpi/lang/sound.rb
+++ b/app/server/ruby/lib/sonicpi/lang/sound.rb
@@ -4032,6 +4032,47 @@ If you wish your synth to work with Sonic Pi's automatic stereo sound infrastruc
         __thread_locals.set(:sonic_pi_mod_sound_current_synth_name, name)
       end
 
+      def __freesound_path(id)
+        cache_dir = home_dir + '/freesound/'
+        ensure_dir(cache_dir)
+
+        cache_file = cache_dir + "freesound-" + id.to_s + ".wav"
+
+        return cache_file if File.exists?(cache_file)
+
+        __info "Caching freesound #{id}..."
+
+        in_thread(name: "download_freesound_#{id}".to_sym) do
+          # API key borrowed from Overtone
+          apiURL = 'http://www.freesound.org/api/sounds/' + id.to_s + '/serve/?api_key=47efd585321048819a2328721507ee23'
+
+          resp = Net::HTTP.get_response(URI(apiURL))
+          case resp
+          when Net::HTTPSuccess then
+            if not resp['Content-Disposition'] =~ /\.wav\"$/ then
+              raise 'Only WAV freesounds are supported, sorry!'
+            end
+
+            open(cache_file, 'wb') do |file|
+              file.write(resp.body)
+            end
+            __info "Freesound #{id} loaded and ready to fire!"
+          else
+            __info "Failed to download freesound #{id}: " + resp.value
+          end
+        end
+        return nil
+      end
+      #        doc name:          :freesound_path,
+      #            introduced:    Version.new(2,1,0),
+      #            summary:       "Return local path for sound from freesound.org",
+      #            doc:           "Download and cache a sample by ID from freesound.org. Returns path as string if cached. If not cached, returns nil and starts a background thread to download the sample.",
+      #            args:          [[:id, :number]],
+      #            opts:          nil,
+      #            accepts_block: false,
+      #            examples:      ["
+      # puts freesound(250129)    # preloads a freesound and prints its local path, such as '/home/user/.sonic_pi/freesound/250129.wav'"]
+
       def scale_time_args_to_bpm!(args_h, info, force_add = true)
         # some of the args in args_h need to be scaled to match the
         # current bpm. Check in info to see if that's necessary and if
@@ -4161,6 +4202,41 @@ If you wish your synth to work with Sonic Pi's automatic stereo sound infrastruc
       def sample_find_candidates(*args)
         @sample_loader.find_candidates(*args)
       end
+
+      def __freesound(id, *opts)
+        path = __freesound_path(id)
+        arg_h = resolve_synth_opts_hash_or_array(opts)
+        fallback = arg_h[:fallback]
+
+        if path
+          sample path
+        elsif fallback
+          raise "Freesound fallback must be a symbol" unless fallback.is_a? Symbol
+          __info "Freesound #{id} not yet loaded, playing #{fallback}"
+          sample fallback
+        else
+          __info "Freesound #{id} not yet loaded, skipping"
+        end
+
+      end
+      #        doc name:          :freesound,
+      #            introduced:    Version.new(2,1,0),
+      #            summary:       "Play sample from freesound.org",
+      #            doc:           "Fetch from cache (or download then cache) a sample by ID from freesound.org, and then play it.",
+      #            args:          [[:id, :number]],
+      #            opts:          {:fallback => "Symbol representing built-in sample to play if the freesound id isn't yet downloaded"},
+      #            accepts_block: false,
+      #            examples:      ["
+      # freesound(250129)  # takes time to download the first time, but then the sample is cached locally
+      # ",
+      # "
+      # loop do
+      #   sample freesound(27130)
+      #   sleep sample_duration(27130)
+      # end
+      # "
+      # ]
+
     end
 
   end

--- a/app/server/ruby/lib/sonicpi/lang/sound.rb
+++ b/app/server/ruby/lib/sonicpi/lang/sound.rb
@@ -4224,7 +4224,7 @@ If you wish your synth to work with Sonic Pi's automatic stereo sound infrastruc
           opts:          nil,
           accepts_block: false,
           examples:      ["
-puts freesound(250129)    # preloads a freesound and prints its local path, such as '/home/user/.sonic_pi/freesound/250129.wav'"]
+puts freesound_path(250129)    # preloads a freesound and prints its local path, such as '/home/user/.sonic_pi/freesound/250129.ogg'"]
 
       def freesound(id, *opts)
         path = freesound_path(id)
@@ -4254,7 +4254,7 @@ freesound(250129)  # takes time to download the first time, but then the sample 
 ",
 "
 loop do
-  sample freesound(27130)
+  freesound 27130
   sleep sample_duration(27130)
 end
 "

--- a/app/server/ruby/lib/sonicpi/lang/sound.rb
+++ b/app/server/ruby/lib/sonicpi/lang/sound.rb
@@ -4166,6 +4166,11 @@ If you wish your synth to work with Sonic Pi's automatic stereo sound infrastruc
         @sample_loader.find_candidates(*args)
       end
 
+      def use_freesound_token(token)
+        raise ArgumentError, "freesound token should be a string." unless token.is_a? String
+        __thread_locals.set(:sonic_pi_freesound_token, token)
+      end
+
       def freesound_path(id)
         cache_dir = home_dir + '/freesound/'
         ensure_dir(cache_dir)
@@ -4177,10 +4182,10 @@ If you wish your synth to work with Sonic Pi's automatic stereo sound infrastruc
         __info "Caching freesound #{id}..."
 
         in_thread(name: "download_freesound_#{id}".to_sym) do
-          # API key borrowed from Overtone
+          token = __thread_locals.get(:sonic_pi_freesound_token)
           apiURL = "http://freesound.org/apiv2/sounds/#{id}/?" +
                    URI::encode_www_form(:fields => 'previews',
-                                        :token => '47efd585321048819a2328721507ee23')
+                                        :token => token)
 
           resp = Net::HTTP.get_response(URI(apiURL))
           case resp

--- a/app/server/ruby/lib/sonicpi/lang/sound.rb
+++ b/app/server/ruby/lib/sonicpi/lang/sound.rb
@@ -2195,6 +2195,8 @@ load_sample dir, /[Bb]ar/ # loads first sample which matches regex /[Bb]ar/ in \
           info, cached = @mod_sound_studio.load_sample(path)
           __info "Loaded sample #{unify_tilde_dir(path).inspect}" unless cached
           return info
+        when Numeric
+          freesound(path)
         else
           raise "Unknown sample description: #{path.inspect}\n expected a string containing a path."
         end
@@ -4032,7 +4034,7 @@ If you wish your synth to work with Sonic Pi's automatic stereo sound infrastruc
         __thread_locals.set(:sonic_pi_mod_sound_current_synth_name, name)
       end
 
-      def __freesound_path(id)
+      def freesound_path(id)
         cache_dir = home_dir + '/freesound/'
         ensure_dir(cache_dir)
 
@@ -4063,15 +4065,15 @@ If you wish your synth to work with Sonic Pi's automatic stereo sound infrastruc
         end
         return nil
       end
-      #        doc name:          :freesound_path,
-      #            introduced:    Version.new(2,1,0),
-      #            summary:       "Return local path for sound from freesound.org",
-      #            doc:           "Download and cache a sample by ID from freesound.org. Returns path as string if cached. If not cached, returns nil and starts a background thread to download the sample.",
-      #            args:          [[:id, :number]],
-      #            opts:          nil,
-      #            accepts_block: false,
-      #            examples:      ["
-      # puts freesound(250129)    # preloads a freesound and prints its local path, such as '/home/user/.sonic_pi/freesound/250129.wav'"]
+      doc name:          :freesound_path,
+          introduced:    Version.new(2,1,0),
+          summary:       "Return local path for sound from freesound.org",
+          doc:           "Download and cache a sample by ID from freesound.org. Returns path as string if cached. If not cached, returns nil and starts a background thread to download the sample.",
+          args:          [[:id, :number]],
+          opts:          nil,
+          accepts_block: false,
+          examples:      ["
+puts freesound(250129)    # preloads a freesound and prints its local path, such as '/home/user/.sonic_pi/freesound/250129.wav'"]
 
       def scale_time_args_to_bpm!(args_h, info, force_add = true)
         # some of the args in args_h need to be scaled to match the
@@ -4203,8 +4205,8 @@ If you wish your synth to work with Sonic Pi's automatic stereo sound infrastruc
         @sample_loader.find_candidates(*args)
       end
 
-      def __freesound(id, *opts)
-        path = __freesound_path(id)
+      def freesound(id, *opts)
+        path = freesound_path(id)
         arg_h = resolve_synth_opts_hash_or_array(opts)
         fallback = arg_h[:fallback]
 
@@ -4219,25 +4221,23 @@ If you wish your synth to work with Sonic Pi's automatic stereo sound infrastruc
         end
 
       end
-      #        doc name:          :freesound,
-      #            introduced:    Version.new(2,1,0),
-      #            summary:       "Play sample from freesound.org",
-      #            doc:           "Fetch from cache (or download then cache) a sample by ID from freesound.org, and then play it.",
-      #            args:          [[:id, :number]],
-      #            opts:          {:fallback => "Symbol representing built-in sample to play if the freesound id isn't yet downloaded"},
-      #            accepts_block: false,
-      #            examples:      ["
-      # freesound(250129)  # takes time to download the first time, but then the sample is cached locally
-      # ",
-      # "
-      # loop do
-      #   sample freesound(27130)
-      #   sleep sample_duration(27130)
-      # end
-      # "
-      # ]
-
+      doc name:          :freesound,
+          introduced:    Version.new(2,1,0),
+          summary:       "Play sample from freesound.org",
+          doc:           "Fetch from cache (or download then cache) a sample by ID from freesound.org, and then play it.",
+          args:          [[:id, :number]],
+          opts:          {:fallback => "Symbol representing built-in sample to play if the freesound id isn't yet downloaded"},
+          accepts_block: false,
+          examples:      ["
+freesound(250129)  # takes time to download the first time, but then the sample is cached locally
+",
+"
+loop do
+  sample freesound(27130)
+  sleep sample_duration(27130)
+end
+"
+]
     end
-
   end
 end

--- a/etc/doc/tutorial/03.6-External-Samples.md
+++ b/etc/doc/tutorial/03.6-External-Samples.md
@@ -45,3 +45,20 @@ sample "/Users/sam/Desktop/my-sound.wav", rate: 0.5, amp: 0.3
 sample "C:/Users/sam/Desktop/my-sound.wav", rate: 0.5, amp: 0.3
 ```
 
+## Freesound Support
+
+Another way to get the ability to experiment with new sounds whilst keeping
+code portability is to use the [Freesound](http:freesound.org)
+support. http://freesound.org is a website which allows people to upload
+and share their samples. Each sample uploaded gets a special number
+(kind of like a phone number) which you can use to dial up that sample
+from Sonic Pi. The only drawback is that you need to have internet
+access for it to work.
+
+If you currently have internet access, try it for yourself:
+
+```
+freesound 27130
+```
+
+You might have to wait a moment.


### PR DESCRIPTION
This is just #2360 rebased onto the ~~new main~~ dev branch. I've copied the description and my comments below.

---

I was poking around the [Freesound API](https://freesound.org/docs/api/resources_apiv2.html#sound-instance), and realised it should be possible to make it work again in Sonic Pi.

I reverted the commits that removed Freesound support, and then modified the downloading code to use the v2 API to get the sample information. In that info there are links to the previews, so I download the high quality .ogg preview. This is all done with just an API token for authentication.

To show how/that it works, I made a quick [screen cast](https://vimeo.com/411625852) that shows it downloading and caching a sample on the first run, then playing it once it's cached.

There are a number of remaining issues to be ironed out, but I think there's enough here to prove that it can be made to work. The things I see that need to be sorted out are:

- The API (in Sonic Pi) needs rethinking. You used to be able to pass an integer to `sample` to play the freesound sample with that ID, but integers now have a different meaning, so you have to use `sample freesound_path(1234)`, which is a bit verbose.
Maybe it should just be renamed `freesound` (and we do away with the current `freesound` function)?
- For simplicity, I just made it download the (high quality) ogg preview, but I think it would be possible to download the original sample when it is in a supported format (wav or flac). However it would then need some way to keep track of which format a particular sample is in so it knows what the cached sample file is called (or it could look for `nnn.wav`, `nnn.flac` and `nnn.ogg` and use the first one it finds?)
- I added a `use_freesound_token` function to set the token to authenticate with freesound because the terms of use don't allow publishing the tokens. Users could sign up for a token and set it in their `init.rb` file. But there could also be a default token compiled into release binaries, as long as it's not easily accessible by users that would be allowed (see [here](https://groups.google.com/forum/#!searchin/freesound-api/open$20source%7Csort:date/freesound-api/Ott9TX7bty4/oxOPWNCCAAAJ)).
- It should really use https, but that didn't work. I think it just needs the openssl gem to be added but I wasn't sure how to do that.

@samaaron what are your thoughts on this?

---

I realised that since Ruby is not compiled, you can't really hide an API token in the release binary, so it might not be so easy to comply with the Freesound API terms. I guess it might be OK if the downloading is moved into a separate (compiled) binary that is called from the Ruby code?

---

@samaaron is this something that you would want back in Sonic Pi? I seem to remember reading that it was originally removed because the Freesound API changed so that token auth was no longer possible (but I don't remember where I saw that, so maybe I'm misremembering), and that now seems to no longer be the case.
From my reading it seems that as long as the token is not visible in cleartext it should comply with the Freesound terms. That means that the component that actually builds the url and does the download would have to be moved to a compiled language, with Sonic Pi's Freesound token injected at build time. If I implement something like that, would this be acceptable to merge into Sonic Pi?