### PR TITLE
Build - use mix assets.deploy instead of phx.digest and make other misc build script fixes around no_imgui

### DIFF
--- a/app/linux-config.sh
+++ b/app/linux-config.sh
@@ -41,11 +41,11 @@ mkdir -p "${SCRIPT_DIR}/build"
 echo "Generating makefiles..."
 cd "${SCRIPT_DIR}/build"
 
-if [ $no_imgui=true ]
+if [ "$no_imgui" == true ]
 then
-    cmake -G "Unix Makefiles" -DBUILD_IMGUI_INTERFACE=OFF -DCMAKE_BUILD_TYPE=\"$config\" ..
+    cmake -G "Unix Makefiles" -DBUILD_IMGUI_INTERFACE=OFF -DCMAKE_BUILD_TYPE="$config" ..
 else
-    cmake -G "Unix Makefiles" -DBUILD_IMGUI_INTERFACE=ON -DCMAKE_BUILD_TYPE=\"$config\" ..
+    cmake -G "Unix Makefiles" -DBUILD_IMGUI_INTERFACE=ON -DCMAKE_BUILD_TYPE="$config" ..
 fi
 
 cd "${SCRIPT_DIR}"

--- a/app/linux-prebuild.sh
+++ b/app/linux-prebuild.sh
@@ -34,7 +34,7 @@ fi
 
 cd vcpkg
 
-if [ $no_imgui == true ]
+if [ "$no_imgui" == true ]
 then
     ./vcpkg install kissfft crossguid platform-folders reproc catch2 --recurse
 else
@@ -72,7 +72,7 @@ cd "${SCRIPT_DIR}"/server/beam/tau
 MIX_ENV=prod mix local.hex --force
 MIX_ENV=prod mix local.rebar --force
 MIX_ENV=prod mix deps.get
-MIX_ENV=prod mix phx.digest
+MIX_ENV=prod mix assets.deploy
 MIX_ENV=prod mix release --overwrite
 
 cp src/tau.app.src ebin/tau.app

--- a/app/mac-prebuild.sh
+++ b/app/mac-prebuild.sh
@@ -34,7 +34,7 @@ fi
 cd vcpkg
 triplet=(x64-osx)
 
-if [ $no_imgui == true ]
+if [ "$no_imgui" == true ]
 then
     ./vcpkg install kissfft crossguid platform-folders reproc catch2 --triplet ${triplet[0]} --recurse
 else
@@ -106,7 +106,7 @@ cd "${SCRIPT_DIR}"/server/beam/tau
 MIX_ENV=prod mix local.hex --force
 MIX_ENV=prod mix local.rebar --force
 MIX_ENV=prod mix deps.get
-MIX_ENV=prod mix phx.digest
+MIX_ENV=prod mix assets.deploy
 MIX_ENV=prod mix release --overwrite
 
 cp src/tau.app.src ebin/tau.app

--- a/app/pi-config.sh
+++ b/app/pi-config.sh
@@ -41,11 +41,11 @@ mkdir -p "${SCRIPT_DIR}/build"
 echo "Generating makefiles..."
 cd "${SCRIPT_DIR}/build"
 
-if [ $no_imgui == true ]
+if [ "$no_imgui" == true ]
 then
-    cmake -G "Unix Makefiles" -DBUILD_IMGUI_INTERFACE=OFF -DRASPBERRY_PI=1 -DCMAKE_BUILD_TYPE=\"$config\" ..
+    cmake -G "Unix Makefiles" -DBUILD_IMGUI_INTERFACE=OFF -DRASPBERRY_PI=1 -DCMAKE_BUILD_TYPE="$config" ..
 else
-    cmake -G "Unix Makefiles" -DBUILD_IMGUI_INTERFACE=ON -DRASPBERRY_PI=1 -DCMAKE_BUILD_TYPE=\"$config\" ..
+    cmake -G "Unix Makefiles" -DBUILD_IMGUI_INTERFACE=ON -DRASPBERRY_PI=1 -DCMAKE_BUILD_TYPE="$config" ..
 fi
 
 # Restore working directory as it was prior to this script running...

--- a/app/pi-prebuild.sh
+++ b/app/pi-prebuild.sh
@@ -15,7 +15,7 @@ while getopts ":n" opt; do
   esac
 done
 
-if [ $no_imgui == true ]
+if [ "$no_imgui" == true ]
 then
     VCPKG_FORCE_SYSTEM_BINARIES=1 "${SCRIPT_DIR}"/linux-prebuild.sh -n
 else

--- a/app/win-prebuild.bat
+++ b/app/win-prebuild.bat
@@ -60,7 +60,7 @@ SET MIX_ENV=prod
 cmd /c mix local.hex --force
 cmd /c mix local.rebar --force
 cmd /c mix deps.get
-cmd /c mix phx.digest
+cmd /c mix assets.deploy
 cmd /c mix release --overwrite
 
 cd %~dp0\server\beam\tau


### PR DESCRIPTION
Using `assets.deploy` will make sure the `app/server/beam/tau/priv/static/assets` directory gets generated and the Mix alias also includes `phx.digest` so that is no longer necessary to run separately

The `no_imgui` variable fixes were mostly for consistency but also they would also print errors (like `bash: [: =: unary operator expected`) if `-n` was not specified since the variable would be empty and quotes were not used in the comparison