### PR TITLE
Issue #2364 - Lissajous not rendered correctly

### DIFF
--- a/app/gui/qt/visualizer/scope.cpp
+++ b/app/gui/qt/visualizer/scope.cpp
@@ -602,15 +602,12 @@ void Scope::DrawLissajous(const ProcessedAudio& audio, QPainter& painter, Panel&
     float scale = std::min(xScale, yScale);
 
     QPoint center = panel.rcGraph.center();
-
-    // First point at 0
-    panel.wavePoints.resize(LissajousSamples + 1);
-    panel.wavePoints[0] = center;
+    panel.wavePoints.resize(LissajousSamples);
     for (int sample = 0; sample < LissajousSamples; sample++)
     {
         auto left = audio.m_samples[0][FrameSamples - LissajousSamples + sample];
         auto right = audio.m_samples[1][FrameSamples - LissajousSamples + sample];
-        panel.wavePoints[sample + 1] = center + QPoint(left * xScale, right * yScale);
+        panel.wavePoints[sample] = center + QPoint(left * xScale, right * yScale);
     }
     painter.setPen(panel.pen);
     painter.drawPolyline(&panel.wavePoints[0], int(panel.wavePoints.size()));

--- a/app/gui/qt/win-prebuild.bat
+++ b/app/gui/qt/win-prebuild.bat
@@ -34,5 +34,5 @@ cd ..\..\server\erlang\sonic_pi_server
 ..\..\native\erlang\bin\erl.exe -make
 cd %~dp0
 cd ..\..\server\erlang\sonic_pi_server
-copy /Y /R src\sonic_pi_server.app.src ebin\sonic_pi_server.app
+xcopy /Y /R src\sonic_pi_server.app.src .\ebin\sonic_pi_server.app
 cd %~dp0


### PR DESCRIPTION
Fix Lissajous scope: don't start in the center
Fix win-prebuild to properly copy the erlang file