### PR TITLE
Docs - fix small grammar issue in RPi build docs

### DIFF
--- a/BUILD-RASPBERRY-PI.md
+++ b/BUILD-RASPBERRY-PI.md
@@ -5,7 +5,7 @@ Hello there lovely Raspberry Pi user - welcome to our build instructions.
 ### TLDR
 
 If you're already familiar with the terminal and running shell scripts,
-etc. You can fetch, build and start Sonic Pi with the following:
+etc., you can fetch, build and start Sonic Pi with the following:
 
 ```
 git clone https://github.com/sonic-pi-net/sonic-pi.git


### PR DESCRIPTION
When 'etc.' is used in the middle of a sentence, it is followed by a comma.
We now do so in the sentence changed in this commit. Also, the word that follows
it is not the start of a new sentence, so it is no longer caplitalised.