### PR TITLE
require QT5 when installing with homebrew

### DIFF
--- a/BUILD-MAC.md
+++ b/BUILD-MAC.md
@@ -68,7 +68,7 @@ Once you have Homebrew installed, pulling in the rest of the
 dependencies is a couple of lines to execute within a terminal:
 
 ```
-brew install qt cmake
+brew install qt@5 cmake
 
 ```
 


### PR DESCRIPTION
Noticed that `brew qt` now installs QT6 by default. This fixes the that when setting up the dev environment on mac.

Let me know if you need me to direct these to `dev` instead and I'll create some new PRs!