### PR TITLE
Spider - remove duplicate dash in version and use 7-digit git hash

### DIFF
--- a/app/server/ruby/lib/sonicpi/runtime.rb
+++ b/app/server/ruby/lib/sonicpi/runtime.rb
@@ -1375,9 +1375,9 @@ module SonicPi
       @user_methods = user_methods
 
       @git_hash = __extract_git_hash
-      gh_short = @git_hash ? "-#{@git_hash[0, 5]}" : ""
+      gh_short = @git_hash ? "-#{@git_hash[0, 7]}" : ""
       @settings = Config::Settings.new(Paths.system_cache_store_path)
-      @version = Version.new(4, 0, 0, "beta-#{gh_short}")
+      @version = Version.new(4, 0, 0, "beta#{gh_short}")
       @server_version = __server_version
       @life_hooks = LifeCycleHooks.new
       @cue_events = IncomingEvents.new


### PR DESCRIPTION
I fixed the double dash in the spider server version (ref: https://github.com/sonic-pi-net/sonic-pi/commit/f4b17fffdeb143e8eb19c3d14ed440f2f6e037f1#commitcomment-66644446) and switched it from a 5-digit hash segment to a 7-digit one. This length is the default for Git/GitHub interfaces because a 5-digit hash segment is much more likely to be ambiguous

@samaaron @ethancrawford Does this seem reasonable?

Edit: CI will be failing until erlef/setup-beam#91 is merged because it looks like the Windows builds default to `windows-2022` now, for which support in the BEAM action is not merged yet