### PR TITLE
Ensure lib files are writable on mac

### DIFF
--- a/app/gui/qt/mac-build-app
+++ b/app/gui/qt/mac-build-app
@@ -52,6 +52,9 @@ mkdir build
 cp -R "$SP_APP" build/
 cd build
 
+# Ensure all library files are writable before modifying them
+find "$SP_APP" -name '*.dylib' -exec chmod u+w {} \;
+
 # Make stand-alone Qt Mac App
 # Pulls in Qt internally and
 # futzes with shared lib paths


### PR DESCRIPTION
When building I ran into the following error:
```
+ /usr/local/Cellar/qt/5.15.0/bin/macdeployqt 'Sonic Pi.app' /usr/local/Cellar/qt/5.15.0
ERROR: "error: /Library/Developer/CommandLineTools/usr/bin/install_name_tool: can't open input file: Sonic Pi.app/Contents/MacOS/libqscintilla2_qt5.15.0.0.dylib for writing (Permission denied)\nerror: /Library/Developer/CommandLineTools/usr/bin/install_name_tool: can't lseek to offset: 0 in file: Sonic Pi.app/Contents/MacOS/libqscintilla2_qt5.15.0.0.dylib for writing (Bad file descriptor)\nerror: /Library/Developer/CommandLineTools/usr/bin/install_name_tool: can't write new headers in file: Sonic Pi.app/Contents/MacOS/libqscintilla2_qt5.15.0.0.dylib (Bad file descriptor)\nerror: /Library/Developer/CommandLineTools/usr/bin/install_name_tool: can't close written on input file: Sonic Pi.app/Contents/MacOS/libqscintilla2_qt5.15.0.0.dylib (Bad file descriptor)\n"
ERROR: ""
ERROR: "error: /Library/Developer/CommandLineTools/usr/bin/install_name_tool: can't open input file: Sonic Pi.app/Contents/MacOS/libqscintilla2_qt5.15.0.0.dylib for writing (Permission denied)\nerror: /Library/Developer/CommandLineTools/usr/bin/install_name_tool: can't lseek to offset: 0 in file: Sonic Pi.app/Contents/MacOS/libqscintilla2_qt5.15.0.0.dylib for writing (Bad file descriptor)\nerror: /Library/Developer/CommandLineTools/usr/bin/install_name_tool: can't write new headers in file: Sonic Pi.app/Contents/MacOS/libqscintilla2_qt5.15.0.0.dylib (Bad file descriptor)\nerror: /Library/Developer/CommandLineTools/usr/bin/install_name_tool: can't close written on input file: Sonic Pi.app/Contents/MacOS/libqscintilla2_qt5.15.0.0.dylib (Bad file descriptor)\n"
ERROR: ""
...
```
It turned out that `libqscintilla2_qt5.15.0.0.dylib` was not writable, and modifying the permissions fixed it.