### PR TITLE
Daemon - move to UDP for kill-switch

### DIFF
--- a/app/api/include/api/sonicpi_api.h
+++ b/app/api/include/api/sonicpi_api.h
@@ -58,9 +58,9 @@ enum class SonicPiPath
 enum class SonicPiPortId
 {
     Invalid,
-    daemon,
-    gui_listen_to_server,
-    gui_send_to_server,
+    daemon_keep_alive,
+    gui_listen_to_spider,
+    gui_send_to_spider,
     scsynth,
     server_osc_cues,
     phx_http
@@ -336,7 +336,6 @@ private:
     std::ofstream m_stdlog;
 
     std::shared_ptr<reproc::process> m_bootDaemonProcess;
-    std::shared_ptr<kissnet::tcp_socket> m_bootDaemonSock;
 
     std::mutex m_osc_mtx;
     bool m_shutdown_engaged = false;
@@ -348,10 +347,12 @@ private:
     std::thread m_pingerThread;
     std::thread m_bootDaemonSockPingLoopThread;
 
-    std::shared_ptr<OscServer> m_spOscServer;
-    std::shared_ptr<OscSender> m_spOscSender;
+    std::shared_ptr<OscServer> m_spOscSpiderServer;
+    std::shared_ptr<OscSender> m_spOscSpiderSender;
+    std::shared_ptr<OscSender> m_spOscKeepAliveSender;
     std::shared_ptr<AudioProcessor> m_spAudioProcessor;
     std::string m_guid;
+    std::string m_kill_token;
 
     IAPIClient* m_pClient = nullptr;
     APIProtocol m_protocol = APIProtocol::UDP;

--- a/app/server/beam/tau/boot-lin.sh
+++ b/app/server/beam/tau/boot-lin.sh
@@ -13,12 +13,13 @@ export TAU_OSC_IN_UDP_PORT=$5
 export TAU_API_PORT=$6
 export TAU_SPIDER_PORT=$7
 export TAU_DAEMON_PORT=$8
-export TAU_LOG_PATH=$9
-export TAU_MIDI_ENABLED=${10}
-export TAU_LINK_ENABLED=${11}
-export TAU_PHX_PORT=${12}
-export SECRET_KEY_BASE=${13}
-export TAU_ENV=${14}
+export TAU_KEEP_ALIVE_PORT=$9
+export TAU_LOG_PATH={$10}
+export TAU_MIDI_ENABLED=${11}
+export TAU_LINK_ENABLED=${12}
+export TAU_PHX_PORT=${13}
+export SECRET_KEY_BASE=${14}
+export TAU_ENV=${15}
 export MIX_ENV=$TAU_ENV
 
 if [ $TAU_ENV == "dev" ]

--- a/app/server/beam/tau/boot-mac.sh
+++ b/app/server/beam/tau/boot-mac.sh
@@ -13,12 +13,13 @@ export TAU_OSC_IN_UDP_PORT=$5
 export TAU_API_PORT=$6
 export TAU_SPIDER_PORT=$7
 export TAU_DAEMON_PORT=$8
-export TAU_LOG_PATH=$9
-export TAU_MIDI_ENABLED=${10}
-export TAU_LINK_ENABLED=${11}
-export TAU_PHX_PORT=${12}
-export SECRET_KEY_BASE=${13}
-export TAU_ENV=${14}
+export TAU_KEEP_ALIVE_PORT=$9
+export TAU_LOG_PATH={$10}
+export TAU_MIDI_ENABLED=${11}
+export TAU_LINK_ENABLED=${12}
+export TAU_PHX_PORT=${13}
+export SECRET_KEY_BASE=${14}
+export TAU_ENV=${15}
 export MIX_ENV=$TAU_ENV
 
 if [ $TAU_ENV == "dev" ]

--- a/app/server/beam/tau/boot-win.bat
+++ b/app/server/beam/tau/boot-win.bat
@@ -13,6 +13,8 @@ set TAU_OSC_IN_UDP_PORT=%5%
 set TAU_API_PORT=%6%
 set TAU_SPIDER_PORT=%7%
 set TAU_DAEMON_PORT=%8%
+set TAU_KEEP_ALIVE_PORT=%9%
+shift
 set TAU_LOG_PATH=%9%
 shift
 set TAU_MIDI_ENABLED=%9%

--- a/app/server/beam/tau/lib/tau.ex
+++ b/app/server/beam/tau/lib/tau.ex
@@ -15,6 +15,7 @@ defmodule Tau do
     api_port                       = extract_env("TAU_API_PORT",                       :int,  5001)
     spider_port                    = extract_env("TAU_SPIDER_PORT",                    :int,  5002)
     daemon_port                    = extract_env("TAU_DAEMON_PORT",                    :int,  -1)
+    keep_alive_port                = extract_env("TAU_KEEP_ALIVE_PORT",                :int,  -1)
 
     if midi_enabled do
       Logger.info("Initialising MIDI native interface")
@@ -40,16 +41,17 @@ defmodule Tau do
       osc_in_udp_port,
       api_port,
       spider_port,
-      daemon_port
+      daemon_port,
+      keep_alive_port
     )
 
     # Although we don't use the supervisor name below directly,
     # it can be useful when debugging or introspecting the system.
 
-    if (daemon_port == -1) do
+    if (keep_alive_port == -1) do
       Logger.info("Not starting keepalive server as no daemon port value was given")
     else
-      :tau_keepalive.start_link(daemon_port)
+      :tau_keepalive.start_link(keep_alive_port, daemon_port)
     end
 
     :tau_server_sup.start_link()

--- a/app/server/beam/tau/src/tau_server/tau_server_sup.erl
+++ b/app/server/beam/tau/src/tau_server/tau_server_sup.erl
@@ -11,7 +11,7 @@
 
 %% Supervisor callbacks
 -export([init/1]).
--export([set_application_env/10]).
+-export([set_application_env/11]).
 
 -define(APPLICATION, tau).
 
@@ -43,7 +43,8 @@ set_application_env(MIDIEnabled,
                     OSCInUDPPort,
                     ApiPort,
                     SpiderPort,
-                    DaemonPort) ->
+                    DaemonPort,
+                    KeepAlivePort) ->
 
     application:set_env(?APPLICATION, midi_enabled, MIDIEnabled),
     application:set_env(?APPLICATION, link_enabled, LinkEnabled),
@@ -54,7 +55,8 @@ set_application_env(MIDIEnabled,
     application:set_env(?APPLICATION, osc_in_udp_port, OSCInUDPPort),
     application:set_env(?APPLICATION, api_port, ApiPort),
     application:set_env(?APPLICATION, spider_port, SpiderPort),
-    application:set_env(?APPLICATION, daemon_port, DaemonPort).
+    application:set_env(?APPLICATION, daemon_port, DaemonPort),
+    application:set_env(?APPLICATION, keep_alive_port, KeepAlivePort).
 
 init(_Args) ->
     CueServer = tau_server_cue:server_name(),


### PR DESCRIPTION
Previously we used TCP connections to detect liveness using both the connection status and message timeouts.

However, on systems that sleep/hibernate such as laptops, these TCP connections can be broken by the OS resulting in the kill switch to be incorrectly triggered.

This commit switches these TCP connections to UDP which doesn't suffer from connection issues as there isn't an actual connection.

Also added an explicit kill switch trigger for the client process which can send /daemon/exit with a supplied exit-token rather than to wait on timeouts. This allows normal exits to be prompt.

The documentation at the top of daemon.rb has been updated appropriately.