### PR TITLE
Build - fix prebuild files to include rebar3 and set MIX_ENV without quotes on Windows

### DIFF
--- a/app/linux-prebuild.sh
+++ b/app/linux-prebuild.sh
@@ -70,6 +70,7 @@ echo "Compiling Erlang/Elixir files..."
 cd "${SCRIPT_DIR}"/server/beam/tau
 
 MIX_ENV=prod mix local.hex --force
+MIX_ENV=prod mix local.rebar --force
 MIX_ENV=prod mix deps.get
 MIX_ENV=prod mix phx.digest
 MIX_ENV=prod mix release --overwrite

--- a/app/mac-prebuild.sh
+++ b/app/mac-prebuild.sh
@@ -104,6 +104,7 @@ echo "Compiling Erlang/Elixir files..."
 cd "${SCRIPT_DIR}"/server/beam/tau
 
 MIX_ENV=prod mix local.hex --force
+MIX_ENV=prod mix local.rebar --force
 MIX_ENV=prod mix deps.get
 MIX_ENV=prod mix phx.digest
 MIX_ENV=prod mix release --overwrite

--- a/app/win-prebuild.bat
+++ b/app/win-prebuild.bat
@@ -55,9 +55,10 @@ forfiles /p gui\qt\lang /s /m *.ts /c "cmd /c %QT_INSTALL_LOCATION%\bin\lrelease
 @echo Compiling Erlang/Elixir files...
 cd %~dp0\server\beam\tau
 
-SET MIX_ENV="prod"
+SET MIX_ENV=prod
 
 cmd /c mix local.hex --force
+cmd /c mix local.rebar --force
 cmd /c mix deps.get
 cmd /c mix phx.digest
 cmd /c mix release --overwrite


### PR DESCRIPTION
This fixes the macOS and Windows CI failures in https://github.com/sonic-pi-net/sonic-pi/actions/runs/1462684334