### PR TITLE
Windows MSI installer: make install directory configurable

### DIFF
--- a/install/windows/wix/sonic-pi-beta.wxs
+++ b/install/windows/wix/sonic-pi-beta.wxs
@@ -56,13 +56,20 @@
         </Feature>
 
         <UI Id="UserInterface">
-            <UIRef Id="WixUI_Minimal" />
+            <UIRef Id="WixUI_InstallDir" />
             <Property Id="WIXUI_INSTALLDIR" Value="TARGETDIR" />
+
+            <DialogRef Id="BrowseDlg"/>
+            <DialogRef Id="DiskCostDlg"/>
+            <DialogRef Id="InstallDirDlg"/>
+            <DialogRef Id="InvalidDirDlg"/>
+
             <DialogRef Id="ProgressDlg" />
             <DialogRef Id="ErrorDlg" />
             <DialogRef Id="FilesInUse" />
             <DialogRef Id="FatalError" />
             <DialogRef Id="UserExit" />
+            
             <Publish Dialog="ExitDialog" Control="Finish" Event="DoAction" Value="LaunchApplication" Order="999">WIXUI_EXITDIALOGOPTIONALCHECKBOX = 1 and NOT Installed</Publish>
             <Publish Dialog="WelcomeDlg" Control="Next" Event="EndDialog" Value="Return" Order="2"></Publish>
         </UI>

--- a/install/windows/wix/sonic-pi.wxs
+++ b/install/windows/wix/sonic-pi.wxs
@@ -56,13 +56,20 @@
         </Feature>
 
         <UI Id="UserInterface">
-            <UIRef Id="WixUI_Minimal" />
+            <UIRef Id="WixUI_InstallDir" />
             <Property Id="WIXUI_INSTALLDIR" Value="TARGETDIR" />
+
+            <DialogRef Id="BrowseDlg"/>
+            <DialogRef Id="DiskCostDlg"/>
+            <DialogRef Id="InstallDirDlg"/>
+            <DialogRef Id="InvalidDirDlg"/>
+
             <DialogRef Id="ProgressDlg" />
             <DialogRef Id="ErrorDlg" />
             <DialogRef Id="FilesInUse" />
             <DialogRef Id="FatalError" />
             <DialogRef Id="UserExit" />
+
             <Publish Dialog="ExitDialog" Control="Finish" Event="DoAction" Value="LaunchApplication" Order="999">WIXUI_EXITDIALOGOPTIONALCHECKBOX = 1 and NOT Installed</Publish>
             <Publish Dialog="WelcomeDlg" Control="Next" Event="EndDialog" Value="Return" Order="2"></Publish>
         </UI>


### PR DESCRIPTION
(Hopefully) allows the user to choose the installation directory instead of always installing in Program Files.
Closes issue #2782 and discussion #2774 

I'm not familiar with WIX or how it works, but I found this: https://wixtoolset.org/documentation/manual/v3/wixui/dialog_reference/wixui_installdir.html which is what I've based this PR from.
This has not been tested yet. Testing is greatly appreciated!