### PR TITLE
[Server] Show filepath in errors

### DIFF
--- a/app/server/ruby/bin/sonic-pi-server.rb
+++ b/app/server/ruby/bin/sonic-pi-server.rb
@@ -346,7 +346,7 @@ begin
 
   # read in init.rb if exists
   if File.exists?(init_path)
-    sp.__spider_eval(File.read(init_path), silent: true)
+    sp.__spider_eval(File.read(init_path), type: :file, name: init_path, silent: true)
   else
     STDOUT.puts "Could not find init.rb file: #{init_path} "
   end
@@ -375,7 +375,7 @@ register_api = lambda do |server|
   server.add_method("/run-code") do |args|
     gui_id = args[0]
     code = args[1].force_encoding("utf-8")
-    sp.__spider_eval code
+    sp.__spider_eval(code, type: :eval, name: "osc-/run-code")
   end
 
   server.add_method("/save-and-run-buffer") do |args|
@@ -384,7 +384,7 @@ register_api = lambda do |server|
     code = args[2].force_encoding("utf-8")
     workspace = args[3]
     sp.__save_buffer(buffer_id, code)
-    sp.__spider_eval code, {workspace: workspace}
+    sp.__spider_eval(code, type: :workspace, name: workspace)
   end
 
   server.add_method("/save-buffer") do |args|

--- a/app/server/ruby/lib/sonicpi/lang/core.rb
+++ b/app/server/ruby/lib/sonicpi/lang/core.rb
@@ -463,7 +463,7 @@ end
       def run_file(path)
         path = File.expand_path(path.to_s)
         raise IOError, "Unable to run file - no file found with path: #{path}" unless File.exist?(path)
-        __spider_eval(File.read(path))
+        __spider_eval(File.read(path), type: :file, name: path)
       end
       doc name:           :run_file,
           introduced:     Version.new(2,11,0),
@@ -477,7 +477,7 @@ end
 run_file \"~/path/to/sonic-pi-code.rb\" #=> will run the contents of this file"]
 
       def run_code(code)
-        __spider_eval(code.to_s)
+        __spider_eval(code.to_s, type: :eval, name: "run_code")
       end
       doc name:           :run_code,
           introduced:     Version.new(2,11,0),
@@ -4785,6 +4785,9 @@ assert_similar(4.9999999999, 5.0) #=> True"
       def load_buffer(path)
         path = File.expand_path(path.to_s)
         raise IOError, "Unable to load buffer - no file found with path: #{path}" unless File.exist?(path)
+
+        raise RuntimeError, "Unable to retrieve the current workspace. Current job info: #{__current_job_info}" unless __current_job_info[:workspace]
+
         buf = __current_job_info[:workspace]
         __info "loading #{buf} with #{path}"
         __replace_buffer(buf, File.read(path))

--- a/app/server/ruby/lib/sonicpi/runtime.rb
+++ b/app/server/ruby/lib/sonicpi/runtime.rb
@@ -55,7 +55,6 @@ module SonicPi
     def load_snippets(path=snippets_path, quiet=false)
       path = File.expand_path(path)
       Dir["#{path}/**/*.sps"].each do |p|
-
         lines = File.readlines(p)
         key = nil
         completion = ""
@@ -315,14 +314,8 @@ module SonicPi
       info = __current_job_info
       err_msg.gsub(/for #<SonicPiSpiderUser[a-z0-9:]+>/, '')
       res = ""
-      w = info[:workspace]
+      w = info[:display_name]
       if line != -1
-
-        # TODO: Remove this hack when we have projects
-        w = normalise_buffer_name(w)
-        w = "buffer " + w
-        # TODO: end of hack
-
         res = res + "[#{w}, line #{line}]"
       else
         res = res + "[#{w}]"
@@ -792,10 +785,12 @@ module SonicPi
       firstline = 1
       firstline -= code.lines.to_a.take_while{|l| l.include? "#__nosave__"}.count
       start_t_prom = Promise.new
-      info[:workspace] = 'eval' unless info[:workspace]
+      
+      display_name = get_spider_eval_display_name(info[:type], info[:name])
 
-      info[:workspace].freeze
+      info[:name].freeze
       info.freeze
+      display_name.freeze
 
       job_in_thread = nil
       job = Thread.new do
@@ -827,7 +822,7 @@ module SonicPi
           code = PreParser.preparse(code, SonicPi::Lang::Core.vec_fns)
 
           job_in_thread = in_thread seed: 0 do
-            eval(code, nil, info[:workspace], firstline)
+            eval(code, nil, info[:name], firstline)
           end
           __schedule_delayed_blocks_and_messages!
         rescue Stop => e
@@ -841,13 +836,7 @@ module SonicPi
             if line
               line = line.to_i
 
-              # TODO: Remove this hack when we have projects
-              w = info[:workspace]
-              w = normalise_buffer_name(w)
-              w = "buffer #{w}"
-              # TODO: end of hack
-
-              err_msg = "[#{w}, line #{line}] \n #{message}"
+              err_msg = "[#{display_name}, line #{line}] \n #{message}"
               error_line = code.lines.to_a[line - firstline] ||  ""
             else
               line = -1
@@ -1277,6 +1266,31 @@ module SonicPi
       res = RBeautify.beautify_string :ruby, source
       res = res.gsub(') ___SONIC_PI_RND_TMP_PLACEHOLDER___ /', ')/')
       res = res.gsub('] ___SONIC_PI_SQR_TMP_PLACEHOLDER___ /', ']/')
+    end
+      
+    def get_spider_eval_display_name(type, name)
+       case info[:type]
+         when :workspace
+           "buffer #{normalise_buffer_name(name)}"
+         when :file
+           name
+         when :eval
+           normalise_eval_name(name)
+       end
+    end
+      
+    def normalise_eval_name(name)
+      if (name.nil?)
+        return "unnamed eval"
+      end
+      
+      norm = case name
+        when "osc-/run-code"
+          "eval"
+        else
+          name
+      end
+      return norm
     end
 
     def normalise_buffer_name(name)

--- a/app/server/ruby/lib/sonicpi/runtime.rb
+++ b/app/server/ruby/lib/sonicpi/runtime.rb
@@ -788,6 +788,7 @@ module SonicPi
 
       display_name = get_job_display_name(info[:type], info[:name])
 
+      info[:name].freeze
       info.freeze
       display_name.freeze
 

--- a/app/server/ruby/lib/sonicpi/runtime.rb
+++ b/app/server/ruby/lib/sonicpi/runtime.rb
@@ -314,7 +314,7 @@ module SonicPi
       info = __current_job_info
       err_msg.gsub(/for #<SonicPiSpiderUser[a-z0-9:]+>/, '')
       res = ""
-      w = info[:display_name]
+      w = get_job_display_name(info[:type], info[:name])
       if line != -1
         res = res + "[#{w}, line #{line}]"
       else
@@ -785,10 +785,9 @@ module SonicPi
       firstline = 1
       firstline -= code.lines.to_a.take_while{|l| l.include? "#__nosave__"}.count
       start_t_prom = Promise.new
-      
-      display_name = get_spider_eval_display_name(info[:type], info[:name])
 
-      info[:name].freeze
+      display_name = get_job_display_name(info[:type], info[:name])
+
       info.freeze
       display_name.freeze
 
@@ -1267,8 +1266,8 @@ module SonicPi
       res = res.gsub(') ___SONIC_PI_RND_TMP_PLACEHOLDER___ /', ')/')
       res = res.gsub('] ___SONIC_PI_SQR_TMP_PLACEHOLDER___ /', ']/')
     end
-      
-    def get_spider_eval_display_name(type, name)
+
+    def get_job_display_name(type, name)
        case type
          when :workspace
            "buffer #{normalise_buffer_name(name)}"

--- a/app/server/ruby/lib/sonicpi/runtime.rb
+++ b/app/server/ruby/lib/sonicpi/runtime.rb
@@ -1269,7 +1269,7 @@ module SonicPi
     end
       
     def get_spider_eval_display_name(type, name)
-       case info[:type]
+       case type
          when :workspace
            "buffer #{normalise_buffer_name(name)}"
          when :file


### PR DESCRIPTION
## Description
Includes the file path in error messages when an error occurs in an external file (via run_file), and 
Should hopefully fix #2336
Fixes a server crashing bug in the original PR (#2470)

## Testing checklist
- [x] Sonic Pi boots without errors
- [x] run_file: Error message shows the external file's path
- [ ] code in buffer: Error message shows the buffer no.

## Screenshots (if appropriate):
 
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
Bug fix (non-breaking change which fixes an issue)