### PR TITLE
GUI - miscellaneous Qt Tau/PhX widget fixes

### DIFF
--- a/app/gui/qt/CMakeLists.txt
+++ b/app/gui/qt/CMakeLists.txt
@@ -44,6 +44,9 @@ if(Qt6_FOUND AND WITH_QT_GUI_WEBENGINE)
   add_compile_definitions(WITH_WEBENGINE)
 elseif(Qt6_FOUND)
   find_package(Qt6 COMPONENTS Core Widgets Gui Concurrent Network OpenGLWidgets PrintSupport Xml Svg REQUIRED)
+elseif(WITH_QT_GUI_WEBENGINE)
+  find_package(Qt5 COMPONENTS Core Widgets Gui Concurrent Network OpenGL PrintSupport Xml Svg WebEngineWidgets REQUIRED)
+  add_compile_definitions(WITH_WEBENGINE)
 else()
   find_package(Qt5 COMPONENTS Core Widgets Gui Concurrent Network OpenGL PrintSupport Xml Svg REQUIRED)
 endif()
@@ -97,7 +100,7 @@ set(SOURCES
     ${QTAPP_ROOT}/model/settings.h
     )
 
-  if(Qt6_FOUND AND WITH_QT_GUI_WEBENGINE)
+  if(WITH_QT_GUI_WEBENGINE)
     set(SOURCES
       ${SOURCES}
       ${QTAPP_ROOT}/widgets/phxwebview.h

--- a/app/gui/qt/widgets/phxwebview.cpp
+++ b/app/gui/qt/widgets/phxwebview.cpp
@@ -17,8 +17,10 @@
 PhxWebView::PhxWebView(QWidget *parent)
     : QWebEngineView(parent)
 {
-    phxProfile = new QWebEngineProfile(this);
-    phxPage = new QWebEnginePage(phxProfile, this);
+    phxProfile = new QWebEngineProfile();
+    phxPage = new QWebEnginePage(phxProfile);
+    phxPage->setParent(this);
+    phxProfile->setParent(this);
     setPage(phxPage);
     setContextMenuPolicy(Qt::NoContextMenu);
     setZoomFactor(2.0);

--- a/app/gui/qt/widgets/phxwidget.cpp
+++ b/app/gui/qt/widgets/phxwidget.cpp
@@ -32,7 +32,7 @@ PhxWidget::PhxWidget(QWidget *parent)
   phxView->setSizePolicy(sp_retain);
   phxView->hide();
   mainLayout = new QHBoxLayout(this);
-  topRowSubLayout = new QVBoxLayout(this);
+  topRowSubLayout = new QVBoxLayout();
   sizeDownButton = new QPushButton("-");
   sizeUpButton = new QPushButton("+");
   openExternalBrowserButton = new QPushButton(" E ");
@@ -50,7 +50,6 @@ PhxWidget::PhxWidget(QWidget *parent)
 
   mainLayout->addWidget(phxView, 1);
   mainLayout->addLayout(topRowSubLayout);
-
 
   connect(sizeDownButton, &QPushButton::released, this, &PhxWidget::handleSizeDown);
   connect(sizeUpButton, &QPushButton::released, this, &PhxWidget::handleSizeUp);


### PR DESCRIPTION
The build change allows using Qt5 WebEngine for the Tau/PhX widget. Even though we only want to support Qt6 WebEngine, it still works just fine with Qt5 and this is a low-maintenance change and won't affect official builds (also the feature is disabled by default). I'm mostly wanting this so I can continue to play with the widget on my system which does not yet support Qt6


The second change fixes Qt object parenting and layout assignment which were causing the following runtime errors in the console

Object destruction order error, fixed by reversing the order the objects are assigned to the parent:
```
Release of profile requested but WebEnginePage still not deleted. Expect troubles !
```

Layout attempted to be overridden error, fixed by only setting the layout for `PhxWidget` (via the `QBoxLayout` constructor) once:
```
QLayout: Attempting to add QLayout "" to PhxWidget "", which already has a layout
```

Edit: CI will be failing until https://github.com/erlef/setup-beam/pull/91 is merged because it looks like the Windows builds default to `windows-2022` now, for which support in the BEAM action is not merged yet