### PR TITLE
GitHub - add issue and pull request templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/FEATURE-REQUEST-FORM.yml
+++ b/.github/ISSUE_TEMPLATE/FEATURE-REQUEST-FORM.yml
@@ -1,0 +1,42 @@
+name: A feature request
+description: Describe a new feature or enhancement that you would like to see in Sonic Pi.
+labels: ["Feature Request"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Hello! Thank you for your interest in improving Sonic Pi.
+
+        The core Sonic Pi development team is fairly small and made up of volunteers (with the exception of Sam Aaron, who relies much on crowd-funding) so the more help we can receive to manage your ideas the better - help us to help you! Please follow the checklist below - that way you might not even need to raise a feature request after all :smile:
+  - type: checkboxes
+    id: prerequisites
+    attributes:
+      options:
+        - label: I've searched the [Sonic Pi features project](https://github.com/orgs/sonic-pi-net/projects/1) for similar existing feature requests
+          required: true
+        - label: To the best of my knowledge, this feature would fit within the [project guidelines](CONTRIBUTING.md#project-and-development-process-guidelines) 
+          required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: Feature Description
+      description: |
+        - Add as much detail as you can about your idea.
+        - What problem would this feature solve, or benefit would it provide? 
+        - If it relates to new functions or changes in the language, give small examples of what you might write in Sonic Pi. Please use code formatting for the examples - if you're not sure how, please see the 'Code' examples at GitHub's [Mastering Markdown examples](https://guides.github.com/features/mastering-markdown/#examples).
+        - You can drag related images into the description if useful - (for example, showing the design or layout of potential features or enhancements in the GUI).
+      placeholder: "Example: I think a foo feature is useful for Sonic Pi because..."
+    validations:
+      required: true
+  - type: textarea
+    id: other-details
+    attributes:
+      label: Other Details
+      description: |
+        Feel free to provide any other relevant information about the feature if you have it, or can get it, such as:
+        - Places where you have seen similar features being used
+        - Ideas about possible ways to build the feature
+        - Etc...
+      placeholder: "Example: We could build the foo feature by adding a bar to the baz panel..."
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/RUNNING-ISSUE-FORM.yml
+++ b/.github/ISSUE_TEMPLATE/RUNNING-ISSUE-FORM.yml
@@ -1,0 +1,103 @@
+name: A problem while Sonic Pi is running 
+description: Sonic Pi starts up, but behaves unexpectedly during use
+title: ""
+labels: ["triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Hello! Thank you for wanting to raise an issue for us, so that we know what's not working for you.
+
+        Sorry you're having issues while Sonic Pi is running! We're always working to improve its behaviour.
+
+        The core Sonic Pi development team is fairly small and made up of volunteers (with the exception of Sam Aaron, who relies much on crowd-funding) so the more help we can receive to manage, troubleshoot and hopefully fix your issues for you the better - help us to help you! Please follow the checklist below - that way you might not even need to raise an issue after all :smile:
+  - type: checkboxes
+    id: read-troubleshooting-guide
+    attributes:
+      options:
+        - label: I've read the [Sonic Pi troubleshooting guide](https://github.com/sonic-pi-net/sonic-pi/wiki/Troubleshooting-Issues) and followed its suggestions where relevant
+          required: true
+  - type: dropdown
+    id: sonic-pi-version
+    attributes:
+      label: Sonic Pi Version
+      description: What version of Sonic Pi were you running?
+      options:
+        - v4.0-Beta2
+        - v4.0-Beta1
+        - v3.3.1
+        - v3.3
+        - v3.2.2
+        - v3.2.1
+        - v3.2
+        - v3.1
+        - v3.0.1
+        - v3.0
+        - v2.11.1
+        - v2.11
+        - v2.10
+        - v2.9
+        - v2.8
+        - v2.7
+        - v2.6
+        - v2.5
+        - v2.4
+        - v2.3
+        - v2.2
+        - v2.1.1
+        - v2.1
+        - v2.0.1
+        - v2.0
+    validations:
+      required: true
+  - type: input
+    id: os-version
+    attributes:
+      label: Operating System
+      description: "What Operating System (and which version) were you using?"
+      placeholder: "Example: Windows 10"
+    validations:
+      required: true
+  - type: textarea
+    id: repro-steps
+    attributes:
+      label: What were you doing when Sonic Pi behaved unexpectedly?
+      description: |
+        You can drag related images into the description if you like.
+        If you were trying to run some code when Sonic Pi behaved unexpectedly, please share a _small_ code example here that demonstrates the unexpected behaviour. (The simpler it is the better).
+        Please use code formatting for the example - if you're not sure how, please see the 'Code' examples at GitHub's [Mastering Markdown examples](https://guides.github.com/features/mastering-markdown/#examples).
+      placeholder: "Example: I typed the following code into Sonic Pi, and then hit 'Run': `play foobar`"
+    validations:
+      required: true
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: |
+        You can drag related images into the description if you like.
+        If Sonic Pi gave you an error, please share it below along with the stacktrace so that we can use it to investigate the cause.
+      placeholder: "Example: Sonic Pi gave me an error. It said: Undefined variable or method `foobar` for Runtime:SonicPiLang, workspace_nine:1:in `block (2 levels) in __spider_eval'"
+    validations:
+      required: true
+  - type: textarea
+    id: expecting
+    attributes:
+      label: What were you expecting to happen instead?
+      description: "You can drag related images into the description if you like"      
+      placeholder: "Example: I was expecting a sound to play."
+    validations:
+      required: true
+  - type: textarea
+    id: other-details
+    attributes:
+      label: Other Details
+      description: |
+        You can drag related images into the description if you like.
+        Feel free to provide any other relevant information about the issue if you have it, or can get it:
+        - Ideas about possible root causes
+        - Links to the problematic commit or location in the source code on GitHub
+        - Workarounds or potential solutions (or even better, send us a pull request!)
+        - Etc...
+      placeholder: "Example: Could this be related to X? Maybe it might be fixed by editing the foo file."
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/STARTUP-ISSUE-FORM.yml
+++ b/.github/ISSUE_TEMPLATE/STARTUP-ISSUE-FORM.yml
@@ -1,0 +1,83 @@
+name: A Sonic Pi start up issue
+description: Sonic Pi doesn't start up successfully
+labels: ["triage", "boot"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Hello! Thank you for wanting to raise an issue for us, so that we know what's not working for you.
+
+        Sorry you're having issues getting Sonic pi to start up! We're always working to improve the success rate.
+
+        The core Sonic Pi development team is fairly small and made up of volunteers (with the exception of Sam Aaron, who relies much on crowd-funding) so the more help we can receive to manage, troubleshoot and hopefully fix your issues for you the better - help us to help you! Please follow the checklist below - that way you might not even need to raise an issue after all :smile:
+  - type: checkboxes
+    id: read-troubleshooting-guide
+    attributes:
+      options:
+        - label: I've read the [Sonic Pi troubleshooting guide](https://github.com/sonic-pi-net/sonic-pi/wiki/Troubleshooting-Issues) and followed its suggestions where relevant
+          required: true
+  - type: dropdown
+    id: sonic-pi-version
+    attributes:
+      label: Sonic Pi Version
+      description: What version of Sonic Pi were you running?
+      options:
+        - v4.0-Beta2
+        - v4.0-Beta1
+        - v3.3.1
+        - v3.3
+        - v3.2.2
+        - v3.2.1
+        - v3.2
+        - v3.1
+        - v3.0.1
+        - v3.0
+        - v2.11.1
+        - v2.11
+        - v2.10
+        - v2.9
+        - v2.8
+        - v2.7
+        - v2.6
+        - v2.5
+        - v2.4
+        - v2.3
+        - v2.2
+        - v2.1.1
+        - v2.1
+        - v2.0.1
+        - v2.0
+    validations:
+      required: true
+  - type: input
+    id: os-version
+    attributes:
+      label: Operating System
+      description: "What Operating System (and which version) were you using?"
+      placeholder: "Example: Windows 10"
+    validations:
+      required: true
+  - type: textarea
+    id: log-details
+    attributes:
+      label: Log file details
+      description: |
+        Please paste in the error report or log file details as outlined in the troubleshooting guide.
+        If the `.sonic-pi/log` directory doesn't exist, then Sonic Pi probably doesn't even load far enough to be able to create it. Please tell us if this is the case!
+      render: shell
+    validations:
+      required: true
+  - type: textarea
+    id: other-details
+    attributes:
+      label: Other Details
+      description: |
+        You can drag related images into the description if you like.
+        Feel free to provide any other relevant information about the issue if you have it, or can get it:
+        - Ideas about possible root causes
+        - Links to the problematic commit or location in the source code on GitHub
+        - Workarounds or potential solutions (or even better, send us a pull request!)
+        - Etc...
+      placeholder: "Example: Could this be related to X? Maybe it might be fixed by editing the foo file."
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,0 +1,23 @@
+Hello! We're so glad you're interested in improving Sonic Pi.
+
+The core Sonic Pi development team is fairly small and made up of volunteers (with the exception of Sam Aaron, who relies much on crowd-funding) so the more help we can receive to manage your pull requests the better! Please follow the checklist below - that way, the process of reviewing and potentially merging your contribution can be streamlined :smile:
+
+- [ ] I've followed the project guidelines and ideal contribution process described in [CONTRIBUTING.md](https://github.com/sonic-pi-net/sonic-pi/blob/main/CONTRIBUTING.md) where relevant.
+
+## Type of change
+Please delete options that are not relevant.
+
+- [ ] A bug fix
+- [ ] A new feature
+- [ ] A breaking change (a bug fix or new feature that would cause existing functionality to not work as expected)
+- [ ] A documentation update
+
+## Description
+- Provide details about the update such as:
+  - The reason for the change (provide context with links to discussions, GitHub issues, or other resources if available. **Note:** if this is a bug fix, you can link this PR to the bug so that it closes the bug when merged, by writing something in your PR comment like: fixes #1234 (where 1234 is the issue number)).
+  - Where relevant, the reason for the particular way this change has been built.
+  - Where relevant, a description of new behaviour.
+  - Screenshots, animated gifs or videos, if the change affects the GUI.
+
+## Other information
+Provide any other information that may be relevant to this PR.


### PR DESCRIPTION
This change add a pull request template, as well as issue template forms for
Sonic Pi startup issues, runtime issues, and feature requests.