### PR TITLE
Fixed Extempore link in contributors.md

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -47,7 +47,7 @@ have provided inspiration for the creation of Sonic Pi through their own
 projects:
 
 * _why (why the lucky stiff) - [Shoes](https://en.wikipedia.org/wiki/Shoes_(GUI_toolkit))
-* Andrew Sorensen  - [Extempore](http://extempore.moso.com.au)
+* Andrew Sorensen  - [Extempore](https://extemporelang.github.io/)
 * James McCartney - [SuperCollider](https://supercollider.github.io)
 * Jeff Rose - [Overtone](https://overtone.github.io/)
 * Joe Armstrong - [Erlang](https://www.erlang.org)


### PR DESCRIPTION
The Extempore link updated to -https://extemporelang.github.io/

Fix #2900