### PR TITLE
API - remove unused string in keep-alive thread

### DIFF
--- a/app/api/src/sonicpi_api.cpp
+++ b/app/api/src/sonicpi_api.cpp
@@ -281,7 +281,6 @@ bool SonicPiAPI::StartBootDaemon()
 
     LOG(INFO, "Setting up Boot Daemon keep alive loop");
     m_bootDaemonSockPingLoopThread = std::thread([&]() {
-      auto keep_alive_msg = std::string{ "keep-alive\n" };
       while(m_keep_alive.load())
       {
         LOG(DBG, "SND keep_alive");


### PR DESCRIPTION
The usage of the `keep-alive` string for the keep-alive loop in the API was removed in bb89130 (when it was moved to a UDP-based killswitch), but the actual variable definition for the string was not removed. This PR removes that unused variable