### PR TITLE
Build - fix erlang -> beam path in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -149,5 +149,5 @@ etc/synthdefs/designs/overtone/sonic-pi/native
 
 
 # Erlang priv dir (for dlls)
-app/server/erlang/tau/priv/*
-app/server/erlang/tau/ebin/*
+app/server/beam/tau/priv/*
+app/server/beam/tau/ebin/*


### PR DESCRIPTION
Update gitignore for the directory rename in e1ef211. It looks like this is the last reference to the old directory that I see