### PR TITLE
Build - clear out only generated files from server/beam/tau/priv

### DIFF
--- a/app/linux-clean.sh
+++ b/app/linux-clean.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
+shopt -s globstar
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 WORKING_DIR="$(pwd)"
-cd ${SCRIPT_DIR}
+cd "${SCRIPT_DIR}"
 
 echo "Cleaning out build dir...."
 rm -rf build
@@ -12,8 +13,11 @@ rm -rf external/build
 
 echo "Cleaning out BEAM distribution..."
 rm -rf server/beam/tau/_build
-rm -rf server/beam/tau/priv
-mkdir -p server/beam/tau/priv
+rm -rf server/beam/tau/priv/static/assets
+rm -rf server/beam/tau/priv/*.{so,dylib,dll}
+rm -rf server/beam/tau/priv/static/cache_manifest.json
+rm -rf server/beam/tau/priv/static/**/*.gz
+rm -rf server/beam/tau/priv/static/**/*-????????????????????????????????.*
 
 echo "Cleaning completed"
 

--- a/app/win-clean.bat
+++ b/app/win-clean.bat
@@ -10,8 +10,11 @@ rmdir external\build /s /q
 
 @echo Cleaning out BEAM distribution....
 rmdir server\beam\tau\_build /s /q
-rmdir server\beam\tau\priv /s /q
-mkdir server\beam\tau\priv
+rmdir server\beam\tau\priv\static\assets /s /q
+del server\beam\tau\priv\*.so server\beam\tau\priv\*.dylib server\beam\tau\priv\*.dll /s /q
+del server\beam\tau\priv\static\cache_manifest.json /s /q
+del server\beam\tau\priv\static\*.gz /s /q
+del server\beam\tau\priv\static\*-????????????????????????????????.* /s /q
 
 @echo Cleaning completed
 


### PR DESCRIPTION
Since commit 567b960, the clean scripts might delete non-generated files from this repository in [`app/server/beam/tau/priv`](https://github.com/sonic-pi-net/sonic-pi/tree/a84e11b/app/server/beam/tau/priv)

This PR fixes this by deleting files in `app/server/beam/tau/priv` based on the current contents in the [.gitignore](https://github.com/sonic-pi-net/sonic-pi/blob/a84e11b/app/server/beam/tau/.gitignore) for the Tau server

I have not tested the `win-clean.bat` script since I don't have a dev environment on my Windows computer, so that needs to be tested before merging. It should work, though, since I tested the individual parts of the commands with fake files and folders on my Windows machine

Edit: I also just pushed a drive-by change to fix quoting for `${SCRIPT_DIR}`, which could cause problems when the dev environment is in a path with spaces or special bash characters