### PR TITLE
Corrected a typo in Tutorial Time-State section

### DIFF
--- a/etc/doc/tutorial/10-State.md
+++ b/etc/doc/tutorial/10-State.md
@@ -19,6 +19,6 @@ might sound complex and difficult (in fact, in the UK, programming with
 multiple threads and shared memory is typically a university level
 subject). However, as you'll see, just like playing your first note,
 *Sonic Pi makes it incredibly simple to share state across threads*
-whilst still keeping your programs *thread-safe and deterministic.*
+whilst still keeping your programs *thread-safe and deterministic*.
 
 Meet `get` and `set`...


### PR DESCRIPTION
Removed an extra full stop after "thread-safe and deterministic." in Tutorial Time-State section

Fixes #2863 