### PR TITLE
Added unit info to Winwood synth docs

### DIFF
--- a/app/server/ruby/lib/sonicpi/synths/synthinfo.rb
+++ b/app/server/ruby/lib/sonicpi/synths/synthinfo.rb
@@ -3364,12 +3364,12 @@ Steal This Sound,  Mitchell Sigman"
           },
           :lfo_width =>
           {
-            :doc => "Width of the low-frequency oscillator (LFO) which determines how wide base tones oscillate around their base frequencies",
+            :doc => "Width of the low-frequency oscillator (LFO) which determines how wide base tones oscillate around their base frequencies; a dimensionless scaled ratio between base and peak oscillator frequencies",
             :modulatable => true
           },
           :lfo_rate =>
           {
-            :doc => "Rate of the low-frequency oscillator (LFO) which determines how fast base tones oscillate around their base frequencies",
+            :doc => "Rate of the low-frequency oscillator (LFO) in Hz which determines how fast base tones oscillate around their base frequencies",
             :modulatable => true
           },
         }


### PR DESCRIPTION
Just a minor thing: I was just doing some write-up of [my synthdef lessons learned](https://in-thread.sonic-pi.net/t/improving-synth-design-md/6297) and found that we never really finished the thread about [time-based units](https://github.com/sonic-pi-net/sonic-pi/pull/2628). `lfo_rate` in fact does not vary with `bpm`, so I really think that Hz is the right thing here. The synthdef uses Hz already, but I added a bit of description to the docs.