### PR TITLE
Docs - Show needed buffer: opt in record fx usage example

### DIFF
--- a/app/server/ruby/lib/sonicpi/synths/synthinfo.rb
+++ b/app/server/ruby/lib/sonicpi/synths/synthinfo.rb
@@ -8303,7 +8303,10 @@ Note: sliding the `phase:` opt with `phase_slide:` will also cause each echo dur
             doc << "use_synth <span class=\"symbol\">:#{safe_k}</span>"
           else
             safe_k = k.to_s[3..-1]
-            doc << "with_fx <span class=\"symbol\">:#{safe_k}</span> <span class=\"keyword\">do</span>\n"
+            opts = if safe_k == 'record'
+                     ", <span class=\"symbol\">buffer: :foo</span>"
+                   end
+            doc << "with_fx <span class=\"symbol\">:#{safe_k}</span>#{opts} <span class=\"keyword\">do</span>\n"
             doc << "  play <span class=\"number\">50</span>\n"
             doc << "<span class=\"keyword\">end</span>"
           end


### PR DESCRIPTION
Previously, usage examples for all fx in the docs had the same format:

with_fx :fx_name do
  play 50
end

However, the :record fx requires a buffer: opt with a value representing a
buffer for the fx to record into. The existing usage example format does not
account for this.

We have now added a simple condition into the code that builds the fx usage
examples, to add in the required buffer opt if the example is for the :record fx.