### PR TITLE
CI - misc fixes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -244,7 +244,8 @@ jobs:
 
     - name: Archive Logs
       uses: actions/upload-artifact@v2
+      if: ${{ always() }}
       with:
-          name: Logs_${{matrix.title}}_${{matrix.build_type}}
+          name: Logs_${{matrix.title}}_${{matrix.cc}}_${{matrix.arch}}_${{matrix.build_type}}
           path: |
             ~/.sonic-pi/log/*.log

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,9 +3,11 @@ name: Build
 on:
   # Do it on every push or PR on these branches
   push:
-    branches: [ dev, main, workflow_dispatch, features/sp-api ]
+    branches: [ dev, stable ]
   pull_request:
-    branches: [ dev, main, workflow_dispatch, features/sp-api ]
+    branches: [ dev, stable ]
+  # Do build on demand
+  workflow_dispatch:
 
 jobs:
   # Build Sonic Pi

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -217,7 +217,7 @@ jobs:
     - name: API Tests - Linux
       working-directory: ${{github.workspace}}/app/build/api-tests
       run: |
-        jackd -d dummy &
+        jackd -rd dummy &
         ctest --verbose
       if: matrix.os == 'ubuntu-latest'
 


### PR DESCRIPTION
This PR contains three CI adjustments:
* Fix branch names in triggers and allow on-demand builds via the `workflow_dispatch` event (helpful to manually run tests on a branch without having to make a PR to it)
* Always upload log artifacts, even on CI failure (to help when debugging failures) and make the names fully unique so there aren't multiple artifacts with the same name
* Disable JACK real-time mode, since real-time mode cannot be used in CI anyway and this avoids a few (but not all) JACK startup error messages in the Linux CI