### PR TITLE
adds a better error when resolve_sample_path returns nil

### DIFF
--- a/app/server/ruby/lib/sonicpi/lang/sound.rb
+++ b/app/server/ruby/lib/sonicpi/lang/sound.rb
@@ -2215,6 +2215,11 @@ load_sample dir, /[Bb]ar/ # loads first sample which matches regex /[Bb]ar/ in \
       def sample_duration(*args)
         filts_and_sources, args_a = sample_split_filts_and_opts(args)
         path = resolve_sample_path(filts_and_sources)
+
+        if path.nil?
+            raise ArgumentError.new("Error calling sample_duration: filters matched no samples")
+        end
+
         dur = load_sample_at_path(path).duration
         args_h = merge_synth_arg_maps_array(args_a)
 

--- a/app/server/ruby/test/lang/sound/test_sound.rb
+++ b/app/server/ruby/test/lang/sound/test_sound.rb
@@ -50,5 +50,10 @@ module SonicPi
       assert_equal(true, @mock_sound.should_trigger?(h))
     end
 
+    def test_sample_duration
+        @mock_sound.stub :resolve_sample_path, nil do
+            assert_raises(ArgumentError) { @mock_sound.sample_duration(["a/directory", "bogus_file_name"]) }
+        end
+    end
   end
 end


### PR DESCRIPTION
### Motivation

Fix for this Issue: https://github.com/sonic-pi-net/sonic-pi/issues/1748

Let me know if you'd prefer a different exception class or any wording changes.

Are errors regionalised? Should I do something for that?