### PR TITLE
GUI - unify on QSplashScreen instead of QMainWindow

### DIFF
--- a/app/gui/qt/main.cpp
+++ b/app/gui/qt/main.cpp
@@ -14,6 +14,7 @@
 #include <iostream>
 
 #include <QApplication>
+#include <QSplashScreen>
 #include <QPixmap>
 #include <QBitmap>
 #include <QLabel>
@@ -76,22 +77,13 @@ int main(int argc, char *argv[])
   QApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
 #endif
 
-  QMainWindow* splashWindow = new QMainWindow(0, Qt::FramelessWindowHint);
-  QLabel* imageLabel = new QLabel();
-  splashWindow->setAttribute( Qt::WA_TranslucentBackground);
-  QPixmap image(":/images/splash@2x.png");
-  imageLabel->setPixmap(image);
+  QPixmap pixmap(":/images/splash@2x.png");
 
-  splashWindow->setCentralWidget(imageLabel);
-  splashWindow->setMinimumHeight(image.height()/2);
-  splashWindow->setMaximumHeight(image.height()/2);
-  splashWindow->setMinimumWidth(image.width()/2);
-  splashWindow->setMaximumWidth(image.width()/2);
-
-  splashWindow->raise();
-  splashWindow->show();
+  QSplashScreen *splash = new QSplashScreen(pixmap);
+  splash->show();
   app.processEvents();
-  MainWindow mainWin(app, splashWindow);
+
+  MainWindow mainWin(app, splash);
 
 #ifdef __linux__
 

--- a/app/gui/qt/main.cpp
+++ b/app/gui/qt/main.cpp
@@ -26,40 +26,29 @@
 
 #include "dpi.h"
 
-#ifdef _WIN32
-#include <QtPlatformHeaders\QWindowsWindowFunctions>
+#ifdef Q_OS_WIN
+#include <QtPlatformHeaders/QWindowsWindowFunctions>
 #endif
 
-#ifdef Q_OS_MAC
-    #include "platform/macos.h"
+#ifdef Q_OS_DARWIN
+#include "platform/macos.h"
 #endif
 
 int main(int argc, char *argv[])
 {
   std::cout << "Starting Sonic Pi..." << std::endl;
-#ifndef Q_OS_MAC
+
+#ifndef Q_OS_DARWIN
   Q_INIT_RESOURCE(SonicPi);
 #endif
 
-  QApplication app(argc, argv);
-
   QApplication::setAttribute(Qt::AA_DontShowIconsInMenus, true);
 
-  QFontDatabase::addApplicationFont(":/fonts/Hack-Regular.ttf");
-  QFontDatabase::addApplicationFont(":/fonts/Hack-Italic.ttf");
-  QFontDatabase::addApplicationFont(":/fonts/Hack-Bold.ttf");
-  QFontDatabase::addApplicationFont(":/fonts/Hack-BoldItalic.ttf");
-
-  qRegisterMetaType<SonicPiLog::MultiMessage>("SonicPiLog::MultiMessage");
-
-  app.setApplicationName(QObject::tr("Sonic Pi"));
-  app.setStyle("gtk");
-
-#ifdef __linux__
+#if defined(Q_OS_LINUX)
   //linux code goes here
   QApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
   QApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
-#elif _WIN32
+#elif defined(Q_OS_WIN)
   // windows code goes here
 
   // A temporary fix, until stylesheets are removed.
@@ -71,11 +60,23 @@ int main(int argc, char *argv[])
       QApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
 
     }
-#elif __APPLE__
+#elif defined(Q_OS_DARWIN)
   // macOS code goes here
   SonicPi::removeMacosSpecificMenuItems();
   QApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
 #endif
+
+  QApplication app(argc, argv);
+
+  QFontDatabase::addApplicationFont(":/fonts/Hack-Regular.ttf");
+  QFontDatabase::addApplicationFont(":/fonts/Hack-Italic.ttf");
+  QFontDatabase::addApplicationFont(":/fonts/Hack-Bold.ttf");
+  QFontDatabase::addApplicationFont(":/fonts/Hack-BoldItalic.ttf");
+
+  qRegisterMetaType<SonicPiLog::MultiMessage>("SonicPiLog::MultiMessage");
+
+  app.setApplicationName(QObject::tr("Sonic Pi"));
+  app.setStyle("gtk");
 
   QPixmap pixmap(":/images/splash@2x.png");
 
@@ -85,15 +86,15 @@ int main(int argc, char *argv[])
 
   MainWindow mainWin(app, splash);
 
-#ifdef __linux__
+#if defined(Q_OS_LINUX)
 
-#elif _WIN32
+#elif defined(Q_OS_WIN)
     // Fix for full screen mode. See: https://doc.qt.io/qt-5/windows-issues.html#fullscreen-opengl-based-windows
   QWindowsWindowFunctions::setHasBorderInFullScreen(mainWin.windowHandle(), true);
-
-#elif __APPLE__
+#elif defined(Q_OS_DARWIN)
 
 #endif
+
   return app.exec();
 
 }

--- a/app/gui/qt/mainwindow.cpp
+++ b/app/gui/qt/mainwindow.cpp
@@ -35,6 +35,7 @@
 #include <QPlainTextEdit>
 #include <QScrollBar>
 #include <QShortcut>
+#include <QSplashScreen>
 #include <QSplitter>
 #include <QStatusBar>
 #include <QStyle>
@@ -95,7 +96,7 @@ using namespace std::chrono;
 
 using namespace SonicPi;
 
-MainWindow::MainWindow(QApplication& app, QMainWindow* splash)
+MainWindow::MainWindow(QApplication& app, QSplashScreen* splash)
 {
     app.installEventFilter(this);
     app.processEvents();
@@ -1102,7 +1103,7 @@ QString MainWindow::rootPath()
 
 void MainWindow::splashClose()
 {
-  splash->close();
+  splash->finish(this);
 }
 
 void MainWindow::showWindow()

--- a/app/gui/qt/mainwindow.h
+++ b/app/gui/qt/mainwindow.h
@@ -62,6 +62,7 @@ class QSignalMapper;
 class QTabWidget;
 class QCheckBox;
 class QVBoxLayout;
+class QSplashScreen;
 class QLabel;
 class QWebEngineView;
 class QWebEngineProfile;
@@ -95,7 +96,7 @@ class MainWindow : public QMainWindow
     Q_OBJECT
 
     public:
-  MainWindow(QApplication &ref, QMainWindow* splash);
+        MainWindow(QApplication &ref, QSplashScreen* splash);
 
         SonicPiLog* GetOutputPane() const;
         SonicPiLog* GetIncomingPane() const;
@@ -343,7 +344,7 @@ signals:
         bool show_rec_icon_a;
         QTimer *rec_flash_timer;
 
-        QMainWindow* splash;
+        QSplashScreen* splash;
 
         bool i18n;
         static const int workspace_max = 10;


### PR DESCRIPTION
As we discussed, this PR is a follow-up to 7569cfa for testing since QSplashScreen seems to have better cross-platform support and the issue on macOS motivating 10f5fc7 may no longer be a problem

This needs testing on macOS to make sure there is no problematic regression in the splash screen, especially on retina displays