### PR TITLE
Fix error in Tau launch scripts

### DIFF
--- a/app/server/beam/tau/boot-lin.sh
+++ b/app/server/beam/tau/boot-lin.sh
@@ -22,7 +22,7 @@ export SECRET_KEY_BASE=${14}
 export TAU_ENV=${15}
 export MIX_ENV=$TAU_ENV
 
-if [ $TAU_ENV == "dev" ]
+if [ $TAU_ENV = "dev" ]
 then
   mix run --no-halt > log/tau_stdout.log 2>&1
 else

--- a/app/server/beam/tau/boot-mac.sh
+++ b/app/server/beam/tau/boot-mac.sh
@@ -22,7 +22,7 @@ export SECRET_KEY_BASE=${14}
 export TAU_ENV=${15}
 export MIX_ENV=$TAU_ENV
 
-if [ $TAU_ENV == "dev" ]
+if [ $TAU_ENV = "dev" ]
 then
   mix run --no-halt > log/tau_stdout.log 2>&1
 else


### PR DESCRIPTION
Fixed some string comparison typos in the shell scripts which prevented the server from launching Tau.