### PR TITLE
Run lrelease during cmake build instead of pre-build

### DIFF
--- a/app/gui/qt/CMakeLists.txt
+++ b/app/gui/qt/CMakeLists.txt
@@ -40,15 +40,15 @@ set_property(GLOBAL PROPERTY AUTOGEN_TARGETS_FOLDER Automoc)
 find_package(Qt6 QUIET)
 
 if(Qt6_FOUND AND WITH_QT_GUI_WEBENGINE)
-  find_package(Qt6 COMPONENTS Core Widgets Gui Concurrent Network OpenGLWidgets PrintSupport Xml Svg WebEngineWidgets REQUIRED)
+  find_package(Qt6 COMPONENTS Core Widgets Gui Concurrent Network OpenGLWidgets PrintSupport Xml Svg LinguistTools WebEngineWidgets REQUIRED)
   add_compile_definitions(WITH_WEBENGINE)
 elseif(Qt6_FOUND)
-  find_package(Qt6 COMPONENTS Core Widgets Gui Concurrent Network OpenGLWidgets PrintSupport Xml Svg REQUIRED)
+  find_package(Qt6 COMPONENTS Core Widgets Gui Concurrent Network OpenGLWidgets PrintSupport Xml Svg LinguistTools REQUIRED)
 elseif(WITH_QT_GUI_WEBENGINE)
-  find_package(Qt5 COMPONENTS Core Widgets Gui Concurrent Network OpenGL PrintSupport Xml Svg WebEngineWidgets REQUIRED)
+  find_package(Qt5 COMPONENTS Core Widgets Gui Concurrent Network OpenGL PrintSupport Xml Svg LinguistTools WebEngineWidgets REQUIRED)
   add_compile_definitions(WITH_WEBENGINE)
 else()
-  find_package(Qt5 COMPONENTS Core Widgets Gui Concurrent Network OpenGL PrintSupport Xml Svg REQUIRED)
+  find_package(Qt5 COMPONENTS Core Widgets Gui Concurrent Network OpenGL PrintSupport Xml Svg LinguistTools REQUIRED)
 endif()
 
 find_package(Threads REQUIRED)
@@ -118,6 +118,61 @@ SET(RESOURCES
     ${QTAPP_ROOT}/images/app.icns
     )
 
+SET(TS_FILES
+    ${QTAPP_ROOT}/lang/sonic-pi_ar.ts
+    ${QTAPP_ROOT}/lang/sonic-pi_bg.ts
+    ${QTAPP_ROOT}/lang/sonic-pi_bn.ts
+    ${QTAPP_ROOT}/lang/sonic-pi_bs.ts
+    ${QTAPP_ROOT}/lang/sonic-pi_ca.ts
+    ${QTAPP_ROOT}/lang/sonic-pi_ca@valencia.ts
+    ${QTAPP_ROOT}/lang/sonic-pi_cs.ts
+    ${QTAPP_ROOT}/lang/sonic-pi_da.ts
+    ${QTAPP_ROOT}/lang/sonic-pi_de.ts
+    ${QTAPP_ROOT}/lang/sonic-pi_el.ts
+    ${QTAPP_ROOT}/lang/sonic-pi_en_AU.ts
+    ${QTAPP_ROOT}/lang/sonic-pi_en_US.ts
+    ${QTAPP_ROOT}/lang/sonic-pi_eo.ts
+    ${QTAPP_ROOT}/lang/sonic-pi_es.ts
+    ${QTAPP_ROOT}/lang/sonic-pi_et.ts
+    ${QTAPP_ROOT}/lang/sonic-pi_eu.ts
+    ${QTAPP_ROOT}/lang/sonic-pi_fa.ts
+    ${QTAPP_ROOT}/lang/sonic-pi_fi.ts
+    ${QTAPP_ROOT}/lang/sonic-pi_fr.ts
+    ${QTAPP_ROOT}/lang/sonic-pi_ga.ts
+    ${QTAPP_ROOT}/lang/sonic-pi_gl.ts
+    ${QTAPP_ROOT}/lang/sonic-pi_he.ts
+    ${QTAPP_ROOT}/lang/sonic-pi_hi.ts
+    ${QTAPP_ROOT}/lang/sonic-pi_hu.ts
+    ${QTAPP_ROOT}/lang/sonic-pi_hy.ts
+    ${QTAPP_ROOT}/lang/sonic-pi_id.ts
+    ${QTAPP_ROOT}/lang/sonic-pi_is.ts
+    ${QTAPP_ROOT}/lang/sonic-pi_it.ts
+    ${QTAPP_ROOT}/lang/sonic-pi_ja.ts
+    ${QTAPP_ROOT}/lang/sonic-pi_ka.ts
+    ${QTAPP_ROOT}/lang/sonic-pi_ko.ts
+    ${QTAPP_ROOT}/lang/sonic-pi_nb.ts
+    ${QTAPP_ROOT}/lang/sonic-pi_nl.ts
+    ${QTAPP_ROOT}/lang/sonic-pi_pl.ts
+    ${QTAPP_ROOT}/lang/sonic-pi_pt_BR.ts
+    ${QTAPP_ROOT}/lang/sonic-pi_pt.ts
+    ${QTAPP_ROOT}/lang/sonic-pi_ro.ts
+    ${QTAPP_ROOT}/lang/sonic-pi_ru.ts
+    ${QTAPP_ROOT}/lang/sonic-pi_si.ts
+    ${QTAPP_ROOT}/lang/sonic-pi_sk.ts
+    ${QTAPP_ROOT}/lang/sonic-pi_sl.ts
+    ${QTAPP_ROOT}/lang/sonic-pi_sv.ts
+    ${QTAPP_ROOT}/lang/sonic-pi_sw.ts
+    ${QTAPP_ROOT}/lang/sonic-pi_th.ts
+    ${QTAPP_ROOT}/lang/sonic-pi_tr.ts
+    ${QTAPP_ROOT}/lang/sonic-pi_ug.ts
+    ${QTAPP_ROOT}/lang/sonic-pi_uk.ts
+    ${QTAPP_ROOT}/lang/sonic-pi_vi.ts
+    ${QTAPP_ROOT}/lang/sonic-pi_zh_HK.ts
+    ${QTAPP_ROOT}/lang/sonic-pi_zh_TW.ts
+    ${QTAPP_ROOT}/lang/sonic-pi_zh-Hans.ts
+    ${QTAPP_ROOT}/lang/sonic-pi_zh.ts
+)
+
 # Enable tracy profiler on debug and rel with debug builds
 if(WIN32)
     SET (SOURCES ${SOURCES} ${APP_ROOT}/external/tracy/TracyClient.cpp)
@@ -134,6 +189,15 @@ if (APPLE)
   _add_executable(${APP_NAME} MACOSX_BUNDLE ${ALL_SOURCES} ${RESOURCES} )
 else()
   add_executable(${APP_NAME} WIN32 ${ALL_SOURCES} ${RESOURCES}) # Win32 ignored on non-windows
+endif()
+
+# Translations: Convert the .ts files into .qm files
+set_source_files_properties(${TS_FILES} PROPERTIES OUTPUT_LOCATION ${QTAPP_ROOT}/lang)
+if (Qt6_FOUND)
+  qt_add_lrelease(${APP_NAME} TS_FILES ${TS_FILES})
+else()
+  qt5_add_translation(QM_FILES ${TS_FILES})
+  set_property(SOURCE ${APP_NAME} APPEND PROPERTY OBJECT_DEPENDS ${QM_FILES})
 endif()
 
 if (APPLE)

--- a/app/linux-prebuild.sh
+++ b/app/linux-prebuild.sh
@@ -63,9 +63,6 @@ echo "Generating docs for the Qt GUI..."
 cp "${SCRIPT_DIR}"/gui/qt/utils/ruby_help.tmpl "${SCRIPT_DIR}"/gui/qt/utils/ruby_help.h
 ruby "${SCRIPT_DIR}"/server/ruby/bin/qt-doc.rb -o "${SCRIPT_DIR}"/gui/qt/utils/ruby_help.h
 
-echo "Updating GUI translation files..."
-PATH=`pkg-config --variable bindir Qt5`:$PATH lrelease "${SCRIPT_DIR}"/gui/qt/lang/*.ts
-
 echo "Compiling Erlang/Elixir files..."
 cd "${SCRIPT_DIR}"/server/beam/tau
 

--- a/app/mac-prebuild.sh
+++ b/app/mac-prebuild.sh
@@ -101,10 +101,6 @@ echo "Generating docs for the Qt GUI..."
 cp "${SCRIPT_DIR}"/gui/qt/utils/ruby_help.tmpl "${SCRIPT_DIR}"/gui/qt/utils/ruby_help.h
 "$RUBY" "${SCRIPT_DIR}"/server/ruby/bin/qt-doc.rb -o "${SCRIPT_DIR}"/gui/qt/utils/ruby_help.h
 
-echo "Updating GUI translation files..."
-# Use lrelease on PATH if available otherwise assume Qt was installed via homebrew
-PATH="$PATH:$QT5_BIN_DIR" lrelease "${SCRIPT_DIR}"/gui/qt/lang/*.ts
-
 echo "Compiling Erlang/Elixir files..."
 cd "${SCRIPT_DIR}"/server/beam/tau
 

--- a/app/mac-prebuild.sh
+++ b/app/mac-prebuild.sh
@@ -2,11 +2,6 @@
 set -e # Quit script on error
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 WORKING_DIR="$(pwd)"
-if command -v brew &> /dev/null && [ -x "$(brew --prefix)"/opt/qt@5/bin/lrelease ]; then
-    QT5_BIN_DIR="$(brew --prefix)"/opt/qt@5/bin
-else
-    QT5_BIN_DIR="${QT5_BIN_DIR:-}"
-fi
 
 cd "${SCRIPT_DIR}"
 

--- a/app/win-pre-translations.bat
+++ b/app/win-pre-translations.bat
@@ -9,7 +9,4 @@ server\native\ruby\bin\ruby server/ruby/bin/i18n-tool.rb -t
 copy /Y gui\qt\utils\ruby_help.tmpl gui\qt\utils\ruby_help.h
 server\native\ruby\bin\ruby server/ruby/bin/qt-doc.rb -o gui\qt\utils/ruby_help.h
 
-@echo Updating GUI translation files...
-forfiles /p gui\qt\lang /s /m *.ts /c "cmd /c %QT_INSTALL_LOCATION%\bin\lrelease.exe @file"
-
 cd %WORKING_DIR%


### PR DESCRIPTION
This PR moves the step which runs lrelease on the .ts files into the CMakeList, which runs it at build time.
This needs testing to see if it works fine on Qt6.

This is done using the Qt Linguist Tools cmake functions.

In Qt6 there's `qt_add_lrelease` which runs lrelease and sets the files as dependencies to the target: https://doc-snapshots.qt.io/qt6-6.3/qtlinguist-cmake-qt-add-lrelease.html

In Qt5 there's `qt5_add_translation` which converts .ts to .qm files, but the qm files then have to be manually added as dependencies to the target: https://doc.qt.io/qt-5/qtlinguist-cmake-qt5-add-translation.html