### PR TITLE
Correcting Sonic Pi version from invalid 3.0.2 to valid 3.1.0

### DIFF
--- a/app/server/ruby/lib/sonicpi/lang/midi.rb
+++ b/app/server/ruby/lib/sonicpi/lang/midi.rb
@@ -737,7 +737,7 @@ Typical MIDI values such as note or cc are represented with 7 bit numbers which 
         nil
       end
       doc name:           :midi_pc,
-          introduced:     Version.new(3,0,2),
+          introduced:     Version.new(3,1,0),
           summary:        "Send MIDI program change message",
           args:           [[:program_num, :midi]],
           returns:        :nil,


### PR DESCRIPTION
This is related to issue #2880:
https://github.com/sonic-pi-net/sonic-pi/issues/2880