### PR TITLE
Fix Error Dialog

### DIFF
--- a/app/api/src/sonicpi_api.cpp
+++ b/app/api/src/sonicpi_api.cpp
@@ -764,7 +764,7 @@ std::string SonicPiAPI::GetLogs()
             auto contents = string_trim(file_read(log));
             if (!contents.empty())
             {
-                str << log << ":" << std::endl
+                str << string_trim(log.filename(), "\"") << ":" << std::endl
                     << contents << std::endl
                     << std::endl;
             }

--- a/app/gui/qt/mainwindow.h
+++ b/app/gui/qt/mainwindow.h
@@ -128,10 +128,6 @@ class MainWindow : public QMainWindow
         void closeEvent(QCloseEvent *event);
         void wheelEvent(QWheelEvent *event);
 
-
-        public slots:
-            void invokeStartupError(QString msg);
-
 signals:
         void settingsChanged();
 


### PR DESCRIPTION
During the change to the API, the error dialog got lost.
This replaces it with a simpler/easier to use one:

- The log messages are collected from the API
- It is a resizable dialog, making it easier for the user to read the
  logs.
- It is desktop modal, meaning it will appear on top of everything so
  you don't accidentally 'lose' it like the last one.

![image](https://user-images.githubusercontent.com/120447/138481351-b069ab9f-d59a-4315-9aa5-9bf255b9ae21.png)
