### PR TITLE
fix: current_debug function

### DIFF
--- a/app/server/ruby/lib/sonicpi/lang/sound.rb
+++ b/app/server/ruby/lib/sonicpi/lang/sound.rb
@@ -2017,7 +2017,7 @@ puts current_volume #=> 2"]
 
 
       def current_debug
-        __thread_locals.get(:sonic_pi_mod_sound_synth_silent)
+        !__thread_locals.get(:sonic_pi_mod_sound_synth_silent)
       end
       doc name:          :current_debug,
           introduced:    Version.new(2,0,0),


### PR DESCRIPTION
Fixes: #2932 
inverts the output of <code>current_debug</code> to get expected output