### PR TITLE
I18n - give list items in translated files bullets/numbers

### DIFF
--- a/app/server/ruby/bin/i18n-tool.rb
+++ b/app/server/ruby/bin/i18n-tool.rb
@@ -80,19 +80,19 @@ def handle_entry(msgid, filename, line, flags = [])
 end
 
 
-def convert_element(filename, el, bullet = nil) case el.type
-
+def convert_element(filename, el, bullet = nil)
+  case el.type
   when :root, :li, :ul, :ol
     i = 0
-    while i < el.children.count do
-      case el.type
-      when :ul
-        b = '*'
-      when :ol
-        b = "#{i+1}."
-      else
-        b = nil
-      end
+    while i < el.children.count
+      b = case el.type
+          when :ul
+            '*'
+          when :ol
+            "#{i + 1}."
+          when :li
+            bullet
+          end
       convert_element(filename, el.children[i], b)
       i += 1
     end


### PR DESCRIPTION
Previously, the i18n-tool.rb script may have already been doing this and then
stopped working at some point, or it may never have worked, I'm not sure.

The reason it was not working prior to this change is that it was assumed, when
processing 'p' elements, that a variable ('bullet') may be present containing a
bullet or number to assign to this 'p' as a list item child.
However, no such variable value was ever passed through to the 'p' processing
code - it was always a value of 'nil', so bullets or numbers were never added to
the translated text.

Now, however, it will correctly output list items with bullets or numbers
as appropriate when creating translated files from the English versions.

Testing was carried out by comparing the translated markdown files for the Spanish locale between the release version of **3.2**, and my local version, **3.3.0-dev** with the change applied, and discounting minor changes in translation wording. (Aside from these, the only changes were to add the missing bullets or numbers to list items).

Example of existing output **(from Sonic Pi 3.2)**:
![before2](https://user-images.githubusercontent.com/10395940/84910010-f22a9680-b0e8-11ea-8b44-af8960127200.png)
Example of fixed output **(from Sonic Pi 3.3.0-dev)**:
![after2](https://user-images.githubusercontent.com/10395940/84910165-1edeae00-b0e9-11ea-9b1b-e3172da6141f.png)
