### PR TITLE
Accessibility focus change for startup

### DIFF
--- a/app/gui/qt/mainwindow.cpp
+++ b/app/gui/qt/mainwindow.cpp
@@ -212,6 +212,7 @@ MainWindow::MainWindow(QApplication& app, QSplashScreen* splash)
         timer->start(1000);
         emit settingsChanged();
         splashClose();
+        focusEditor();
         showWindow();
         app.processEvents();
         std::cout << "[GUI] - boot sequence completed." << std::endl;


### PR DESCRIPTION
This changes the focus to the code edit window at startup for
ppeople using assistive software.  It should not affect those who are not
using accessibility technologies.