### PR TITLE
fixes logic error on merging opts

### DIFF
--- a/app/server/ruby/bin/daemon.rb
+++ b/app/server/ruby/bin/daemon.rb
@@ -847,7 +847,7 @@ module SonicPi
         # extract scsynth opts
         begin
           scsynth_opts_a = Shellwords.split(opts.fetch(:scsynth_opts, ""))
-          scsynth_opts = clobber_opts_a.each_slice(2).to_h
+          scsynth_opts = scsynth_opts_a.each_slice(2).to_h
         rescue
           scsynth_opts = {}
         end


### PR DESCRIPTION
Fixes: https://github.com/sonic-pi-net/sonic-pi/issues/2868

I went down a bit of a rabbit hole with this - first I tried to get some unit tests working on `app/server/ruby/bin/daemon.rb` - it took me a while to work out that the tests weren't running because of (I think) a conflict in the way the tests are run with a daemon referenced and the way I was requiring the file (I see now, it's maybe something to do with the `SonicPi::Daemon::Init.new` line 🤷) 

Then I started to look at refactoring `merge_opts` in to `app/server/ruby/lib/sonicpi/util.rb` - not sure if this is the best place for it but it gave me an angle of attack. As I dug in I realised that it would end up being a fairly large refactor so maybe not worth the effort right now.

I also noticed that `Util.os` within daemon.rb also exist within util.rb - perhaps there's a larger task here to strip out more of the code in daemon.rb in to sub files. It would be good to encapsulate more of the code within here and slim the file size down - this should also allow us to share some bits of code like that `os` function and also aid unit testing.

Perhaps something I could look at when I'm more confident I grasp the project as a whole.