### PR TITLE
GUI - fix macOS not launching main window when starting app

### DIFF
--- a/app/gui/qt/main.cpp
+++ b/app/gui/qt/main.cpp
@@ -74,8 +74,6 @@ int main(int argc, char *argv[])
   // macOS code goes here
   SonicPi::removeMacosSpecificMenuItems();
   QApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
-  return app.exec();
-
 #endif
 
   QMainWindow* splashWindow = new QMainWindow(0, Qt::FramelessWindowHint);


### PR DESCRIPTION
A line was missed during the refactoring in 7569cfa which prevented MainWindow from being constructed on macOS