### PR TITLE
[erlang] Handle more than one osc cmd in bundle

### DIFF
--- a/app/server/erlang/sonic_pi_server/src/osc/osc_tests.erl
+++ b/app/server/erlang/sonic_pi_server/src/osc/osc_tests.erl
@@ -39,7 +39,7 @@ prepp(X) ->
 
 test3() ->
     %% use default ports from .app file
-    application:load(pi_server),
+    application:load(?APPLICATION),
     APIPort = application:get_env(?APPLICATION, api_port, undefined),
     OSCInPort = application:get_env(?APPLICATION, in_port, undefined),
     FwPort = 6000,


### PR DESCRIPTION
osc:decode_bundle/1 may return a list of more than one osc cmds but pi_server:do_bundle/3 only handled a list of one item. This has worked if sonic-pi only sends bundles with one item.