### PR TITLE
Tau - do not write log/tau_stdout.log in prod mode

### DIFF
--- a/app/server/beam/tau/boot-lin.sh
+++ b/app/server/beam/tau/boot-lin.sh
@@ -25,5 +25,5 @@ if [ $TAU_ENV == "dev" ]
 then
   mix run --no-halt > log/tau_stdout.log 2>&1
 else
-  _build/prod/rel/tau/bin/tau start > log/tau_stdout.log 2>&1
+  _build/prod/rel/tau/bin/tau start > /dev/null 2>&1
 fi

--- a/app/server/beam/tau/boot-mac.sh
+++ b/app/server/beam/tau/boot-mac.sh
@@ -25,5 +25,5 @@ if [ $TAU_ENV == "dev" ]
 then
   mix run --no-halt > log/tau_stdout.log 2>&1
 else
-  _build/prod/rel/tau/bin/tau start > log/tau_stdout.log 2>&1
+  _build/prod/rel/tau/bin/tau start > /dev/null 2>&1
 fi

--- a/app/server/beam/tau/boot-win.bat
+++ b/app/server/beam/tau/boot-win.bat
@@ -30,5 +30,5 @@ set MIX_ENV=%TAU_ENV%
 IF "%TAU_ENV%" == "dev" (
   mix run --no-halt > log\tau_stdout.log 2>&1
 ) ELSE (
-  _build\prod\rel\tau\bin\tau start > log\tau_stdout.log 2>&1
+  _build\prod\rel\tau\bin\tau start > NUL 2>&1
 )


### PR DESCRIPTION
On some OSs (like Windows and Linuxes) when the program is installed to a system directory (`C:\Program Files` for Windows and `/usr` on Linux) the `app/server/beam/tau/log` directory is not writable by the user running the program and causes the boot scripts to fail at runtime

This PR avoids writing to that directory at runtime by redirecting stdout to the null device when Tau is run in prod mode. Is there a better way not writing to this directory should be handled at runtime, or is this solution reasonable?

(Side note: I didn't actually test on Windows so it might be working fine from `C:\Program Files` without this, but I know programs have had issues with writing to `C:\Program Files` since that got restricted more in Vista)