### PR TITLE
Prevent infinite loop on range function when step size = 0

### DIFF
--- a/app/server/ruby/lib/sonicpi/lang/core.rb
+++ b/app/server/ruby/lib/sonicpi/lang/core.rb
@@ -1750,6 +1750,9 @@ end"
         end
 
         return [].ring if start == finish
+
+        raise ArgumentError, "step size: opt for fn range should be a non-zero number" unless step_size != 0
+        
         step_size = step_size.abs
         res = []
         cur = start

--- a/app/server/ruby/test/test_ring.rb
+++ b/app/server/ruby/test/test_ring.rb
@@ -60,6 +60,10 @@ module SonicPi
       assert_equal(range(1, 3).class, SonicPi::Core::RingVector)
       assert_equal(range(10, 10, step: -1), ring())
 
+      assert_raises ArgumentError, "step size" do
+        assert_equal(range(1, 5, step: 0), [1.0, 2.0, 3.0, 4.0].ring)
+      end
+
     end
 
     def test_line


### PR DESCRIPTION
Signed-off-by: Jay Clark <jay@jayeclark.dev>

# Description
Fixes issues #2921 

Changes the `range` function to raise an argument error if step size is 0. 

# Testing
Added and ran the appropriate test to confirm that passing a step size of 0 raises an argument error. (Test is included in PR.)