### PR TITLE
Comms token

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,8 +22,8 @@ jobs:
            - { title: "Linux", os: "ubuntu-latest", cc: "clang", arch: "x64", build_type: "Debug" }
            - { title: "Linux", os: "ubuntu-latest", cc: "gcc", arch: "x64", build_type: "Release" }
            - { title: "Linux", os: "ubuntu-latest", cc: "gcc", arch: "x64", build_type: "Debug" }
-           - { title: "Windows", os: "windows-latest", cc: "vs2019", arch: "x64", build_type: "Release" }
-           - { title: "Windows", os: "windows-latest", cc: "vs2019", arch: "x64", build_type: "Debug" }
+           - { title: "Windows", os: "windows-latest", cc: "vs2022", arch: "x64", build_type: "Release" }
+           - { title: "Windows", os: "windows-latest", cc: "vs2022", arch: "x64", build_type: "Debug" }
            - { title: "Mac", os: "macos-latest", cc: "clang", arch: "x64", build_type: "Release" }
            - { title: "Mac", os: "macos-latest", cc: "clang", arch: "x64", build_type: "Debug" }
 

--- a/app/api/include/api/sonicpi_api.h
+++ b/app/api/include/api/sonicpi_api.h
@@ -270,7 +270,7 @@ public:
     // Stop all music
     virtual void Stop();
 
-    virtual void BufferNewLineAndIndent(int point_line, int point_index, int first_line, const std::string& code, const std::string& fileName, const std::string& id);
+    virtual void BufferNewLineAndIndent(int point_line, int point_index, int first_line, const std::string& code, const std::string& fileName);
 
     // ** Audio processor
 

--- a/app/api/include/api/sonicpi_api.h
+++ b/app/api/include/api/sonicpi_api.h
@@ -62,7 +62,7 @@ enum class SonicPiPortId
     gui_listen_to_spider,
     gui_send_to_spider,
     scsynth,
-    server_osc_cues,
+    tau_osc_cues,
     tau,
     phx_http
 };

--- a/app/api/include/api/sonicpi_api.h
+++ b/app/api/include/api/sonicpi_api.h
@@ -63,6 +63,7 @@ enum class SonicPiPortId
     gui_send_to_spider,
     scsynth,
     server_osc_cues,
+    tau,
     phx_http
 };
 
@@ -287,8 +288,7 @@ public:
 
     std::string GetLogs();
 
-    const std::string& GetGuid() const;
-
+    const int GetGuid() const;
 
     virtual bool TestAudio();
 
@@ -299,6 +299,7 @@ public:
     virtual const int& GetPort(SonicPiPortId port);
 
     virtual bool SendOSC(oscpkt::Message m);
+    virtual bool TauSendOSC(oscpkt::Message m);
 
     virtual void LoadWorkspaces();
 
@@ -350,9 +351,9 @@ private:
     std::shared_ptr<OscServer> m_spOscSpiderServer;
     std::shared_ptr<OscSender> m_spOscSpiderSender;
     std::shared_ptr<OscSender> m_spOscKeepAliveSender;
+    std::shared_ptr<OscSender> m_spOscTauSender;
     std::shared_ptr<AudioProcessor> m_spAudioProcessor;
-    std::string m_guid;
-    std::string m_kill_token;
+    int m_token;
 
     IAPIClient* m_pClient = nullptr;
     APIProtocol m_protocol = APIProtocol::UDP;

--- a/app/api/include/api/sonicpi_api.h
+++ b/app/api/include/api/sonicpi_api.h
@@ -102,7 +102,7 @@ enum class MessageType
     Message,
     Info,
     InfoText,
-    Muti
+    Multi
 };
 
 struct MessageData

--- a/app/api/src/osc/osc_handler.cpp
+++ b/app/api/src/osc/osc_handler.cpp
@@ -50,7 +50,7 @@ void OscHandler::oscMessage(std::vector<char> buffer)
         if (msg->match("/log/multi_message"))
         {
             MessageInfo message;
-            message.type = MessageType::Muti;
+            message.type = MessageType::Multi;
 
             oscpkt::Message::ArgReader ar = msg->arg();
             ar.popInt32(message.jobId);

--- a/app/api/src/osc/udp_osc_server.cpp
+++ b/app/api/src/osc/udp_osc_server.cpp
@@ -60,9 +60,6 @@ void OscServerUDP::start()
         {
             handler->oscMessage(sock.buffer);
             std::vector<char>().swap(sock.buffer);
-
-            // TODO what's this for???
-            std::cout << std::flush;
         }
     }
 

--- a/app/api/src/sonicpi_api.cpp
+++ b/app/api/src/sonicpi_api.cpp
@@ -356,8 +356,7 @@ void SonicPiAPI::Shutdown()
     m_state = State::Reset;
     LOG(INFO, "API State set to: Reset...");
     LOG(INFO, "Waiting for Daemon keep alive loop to have stopped...");
-
-    LOG(INFO, "Sending /daemon/exit to daemon's kill switch with token " << m_kill_token) ;
+    LOG(INFO, "Sending /daemon/exit to daemon's kill switch with token " << std::to_string(m_token)) ;
     Message msg("/daemon/exit");
     msg.pushInt32(m_token);
     m_spOscKeepAliveSender->sendOSC(msg);

--- a/app/api/src/sonicpi_api.cpp
+++ b/app/api/src/sonicpi_api.cpp
@@ -826,7 +826,7 @@ const int SonicPiAPI::GetGuid() const
     return m_token;
 }
 
-void SonicPiAPI::BufferNewLineAndIndent(int point_line, int point_index, int first_line, const std::string& code, const std::string& fileName, const std::string& id)
+void SonicPiAPI::BufferNewLineAndIndent(int point_line, int point_index, int first_line, const std::string& code, const std::string& fileName)
 {
     Message msg("/buffer-newline-and-indent");
     msg.pushInt32(m_token);

--- a/app/api/src/sonicpi_api.cpp
+++ b/app/api/src/sonicpi_api.cpp
@@ -276,8 +276,10 @@ bool SonicPiAPI::StartBootDaemon()
     m_ports[SonicPiPortId::phx_http] = std::stoi(daemon_stdout[6]);
     m_token = std::stoi(daemon_stdout[7]);
 
-    m_spOscSpiderSender = std::make_shared<OscSender>(m_ports[SonicPiPortId::gui_send_to_spider]);
+    LOG(INFO, "Setting up OSC sender to Spider on port " << m_ports[SonicPiPortId::gui_send_to_spider]);
+    m_spOscSpiderSender    = std::make_shared<OscSender>(m_ports[SonicPiPortId::gui_send_to_spider]);
 
+    LOG(INFO, "Setting up OSC sender to Daemon on port " << m_ports[SonicPiPortId::daemon_keep_alive]);
     m_spOscKeepAliveSender = std::make_shared<OscSender>(m_ports[SonicPiPortId::daemon_keep_alive]);
 
     LOG(INFO, "Setting up OSC sender to Tau on port " << m_ports[SonicPiPortId::tau]);
@@ -445,7 +447,7 @@ bool SonicPiAPI::WaitUntilReady()
             LOG(ERR, "Oh no, Spider Server got to an Error State whilst starting...");
             return false;
         }
-        LOG(ERR, "Waiting Until Ready... " + std::to_string(num_tries));
+        LOG(INFO, "Waiting Until Ready... " + std::to_string(num_tries));
         std::this_thread::sleep_for(1s);
     }
 

--- a/app/api/src/sonicpi_api.cpp
+++ b/app/api/src/sonicpi_api.cpp
@@ -243,7 +243,7 @@ bool SonicPiAPI::StartBootDaemon()
 
     if(ec || bytes_read < 0) {
       if(ec) {
-        LOG(ERR, "Error reading ports via Boot Daemon STDOUT");
+        LOG(ERR, "Error reading ports via Boot Daemon STDOUT: " << ec);
       } else {
         LOG(ERR, "Failed to read ports via Boot Daemon STDOUT. Bytes read: " + std::to_string(bytes_read));
 

--- a/app/api/src/sonicpi_api.cpp
+++ b/app/api/src/sonicpi_api.cpp
@@ -379,12 +379,12 @@ bool SonicPiAPI::StartOscServer()
     if (m_protocol == APIProtocol::UDP)
 
       {
-        auto listenPort = GetPort(SonicPiPortId::gui_listen_to_spider);
+          auto listenPort = GetPort(SonicPiPortId::gui_listen_to_spider);
 
-        m_spOscSpiderServer = std::make_shared<OscServerUDP>(m_pClient, std::make_shared<OscHandler>(m_pClient), listenPort);
-        m_oscServerThread = std::thread([&]() {
-            m_spOscSpiderServer->start();
-            LOG(DBG, "Osc Server Thread Exiting");
+          m_spOscSpiderServer = std::make_shared<OscServerUDP>(m_pClient, std::make_shared<OscHandler>(m_pClient), listenPort);
+          m_oscServerThread = std::thread([&]() {
+              m_spOscSpiderServer->start();
+              LOG(DBG, "Osc Server Thread Exiting");
         });
     }
     else
@@ -443,8 +443,8 @@ bool SonicPiAPI::WaitUntilReady()
         num_tries--;
         if (m_state == State::Error)
         {
-          LOG(ERR, "Oh no, Spider Server got to an Error State whilst starting...");
-          return false;
+            LOG(ERR, "Oh no, Spider Server got to an Error State whilst starting...");
+            return false;
         }
         LOG(ERR, "Waiting Until Ready... " + std::to_string(num_tries));
         std::this_thread::sleep_for(1s);
@@ -452,9 +452,9 @@ bool SonicPiAPI::WaitUntilReady()
 
     if (num_tries < 1)
     {
-      return false;
+        return false;
     } else {
-      return true;
+        return true;
     }
 }
 
@@ -466,8 +466,8 @@ bool SonicPiAPI::PingUntilServerCreated()
 
     if (m_state == State::Created)
     {
-      LOG(ERR, "Error! No need to ping server as it's already created!");
-      return true;
+        LOG(ERR, "Error! No need to ping server as it's already created!");
+        return true;
     }
 
     if (m_state != State::Initializing)
@@ -665,7 +665,7 @@ bool SonicPiAPI::InitializePaths(const fs::path& root)
     }
 
     // Set Ruby script paths
-    m_paths[SonicPiPath::BootDaemonPath]      = m_paths[SonicPiPath::RootPath] / "app/server/ruby/bin/daemon.rb";
+   m_paths[SonicPiPath::BootDaemonPath]      = m_paths[SonicPiPath::RootPath] / "app/server/ruby/bin/daemon.rb";
     m_paths[SonicPiPath::FetchUrlPath]        = m_paths[SonicPiPath::RootPath] / "app/server/ruby/bin/fetch-url.rb";
 
     // Set Log paths

--- a/app/api/src/sonicpi_api.cpp
+++ b/app/api/src/sonicpi_api.cpp
@@ -271,7 +271,7 @@ bool SonicPiAPI::StartBootDaemon()
     m_ports[SonicPiPortId::gui_listen_to_spider] = std::stoi(daemon_stdout[1]);
     m_ports[SonicPiPortId::gui_send_to_spider] = std::stoi(daemon_stdout[2]);
     m_ports[SonicPiPortId::scsynth] = std::stoi(daemon_stdout[3]);
-    m_ports[SonicPiPortId::server_osc_cues] = std::stoi(daemon_stdout[4]);
+    m_ports[SonicPiPortId::tau_osc_cues] = std::stoi(daemon_stdout[4]);
     m_ports[SonicPiPortId::tau] = std::stoi(daemon_stdout[5]);
     m_ports[SonicPiPortId::phx_http] = std::stoi(daemon_stdout[6]);
     m_token = std::stoi(daemon_stdout[7]);

--- a/app/gui/imgui/app.cpp
+++ b/app/gui/imgui/app.cpp
@@ -24,7 +24,7 @@ void SPClient::Report(const MessageInfo& info)
     {
         log_window_add_log(info.style, info.text + "\n");
     }
-    else if (info.type == MessageType::Muti)
+    else if (info.type == MessageType::Multi)
     {
         std::ostringstream str;
         str << "{run: " << info.jobId << ", time: " << info.runtime;

--- a/app/gui/qt/mainwindow.cpp
+++ b/app/gui/qt/mainwindow.cpp
@@ -210,8 +210,9 @@ MainWindow::MainWindow(QApplication& app, QSplashScreen* splash)
 #endif
 
         scopeWindow->Booted();
-        std::cout << "[GUI] - honour prefs" << std::endl;
+        std::cout << "[GUI] - restore windows" << std::endl;
         restoreWindows();
+        std::cout << "[GUI] - honour prefs" << std::endl;
         honourPrefs();
         std::cout << "[GUI] - update prefs icon" << std::endl;
         updatePrefsIcon();

--- a/app/gui/qt/mainwindow.cpp
+++ b/app/gui/qt/mainwindow.cpp
@@ -3238,14 +3238,27 @@ void MainWindow::restoreWindows()
 
     docsplit->restoreState(gui_settings->value("docsplitState").toByteArray());
     //bool visualizer = piSettings->show_scopes;
-    restoreState(gui_settings->value("windowState").toByteArray());
     //    restoreGeometry(settings.value("windowGeom").toByteArray());
+
+    auto current_state = saveState();
+
+    // clear windowState - in some circumstances an invalid windowState
+    // can crash the GUI. Therefore clear it now in case we do have a
+    // crash after which a restart should start up fine with a fresh new
+    // state. If there is no crash, we still store the windowState
+    // immidiately prior to shutting down.
+    gui_settings->remove("windowState");
+    gui_settings->sync();
+
+    // Note: this line has crashed with bad state in the past. It wasn't
+    // possible to rescue any exceptions.
+    restoreState(gui_settings->value("windowState").toByteArray();
+
 
     //    if (visualizer != piSettings->show_scopes) {
     //        piSettings->show_scopes = visualizer;
     //        scope();
     //    }
-
     resize(size);
     move(pos);
 }

--- a/app/gui/qt/mainwindow.cpp
+++ b/app/gui/qt/mainwindow.cpp
@@ -3252,7 +3252,7 @@ void MainWindow::restoreWindows()
 
     // Note: this line has crashed with bad state in the past. It wasn't
     // possible to rescue any exceptions.
-    restoreState(gui_settings->value("windowState").toByteArray();
+    restoreState(gui_settings->value("windowState").toByteArray());
 
 
     //    if (visualizer != piSettings->show_scopes) {

--- a/app/gui/qt/mainwindow.cpp
+++ b/app/gui/qt/mainwindow.cpp
@@ -394,7 +394,7 @@ void MainWindow::setupWindowStructure()
     prefsWidget->setAllowedAreas(Qt::RightDockWidgetArea);
     prefsWidget->setFeatures(QDockWidget::DockWidgetClosable);
 
-    settingsWidget = new SettingsWidget(m_spAPI->GetPort(SonicPiPortId::server_osc_cues), i18n, piSettings, sonicPii18n, this);
+    settingsWidget = new SettingsWidget(m_spAPI->GetPort(SonicPiPortId::tau_osc_cues), i18n, piSettings, sonicPii18n, this);
     connect(settingsWidget, SIGNAL(restartApp()), this, SLOT(restartApp()));
     connect(settingsWidget, SIGNAL(volumeChanged(int)), this, SLOT(changeSystemPreAmp(int)));
     connect(settingsWidget, SIGNAL(mixerSettingsChanged()), this, SLOT(mixerSettingsChanged()));
@@ -2912,7 +2912,7 @@ void MainWindow::createToolBar()
     }
 
     QMenu* incomingOSCPortMenu = ioMenu->addMenu(tr("Incoming OSC Port"));
-    incomingOSCPortMenu->addAction(QString::number(m_spAPI->GetPort(SonicPiPortId::server_osc_cues)));
+    incomingOSCPortMenu->addAction(QString::number(m_spAPI->GetPort(SonicPiPortId::tau_osc_cues)));
 
     viewMenu = menuBar()->addMenu(tr("View"));
 

--- a/app/gui/qt/mainwindow.cpp
+++ b/app/gui/qt/mainwindow.cpp
@@ -462,9 +462,9 @@ void MainWindow::setupWindowStructure()
         connect(workspace,
                 &SonicPiScintilla::bufferNewlineAndIndent,
                 this,
-                [this](int point_line, int point_index, int first_line, const std::string& code, const std::string& fileName, const std::string& id)
+                [this](int point_line, int point_index, int first_line, const std::string& code, const std::string& fileName)
                 {
-                  m_spAPI->BufferNewLineAndIndent(point_line, point_index, first_line, code, fileName, id);
+                  m_spAPI->BufferNewLineAndIndent(point_line, point_index, first_line, code, fileName);
                 });
 
         workspace->setObjectName(QString("Buffer %1").arg(ws));

--- a/app/gui/qt/mainwindow.cpp
+++ b/app/gui/qt/mainwindow.cpp
@@ -145,7 +145,7 @@ MainWindow::MainWindow(QApplication& app, QSplashScreen* splash)
     const QRect rect = this->geometry();
     m_appWindowSizeRect = std::make_shared<QRect>(rect);
 
-    guiID = QString::fromStdString(m_spAPI->GetGuid());
+    guiID = m_spAPI->GetGuid();
 
     this->sonicPii18n = new SonicPii18n(rootPath());
     std::cout << "[GUI] - Language setting: " << piSettings->language.toUtf8().constData() << std::endl;
@@ -791,7 +791,7 @@ void MainWindow::handleCustomUrl(const QUrl& url)
                        "sample :"
             + sample;
         Message msg("/run-code");
-        msg.pushStr(guiID.toStdString());
+        msg.pushInt32(guiID);
         msg.pushStr(code.toStdString());
         if (sendOSC(msg))
         {
@@ -1070,7 +1070,7 @@ void MainWindow::completeSnippetOrIndentCurrentLineOrSelection(SonicPiScintilla*
     std::string code = ws->text().toStdString();
 
     Message msg("/buffer-section-complete-snippet-or-indent-selection");
-    msg.pushStr(guiID.toStdString());
+    msg.pushInt32(guiID);
     std::string filename = ws->fileName.toStdString();
     msg.pushStr(filename);
     msg.pushStr(code);
@@ -1107,7 +1107,7 @@ void MainWindow::toggleComment(SonicPiScintilla* ws)
     std::string code = ws->text().toStdString();
 
     Message msg("/buffer-section-toggle-comment");
-    msg.pushStr(guiID.toStdString());
+    msg.pushInt32(guiID);
     std::string filename = ws->fileName.toStdString();
     msg.pushStr(filename);
     msg.pushStr(code);
@@ -1417,7 +1417,7 @@ void MainWindow::loadWorkspaces()
     for (int i = 0; i < workspace_max; i++)
     {
         Message msg("/load-buffer");
-        msg.pushStr(guiID.toStdString());
+        msg.pushInt32(guiID);
         std::string s = "workspace_" + number_name(i);
         msg.pushStr(s);
         sendOSC(msg);
@@ -1432,7 +1432,7 @@ void MainWindow::saveWorkspaces()
     {
         std::string code = workspaces[i]->text().toStdString();
         Message msg("/save-buffer");
-        msg.pushStr(guiID.toStdString());
+        msg.pushInt32(guiID);
         std::string s = "workspace_" + number_name(i);
         msg.pushStr(s);
         msg.pushStr(code);
@@ -1582,7 +1582,7 @@ void MainWindow::runCode()
 
     //std::string code = ws->text().toStdString();
     Message msg("/save-and-run-buffer");
-    msg.pushStr(guiID.toStdString());
+    msg.pushInt32(guiID);
 
     std::string filename = ((SonicPiScintilla*)tabs->currentWidget())->fileName.toStdString();
     msg.pushStr(filename);
@@ -1629,7 +1629,7 @@ void MainWindow::beautifyCode()
     ws->getCursorPosition(&line, &index);
     int first_line = ws->firstVisibleLine();
     Message msg("/buffer-beautify");
-    msg.pushStr(guiID.toStdString());
+    msg.pushInt32(guiID);
     std::string filename = ((SonicPiScintilla*)tabs->currentWidget())->fileName.toStdString();
     msg.pushStr(filename);
     msg.pushStr(code);
@@ -1648,7 +1648,7 @@ void MainWindow::reloadServerCode()
 {
     statusBar()->showMessage(tr("Reloading..."), 2000);
     Message msg("/reload");
-    msg.pushStr(guiID.toStdString());
+    msg.pushInt32(guiID);
     sendOSC(msg);
 }
 
@@ -1656,7 +1656,7 @@ void MainWindow::check_for_updates_now()
 {
     statusBar()->showMessage(tr("Checking for updates..."), 2000);
     Message msg("/check-for-updates-now");
-    msg.pushStr(guiID.toStdString());
+    msg.pushInt32(guiID);
     sendOSC(msg);
 }
 
@@ -1664,7 +1664,7 @@ void MainWindow::enableCheckUpdates()
 {
     statusBar()->showMessage(tr("Enabling update checking..."), 2000);
     Message msg("/enable-update-checking");
-    msg.pushStr(guiID.toStdString());
+    msg.pushInt32(guiID);
     sendOSC(msg);
 }
 
@@ -1672,7 +1672,7 @@ void MainWindow::disableCheckUpdates()
 {
     statusBar()->showMessage(tr("Disabling update checking..."), 2000);
     Message msg("/disable-update-checking");
-    msg.pushStr(guiID.toStdString());
+    msg.pushInt32(guiID);
     sendOSC(msg);
 }
 
@@ -1680,7 +1680,7 @@ void MainWindow::mixerHpfEnable(float freq)
 {
     statusBar()->showMessage(tr("Enabling Mixer HPF..."), 2000);
     Message msg("/mixer-hpf-enable");
-    msg.pushStr(guiID.toStdString());
+    msg.pushInt32(guiID);
     msg.pushFloat(freq);
     sendOSC(msg);
 }
@@ -1689,7 +1689,7 @@ void MainWindow::mixerHpfDisable()
 {
     statusBar()->showMessage(tr("Disabling Mixer HPF..."), 2000);
     Message msg("/mixer-hpf-disable");
-    msg.pushStr(guiID.toStdString());
+    msg.pushInt32(guiID);
     sendOSC(msg);
 }
 
@@ -1697,7 +1697,7 @@ void MainWindow::mixerLpfEnable(float freq)
 {
     statusBar()->showMessage(tr("Enabling Mixer LPF..."), 2000);
     Message msg("/mixer-lpf-enable");
-    msg.pushStr(guiID.toStdString());
+    msg.pushInt32(guiID);
     msg.pushFloat(freq);
     sendOSC(msg);
 }
@@ -1706,7 +1706,7 @@ void MainWindow::mixerLpfDisable()
 {
     statusBar()->showMessage(tr("Disabling Mixer LPF..."), 2000);
     Message msg("/mixer-lpf-disable");
-    msg.pushStr(guiID.toStdString());
+    msg.pushInt32(guiID);
     sendOSC(msg);
 }
 
@@ -1714,7 +1714,7 @@ void MainWindow::mixerInvertStereo()
 {
     statusBar()->showMessage(tr("Enabling Inverted Stereo..."), 2000);
     Message msg("/mixer-invert-stereo");
-    msg.pushStr(guiID.toStdString());
+    msg.pushInt32(guiID);
     sendOSC(msg);
 }
 
@@ -1722,7 +1722,7 @@ void MainWindow::mixerStandardStereo()
 {
     statusBar()->showMessage(tr("Enabling Standard Stereo..."), 2000);
     Message msg("/mixer-standard-stereo");
-    msg.pushStr(guiID.toStdString());
+    msg.pushInt32(guiID);
     sendOSC(msg);
 }
 
@@ -1730,7 +1730,7 @@ void MainWindow::mixerMonoMode()
 {
     statusBar()->showMessage(tr("Mono Mode..."), 2000);
     Message msg("/mixer-mono-mode");
-    msg.pushStr(guiID.toStdString());
+    msg.pushInt32(guiID);
     sendOSC(msg);
 }
 
@@ -1738,7 +1738,7 @@ void MainWindow::mixerStereoMode()
 {
     statusBar()->showMessage(tr("Stereo Mode..."), 2000);
     Message msg("/mixer-stereo-mode");
-    msg.pushStr(guiID.toStdString());
+    msg.pushInt32(guiID);
     sendOSC(msg);
 }
 
@@ -1880,7 +1880,7 @@ void MainWindow::changeSystemPreAmp(int val, int silent)
     float v = (float)val;
     v = (v / 100.0) * 2.0;
     Message msg("/mixer-amp");
-    msg.pushStr(guiID.toStdString());
+    msg.pushInt32(guiID);
     msg.pushFloat(v);
     msg.pushInt32(silent);
     sendOSC(msg);
@@ -2387,7 +2387,7 @@ void MainWindow::wheelEvent(QWheelEvent* event)
 void MainWindow::stopRunningSynths()
 {
     Message msg("/stop-all-jobs");
-    msg.pushStr(guiID.toStdString());
+    msg.pushInt32(guiID);
     sendOSC(msg);
 }
 
@@ -3167,7 +3167,7 @@ void MainWindow::toggleRecording()
         // recAct->setText(tr("Stop Recording"));
         rec_flash_timer->start(500);
         Message msg("/start-recording");
-        msg.pushStr(guiID.toStdString());
+        msg.pushInt32(guiID);
         sendOSC(msg);
     }
     else
@@ -3177,7 +3177,7 @@ void MainWindow::toggleRecording()
         recAct->setIcon(theme->getRecIcon(is_recording, false));
 
         Message msg("/stop-recording");
-        msg.pushStr(guiID.toStdString());
+        msg.pushInt32(guiID);
         sendOSC(msg);
         QString lastDir = gui_settings->value("lastDir", QDir::homePath() + "/Desktop").toString();
         QString fileName = QFileDialog::getSaveFileName(this, tr("Save Recording"), lastDir, tr("Wavefile (*.wav)"));
@@ -3185,14 +3185,14 @@ void MainWindow::toggleRecording()
         {
             gui_settings->setValue("lastDir", QDir(fileName).absolutePath());
             Message msg("/save-recording");
-            msg.pushStr(guiID.toStdString());
+            msg.pushInt32(guiID);
             msg.pushStr(fileName.toStdString());
             sendOSC(msg);
         }
         else
         {
             Message msg("/delete-recording");
-            msg.pushStr(guiID.toStdString());
+            msg.pushInt32(guiID);
             sendOSC(msg);
         }
     }
@@ -3512,7 +3512,7 @@ void MainWindow::restartApp()
 void MainWindow::heartbeatOSC()
 {
     // Message msg("/gui-heartbeat");
-    // msg.pushStr(guiID.toStdString());
+    // msg.pushInt32(guiID);
     // sendOSC(msg);
 }
 
@@ -3702,7 +3702,7 @@ void MainWindow::printAsciiArtLogo()
 void MainWindow::requestVersion()
 {
     Message msg("/version");
-    msg.pushStr(guiID.toStdString());
+    msg.pushInt32(guiID);
     sendOSC(msg);
 }
 
@@ -3763,7 +3763,7 @@ void MainWindow::toggleMidi(int silent)
     {
         statusBar()->showMessage(tr("Enabling MIDI input..."), 2000);
         Message msg("/midi-start");
-        msg.pushStr(guiID.toStdString());
+        msg.pushInt32(guiID);
         msg.pushInt32(silent);
         sendOSC(msg);
     }
@@ -3771,7 +3771,7 @@ void MainWindow::toggleMidi(int silent)
     {
         statusBar()->showMessage(tr("Disabling MIDI input..."), 2000);
         Message msg("/midi-stop");
-        msg.pushStr(guiID.toStdString());
+        msg.pushInt32(guiID);
         msg.pushInt32(silent);
         sendOSC(msg);
     }
@@ -3791,7 +3791,7 @@ void MainWindow::resetMidi()
         settingsWidget->updateMidiOutPorts(tr("No connected output devices"));
         statusBar()->showMessage(tr("Resetting MIDI..."), 2000);
         Message msg("/midi-reset");
-        msg.pushStr(guiID.toStdString());
+        msg.pushInt32(guiID);
         sendOSC(msg);
     }
     else
@@ -3809,7 +3809,7 @@ void MainWindow::toggleOSCServer(int silent)
         enableOSCServerAct->setChecked(true);
         std::cout << "[GUI] - asking OSC server to start" << std::endl;
         Message msg("/cue-port-start");
-        msg.pushStr(guiID.toStdString());
+        msg.pushInt32(guiID);
         sendOSC(msg);
     }
     else
@@ -3819,7 +3819,7 @@ void MainWindow::toggleOSCServer(int silent)
         statusBar()->showMessage(tr("Disabling OSC cue port..."), 2000);
         std::cout << "[GUI] - asking OSC server to stop" << std::endl;
         Message msg("/cue-port-stop");
-        msg.pushStr(guiID.toStdString());
+        msg.pushInt32(guiID);
         sendOSC(msg);
     }
 
@@ -3835,7 +3835,7 @@ void MainWindow::toggleOSCServer(int silent)
 
         std::cout << "[GUI] - cue port in external mode" << std::endl;
         Message msg("/cue-port-external");
-        msg.pushStr(guiID.toStdString());
+        msg.pushInt32(guiID);
         sendOSC(msg);
     }
     else
@@ -3848,7 +3848,7 @@ void MainWindow::toggleOSCServer(int silent)
         }
         std::cout << "[GUI] - cue port in internal mode" << std::endl;
         Message msg("/cue-port-internal");
-        msg.pushStr(guiID.toStdString());
+        msg.pushInt32(guiID);
         sendOSC(msg);
     }
 }

--- a/app/gui/qt/mainwindow.h
+++ b/app/gui/qt/mainwindow.h
@@ -432,7 +432,7 @@ signals:
         SonicPi::ScopeWindow* scopeWindow;
         std::shared_ptr<SonicPi::QtAPIClient> m_spClient;
         std::shared_ptr<SonicPi::SonicPiAPI> m_spAPI;
-       std::shared_ptr<QRect> m_appWindowSizeRect;
+        std::shared_ptr<QRect> m_appWindowSizeRect;
 
         QSet<QString> cuePaths;
 

--- a/app/gui/qt/mainwindow.h
+++ b/app/gui/qt/mainwindow.h
@@ -427,7 +427,7 @@ signals:
         QLabel *versionLabel;
         bool tmpFileStoreAvailable;
         bool updated_dark_mode_for_help, updated_dark_mode_for_prefs;
-        QString guiID;
+        int guiID;
 
         SonicPi::ScopeWindow* scopeWindow;
         std::shared_ptr<SonicPi::QtAPIClient> m_spClient;

--- a/app/gui/qt/osc/oscsender.cpp
+++ b/app/gui/qt/osc/oscsender.cpp
@@ -38,7 +38,7 @@ bool OscSender::sendOSC(Message m) {
 }
 
 
-void OscSender::bufferNewlineAndIndent(int point_line, int point_index, int first_line, std::string code, std::string fileName, std::string id) {
+void OscSender::bufferNewlineAndIndent(int point_line, int point_index, int first_line, std::string code, std::string fileName) {
 
   Message msg("/buffer-newline-and-indent");
   msg.pushStr(id);

--- a/app/gui/qt/osc/oscsender.h
+++ b/app/gui/qt/osc/oscsender.h
@@ -23,7 +23,7 @@ class OscSender
 public:
     OscSender(int port);
     bool sendOSC(Message m);
-    void bufferNewlineAndIndent(int point_line, int point_index, int first_line, std::string code, std::string fileName, std::string id);
+    void bufferNewlineAndIndent(int point_line, int point_index, int first_line, std::string code, std::string fileName);
 
 private:
     int port;

--- a/app/gui/qt/qt_api_client.cpp
+++ b/app/gui/qt/qt_api_client.cpp
@@ -23,7 +23,7 @@ QtAPIClient::~QtAPIClient()
 
 void QtAPIClient::ReportGui(const MessageInfo& info)
 {
-    if (info.type == MessageType::Muti)
+    if (info.type == MessageType::Multi)
     {
         // TODO: No longer need to do this translation; just pass info to log
         SonicPiLog::MultiMessage mm;

--- a/app/gui/qt/widgets/settingswidget.cpp
+++ b/app/gui/qt/widgets/settingswidget.cpp
@@ -22,12 +22,12 @@
 /**
  * Default Constructor
  */
-SettingsWidget::SettingsWidget(int port, bool i18n, SonicPiSettings *piSettings, SonicPii18n *sonicPii18n, QWidget *parent) {
+SettingsWidget::SettingsWidget(int tau_osc_cues_port, bool i18n, SonicPiSettings *piSettings, SonicPii18n *sonicPii18n, QWidget *parent) {
     this->piSettings = piSettings;
     this->i18n = i18n;
     this->sonicPii18n = sonicPii18n;
     this->available_languages = sonicPii18n->getAvailableLanguages();
-    server_osc_cues_port = port;
+    this->tau_osc_cues_port = tau_osc_cues_port;
 
     prefTabs = new QTabWidget();
 
@@ -181,7 +181,7 @@ QGroupBox* SettingsWidget::createIoPrefsTab() {
         ip_address = tr("Unavailable");
     }
 
-    network_ip_label->setText(ip_address_trans + ": " + ip_address + "\n" + port_num_trans + + ": " + QString::number(server_osc_cues_port));
+    network_ip_label->setText(ip_address_trans + ": " + ip_address + "\n" + port_num_trans + + ": " + QString::number(tau_osc_cues_port));
     network_ip_label->setToolTip(all_ip_addresses);
 
     osc_public_check = new QCheckBox(tr("Allow OSC from other computers"));

--- a/app/gui/qt/widgets/settingswidget.h
+++ b/app/gui/qt/widgets/settingswidget.h
@@ -24,7 +24,7 @@ class SettingsWidget : public QWidget
     Q_OBJECT
 
 public:
-    SettingsWidget(int server_osc_cues_port, bool i18n, SonicPiSettings *piSettings, SonicPii18n *sonicPii18n, QWidget *parent = nullptr);
+    SettingsWidget(int tau_osc_cues_port, bool i18n, SonicPiSettings *piSettings, SonicPii18n *sonicPii18n, QWidget *parent = nullptr);
     ~SettingsWidget();
 
     void updateVersionInfo( QString info_string, QString visit, bool sonic_pi_net_visible, bool check_now_visible);
@@ -112,7 +112,7 @@ private:
     std::map<QString, QString> localeNames;
     QStringList available_languages;
     bool i18n;
-    int server_osc_cues_port;
+    int tau_osc_cues_port;
 
     QTabWidget *prefTabs;
 

--- a/app/gui/qt/widgets/sonicpiscintilla.cpp
+++ b/app/gui/qt/widgets/sonicpiscintilla.cpp
@@ -605,10 +605,7 @@ void SonicPiScintilla::newlineAndIndent() {
 
   std::string code = text().toStdString();
 
-  // TODO: fix this:
-  std::string id = "foobar";
-
-  emit bufferNewlineAndIndent(point_line, point_index, first_line, code, fileName.toStdString(), id);
+  emit bufferNewlineAndIndent(point_line, point_index, first_line, code, fileName.toStdString());
   mutex->unlock();
 }
 

--- a/app/gui/qt/widgets/sonicpiscintilla.h
+++ b/app/gui/qt/widgets/sonicpiscintilla.h
@@ -36,7 +36,7 @@ class SonicPiScintilla : public QsciScintilla
   void redraw();
 
 signals:
-  void bufferNewlineAndIndent(int point_line, int point_index, int first_line, const std::string& code, const std::string& fileName, const std::string& id);
+  void bufferNewlineAndIndent(int point_line, int point_index, int first_line, const std::string& code, const std::string& fileName);
 
   public slots:
     void cutLineFromPoint();

--- a/app/linux-prebuild.sh
+++ b/app/linux-prebuild.sh
@@ -22,7 +22,7 @@ done
 # Build vcpkg
 if [ ! -d "vcpkg" ]; then
     echo "Cloning vcpkg"
-    git clone --depth 1 --branch "${VCPKG_BRANCH:-2022.01.01}" https://github.com/microsoft/vcpkg.git
+    git clone --depth 1 --branch "${VCPKG_BRANCH:-2022.02.02}" https://github.com/microsoft/vcpkg.git
 fi
 
 if [ ! -f "vcpkg/vcpkg" ]; then

--- a/app/mac-prebuild.sh
+++ b/app/mac-prebuild.sh
@@ -26,7 +26,7 @@ done
 # Build vcpkg
 if [ ! -d "vcpkg" ]; then
     echo "Cloning vcpkg"
-    git clone --depth 1 --branch 2022.01.01  https://github.com/microsoft/vcpkg.git vcpkg
+    git clone --depth 1 --branch 2022.02.02  https://github.com/microsoft/vcpkg.git vcpkg
 fi
 
 if [ ! -f "vcpkg/vcpkg" ]; then

--- a/app/pi-prebuild.sh
+++ b/app/pi-prebuild.sh
@@ -17,9 +17,9 @@ done
 
 if [ "$no_imgui" == true ]
 then
-    VCPKG_BRANCH="2022.01.01" VCPKG_FORCE_SYSTEM_BINARIES=1 "${SCRIPT_DIR}"/linux-prebuild.sh -n
+    VCPKG_BRANCH="2022.02.02" VCPKG_FORCE_SYSTEM_BINARIES=1 "${SCRIPT_DIR}"/linux-prebuild.sh -n
 else
-    VCPKG_BRANCH="2022.01.01" VCPKG_FORCE_SYSTEM_BINARIES=1 "${SCRIPT_DIR}"/linux-prebuild.sh
+    VCPKG_BRANCH="2022.02.02" VCPKG_FORCE_SYSTEM_BINARIES=1 "${SCRIPT_DIR}"/linux-prebuild.sh
 fi
 
 # Restore working directory as it was prior to this script running...

--- a/app/pi-prebuild.sh
+++ b/app/pi-prebuild.sh
@@ -17,9 +17,9 @@ done
 
 if [ "$no_imgui" == true ]
 then
-    VCPKG_BRANCH="2022.02.02" VCPKG_FORCE_SYSTEM_BINARIES=1 "${SCRIPT_DIR}"/linux-prebuild.sh -n
+    VCPKG_FORCE_SYSTEM_BINARIES=1 "${SCRIPT_DIR}"/linux-prebuild.sh -n
 else
-    VCPKG_BRANCH="2022.02.02" VCPKG_FORCE_SYSTEM_BINARIES=1 "${SCRIPT_DIR}"/linux-prebuild.sh
+    VCPKG_FORCE_SYSTEM_BINARIES=1 "${SCRIPT_DIR}"/linux-prebuild.sh
 fi
 
 # Restore working directory as it was prior to this script running...

--- a/app/server/beam/tau/boot-lin.sh
+++ b/app/server/beam/tau/boot-lin.sh
@@ -19,7 +19,8 @@ export TAU_MIDI_ENABLED=${11}
 export TAU_LINK_ENABLED=${12}
 export TAU_PHX_PORT=${13}
 export SECRET_KEY_BASE=${14}
-export TAU_ENV=${15}
+export TAU_DAEMON_TOKEN=${15}
+export TAU_ENV=${16}
 export MIX_ENV=$TAU_ENV
 
 if [ $TAU_ENV = "dev" ]

--- a/app/server/beam/tau/boot-mac.sh
+++ b/app/server/beam/tau/boot-mac.sh
@@ -19,7 +19,8 @@ export TAU_MIDI_ENABLED=${11}
 export TAU_LINK_ENABLED=${12}
 export TAU_PHX_PORT=${13}
 export SECRET_KEY_BASE=${14}
-export TAU_ENV=${15}
+export TAU_DAEMON_TOKEN=${15}
+export TAU_ENV=${16}
 export MIX_ENV=$TAU_ENV
 
 if [ $TAU_ENV = "dev" ]

--- a/app/server/beam/tau/boot-win.bat
+++ b/app/server/beam/tau/boot-win.bat
@@ -25,6 +25,8 @@ set TAU_PHX_PORT=%9%
 shift
 set SECRET_KEY_BASE=%9%
 shift
+set TAU_DAEMON_TOKEN=%9%
+shift
 set TAU_ENV=%9%
 
 set MIX_ENV=%TAU_ENV%

--- a/app/server/beam/tau/lib/tau.ex
+++ b/app/server/beam/tau/lib/tau.ex
@@ -5,6 +5,8 @@ defmodule Tau do
   @impl true
   def start(_type, _args) do
     Logger.info("All systems booting....")
+
+    _tau_env                       = extract_env("TAU_ENV",                            :string, "prod")
     midi_enabled                   = extract_env("TAU_MIDI_ENABLED",                   :bool, false)
     link_enabled                   = extract_env("TAU_LINK_ENABLED",                   :bool, false)
     cues_on                        = extract_env("TAU_CUES_ON",                        :bool, true)
@@ -16,6 +18,7 @@ defmodule Tau do
     spider_port                    = extract_env("TAU_SPIDER_PORT",                    :int,  5002)
     daemon_port                    = extract_env("TAU_DAEMON_PORT",                    :int,  -1)
     keep_alive_port                = extract_env("TAU_KEEP_ALIVE_PORT",                :int,  -1)
+    daemon_token                   = extract_env("TAU_DAEMON_TOKEN",                   :int,  -1)
 
     if midi_enabled do
       Logger.info("Initialising MIDI native interface")
@@ -42,7 +45,8 @@ defmodule Tau do
       api_port,
       spider_port,
       daemon_port,
-      keep_alive_port
+      keep_alive_port,
+      daemon_token
     )
 
     # Although we don't use the supervisor name below directly,
@@ -51,7 +55,7 @@ defmodule Tau do
     if (keep_alive_port == -1) do
       Logger.info("Not starting keepalive server as no daemon port value was given")
     else
-      :tau_keepalive.start_link(keep_alive_port, daemon_port)
+      :tau_keepalive.start_link(keep_alive_port, daemon_port, daemon_token)
     end
 
     :tau_server_sup.start_link()

--- a/app/server/beam/tau/src/tau_server/tau_keepalive.erl
+++ b/app/server/beam/tau/src/tau_server/tau_keepalive.erl
@@ -14,22 +14,22 @@
 
 -module(tau_keepalive).
 
--export([start_link/2, init/2, loop/0]).
+-export([start_link/3, init/3, loop/0]).
 
-start_link(KeepAlivePortNum, DaemonPortNum) ->
-    spawn_link(?MODULE, init, [KeepAlivePortNum, DaemonPortNum]).
+start_link(KeepAlivePortNum, DaemonPortNum, DaemonToken) ->
+    spawn_link(?MODULE, init, [KeepAlivePortNum, DaemonPortNum, DaemonToken]).
 
-init(KeepAlivePortNum, DaemonPortNum) ->
-    logger:error("Connecting to Daemon keepalive port via UDP...~p ~p", [KeepAlivePortNum, DaemonPortNum]),
+init(KeepAlivePortNum, DaemonPortNum, DaemonToken) ->
+    logger:info("Connecting to Daemon keepalive port via UDP...~p ~p w\ token ~p", [KeepAlivePortNum, DaemonPortNum, DaemonToken]),
 
     OSPid = list_to_integer(os:getpid()),
-    PidMsg = osc:encode(["/tau/pid", OSPid]),
+    PidMsg = osc:encode(["/tau/pid", DaemonToken, OSPid]),
     {ok, DaemonSocket} = gen_udp:open(0, [binary, {ip, loopback}]),
     erlang:send_after(1000, self(), {send_pid, DaemonSocket, DaemonPortNum, PidMsg, 30}),
 
 
     {ok, KeepAliveSocket} = gen_udp:open(0, [binary, {ip, loopback}]),
-    KeepAliveMsg = osc:encode(["/daemon/keep-alive"]),
+    KeepAliveMsg = osc:encode(["/daemon/keep-alive", DaemonToken]),
     erlang:send_after(1000, self(), {send_keep_alive, KeepAliveSocket, KeepAlivePortNum, KeepAliveMsg}),
     logger:info("Waiting for keepalive messages..."),
     loop().

--- a/app/server/beam/tau/src/tau_server/tau_server_api.erl
+++ b/app/server/beam/tau/src/tau_server/tau_server_api.erl
@@ -74,6 +74,8 @@ start_link(CueServer, MIDIServer, LinkServer) ->
 init(Parent, CueServer, MIDIServer, LinkServer) ->
     register(?SERVER, self()),
     APIPort = application:get_env(?APPLICATION, api_port, undefined),
+    DaemonToken = application:get_env(?APPLICATION, daemon_token, undefined),
+
     logger:info("~n"
               "+--------------------------------------+~n"
               "    This is the Sonic Pi API Server     ~n"
@@ -95,6 +97,7 @@ init(Parent, CueServer, MIDIServer, LinkServer) ->
     logger:debug("listening for API commands on socket: ~p",
           [try erlang:port_info(APISocket) catch _:_ -> undefined end]),
     State = #{parent => Parent,
+              daemon_token => DaemonToken,
               api_socket => APISocket,
               cue_server => CueServer,
               midi_server => MIDIServer,
@@ -105,6 +108,7 @@ init(Parent, CueServer, MIDIServer, LinkServer) ->
     loop(State).
 
 loop(State) ->
+    DaemonToken = maps:get(daemon_token, State),
     receive
         {tcp, Socket, Data} ->
             logger:debug("api server got TCP on ~p:~p", [Socket, Data]),

--- a/app/server/beam/tau/src/tau_server/tau_server_sup.erl
+++ b/app/server/beam/tau/src/tau_server/tau_server_sup.erl
@@ -11,7 +11,7 @@
 
 %% Supervisor callbacks
 -export([init/1]).
--export([set_application_env/11]).
+-export([set_application_env/12]).
 
 -define(APPLICATION, tau).
 
@@ -44,7 +44,8 @@ set_application_env(MIDIEnabled,
                     ApiPort,
                     SpiderPort,
                     DaemonPort,
-                    KeepAlivePort) ->
+                    KeepAlivePort,
+                    DaemonToken) ->
 
     application:set_env(?APPLICATION, midi_enabled, MIDIEnabled),
     application:set_env(?APPLICATION, link_enabled, LinkEnabled),
@@ -56,7 +57,8 @@ set_application_env(MIDIEnabled,
     application:set_env(?APPLICATION, api_port, ApiPort),
     application:set_env(?APPLICATION, spider_port, SpiderPort),
     application:set_env(?APPLICATION, daemon_port, DaemonPort),
-    application:set_env(?APPLICATION, keep_alive_port, KeepAlivePort).
+    application:set_env(?APPLICATION, keep_alive_port, KeepAlivePort),
+    application:set_env(?APPLICATION, daemon_token, DaemonToken).
 
 init(_Args) ->
     CueServer = tau_server_cue:server_name(),

--- a/app/server/ruby/bin/daemon.rb
+++ b/app/server/ruby/bin/daemon.rb
@@ -150,7 +150,7 @@ module SonicPi
         @tau_booter      = nil
         @spider_booter   = nil
 
-        # use an value within the valid range for a 32 bit signed complement integer
+        # use a value within the valid range for a 32 bit signed complement integer
         token =  rand(-2147483647..2147483647)
 
         # don't worry if there's a problem clearing the logs.

--- a/app/server/ruby/bin/daemon.rb
+++ b/app/server/ruby/bin/daemon.rb
@@ -779,7 +779,19 @@ module SonicPi
         @port = ports["scsynth"]
         begin
           toml_opts_hash = Tomlrb.load_file(Paths.user_audio_settings_path, symbolize_keys: true).freeze
-        rescue StandardError
+        rescue StandardError => e
+          Util.log "---- Audio Config Issue ----"
+
+          if !File.exist? Paths.user_audio_settings_path
+            Util.log "Could not find #{Paths.user_audio_settings_path} - reverting to default audio options."
+          else
+            Util.log "Issue reading #{Paths.user_audio_settings_path}:"
+            Util.log "Warning Class: #{e.class}"
+            Util.log "Warning Message: #{e.message}"
+            Util.log "Warning Backtrace: #{e.backtrace.inspect}"
+          end
+          Util.log "This is not critical - reverting to default audio options"
+          Util.log "----------------------------"
           toml_opts_hash = {}
         end
 

--- a/app/server/ruby/bin/daemon.rb
+++ b/app/server/ruby/bin/daemon.rb
@@ -237,9 +237,12 @@ module SonicPi
           kill_switch.deliver!(true)
         end
 
-        server = SonicPi::OSC::UDPServer.new(port_num, suppress_errors: false) do |address, args, sender_addrinfo|
-          Util.log "Kill switch ##{port_num} Received UDP data #{[address, args, sender_addrinfo].inspect}"
-        end
+        # For debugging purposes:
+        # server = SonicPi::OSC::UDPServer.new(port_num, suppress_errors: false) do |address, args, sender_addrinfo|
+        #   Util.log "Kill switch ##{port_num} Received UDP data #{[address, args, sender_addrinfo].inspect}"
+        # end
+
+        server = SonicPi::OSC::UDPServer.new(port_num, suppress_errors: false)
 
         server.add_method("/daemon/keep-alive") do |args|
           if args[0] && args[0] == token
@@ -626,9 +629,13 @@ module SonicPi
         @tau_pid                       = Promise.new
 
         Util.log "Daemon listening to info from Tau on port #{daemon_port}"
-        @udp_osc_server = SonicPi::OSC::UDPServer.new(daemon_port) do |address, args, sender_addrinfo|
-          Util.log "Daemon received UDP data from Tau: #{[address, args, sender_addrinfo].inspect}"
-        end
+
+        # For debugging purposes:
+        # @udp_osc_server = SonicPi::OSC::UDPServer.new(daemon_port) do |address, args, sender_addrinfo|
+        #   Util.log "Daemon received UDP data from Tau: #{[address, args, sender_addrinfo].inspect}"
+        # end
+
+        @udp_osc_server = SonicPi::OSC::UDPServer.new(daemon_port)
 
         @udp_osc_server.add_method("/tau/pid") do |args|
           # Util.log "Daemon received Pid data from Tau: #{args.inspect}"

--- a/app/server/ruby/bin/daemon.rb
+++ b/app/server/ruby/bin/daemon.rb
@@ -125,7 +125,7 @@ Thread::abort_on_exception = true
 #
 #
 # token:                Integer used as a token to authenticate OSC messages.
-#                       All OSCmessages sent from the GUI must include this token
+#                       All OSC messages sent from the GUI must include this token
 #                       as the first argument
 
 

--- a/app/server/ruby/bin/daemon.rb
+++ b/app/server/ruby/bin/daemon.rb
@@ -74,11 +74,11 @@ Thread::abort_on_exception = true
 #
 # If the client wants to explicitly trigger the kill switch directly
 # rather than via a timeout it can send an OSC message with path
-# /daemon/exit along with a single argument which is the exit-token
-# (also printed to STDOUT - see below).
+# /daemon/exit along with a single integer argument which is the comms
+# token (also printed to STDOUT - see below).
 #
 #
-# Port Allocation and exit-token
+# Port Allocations & Comms Token
 # ------------------------------
 #
 # The Daemon figures out appropriate (and currently free) values for all
@@ -89,10 +89,15 @@ Thread::abort_on_exception = true
 # Some of these port numbers need to be known by the client process
 # so that it can both send code to run and receive log updates via UDP.
 #
+# The final value printed to stdout is the comms token which is a random
+# 32 bit signed integer. This must be used as the first argument to all
+# OSC messages sent from the GUI to Daemon such as: /daemon/keep-alive
+# and /daemon/exit.
+#
 # The current allocations of these external port numbers are printed to
 # STDOUT in the following order:
 #
-# daemon-keep-alive gui-listen-to-server gui-send-to-server scsynth osc-cues phx exit-token
+# daemon-keep-alive gui-listen-to-server gui-send-to-server scsynth osc-cues tau-api tau-phx token
 #
 #
 # Stdout Parameter Descriptions
@@ -113,12 +118,15 @@ Thread::abort_on_exception = true
 # osc-cues:             UDP port used to receive OSC cue messages from external
 #                       processes.
 #
-# phx:                  HTTP port used by the Phoenix web server
+# tau-api:              UDP port used to send OSC messages to trigger the
+#                       Tau API
 #
-# exit-token:           String that can be sent as the single argument in an OSC
-#                       message with path /daemon/exit sent to daemon-keep-alive
-#                       to trigger the daemon kill switch and force it to exit
-#                       early yet cleanly (i.e. all child processes are closed).
+# tau-phx:              HTTP port used by Tau's Phoenix web server
+#
+#
+# token:                Integer used as a token to authenticate OSC messages.
+#                       All OSCmessages sent from the GUI must include this token
+#                       as the first argument
 
 
 module SonicPi
@@ -142,7 +150,8 @@ module SonicPi
         @tau_booter      = nil
         @spider_booter   = nil
 
-        exit_token       = SecureRandom.base64(64)
+        # use an value within the valid range for a 32 bit signed complement integer
+        token =  rand(-2147483647..2147483647)
 
         # don't worry if there's a problem clearing the logs.
         begin
@@ -163,16 +172,16 @@ module SonicPi
         Util.log ports.inspect
 
         Util.log "Setting up zombie kill switch for gui-keep-alive listening on port #{ports["gui-keep-alive"]}"
-        caller_kill_switch = udp_zombie_kill_switch(ports["gui-keep-alive"], exit_token)
+        caller_kill_switch = udp_zombie_kill_switch(ports["gui-keep-alive"], token)
 
         Util.log "Setting up zombie kill switch for tau-keep-alive listening on port #{ports["tau-keep-alive"]}"
-        tau_kill_switch = udp_zombie_kill_switch(ports["tau-keep-alive"], exit_token)
+        tau_kill_switch = udp_zombie_kill_switch(ports["tau-keep-alive"], token)
 
         # Initiate boot processes
 
         Util.log "Booting Tau"
         begin
-          @tau_booter = TauBooter.new(ports, tau_kill_switch)
+          @tau_booter = TauBooter.new(ports, tau_kill_switch, token)
         rescue StandardError => e
           Util.log "Oh no, something went wrong booting Tau"
           Util.log "Error Class: #{e.class}"
@@ -183,7 +192,7 @@ module SonicPi
         # Let the calling process (likely the GUI) know which port to
         # listen to and communicate on with the Ruby spider server via
         # STDOUT.
-        puts "#{ports["gui-keep-alive"]} #{ports["gui-listen-to-spider"]} #{ports["gui-send-to-spider"]} #{ports["scsynth"]} #{ports["osc-cues"]} #{@tau_booter.phx_port} #{exit_token}"
+        puts "#{ports["gui-keep-alive"]} #{ports["gui-listen-to-spider"]} #{ports["gui-send-to-spider"]} #{ports["scsynth"]} #{ports["osc-cues"]} #{ports["tau"]} #{@tau_booter.phx_port} #{token}"
         STDOUT.flush
 
 
@@ -206,7 +215,7 @@ module SonicPi
         Util.log "Spider Server process has completed"
       end
 
-      def udp_zombie_kill_switch(port_num, exit_token)
+      def udp_zombie_kill_switch(port_num, token)
         kill_switch = Promise.new
         queue = Queue.new
 
@@ -233,13 +242,15 @@ module SonicPi
         end
 
         server.add_method("/daemon/keep-alive") do |args|
-          queue << true
+          if args[0] && args[0] == token
+            queue << true
+          end
         end
 
-        if exit_token
+        if token
           server.add_method("/daemon/exit") do |args|
-            if args[0] && args[0] == exit_token
-              Util.log "Kill switch for port #{port_num} remotely activated using token #{exit_token}"
+            if args[0] && args[0] == token
+              Util.log "Kill switch for port #{port_num} remotely activated using token #{token}"
               @safe_exit.exit
             else
               Util.log "Kill switch for port #{port_num} received incorrect token. Ignoring #{args[0]}"
@@ -578,7 +589,12 @@ module SonicPi
     class TauBooter < ProcessBooter
       attr_reader :phx_port
 
-      def initialize(ports, kill_switch)
+      def initialize(ports, kill_switch, token)
+
+        # This is used to determine whether the spawned process is still
+        # alive as we don't have access to the BEAM pid with this
+        # spawning method (it's hidden behind release script
+        # files). Instead, Tau sends us its pid which we then work with.
         @tau_alive_thread = Thread.new do
           kill_switch.get
         end
@@ -615,8 +631,13 @@ module SonicPi
         end
 
         @udp_osc_server.add_method("/tau/pid") do |args|
-          Util.log "Daemon received Pid data from Tau: #{args.inspect}"
-          @tau_pid.deliver!(args[0], false) if args
+          # Util.log "Daemon received Pid data from Tau: #{args.inspect}"
+          # Util.log "token: #{token}"
+          if args[0] && args[0] == token
+            @tau_pid.deliver!(args[1], false) if args[1]
+            # Util.log "Daemon staying alive for longer..."
+            queue << true
+          end
         end
 
         args = [
@@ -634,6 +655,7 @@ module SonicPi
           link_enabled,
           phx_port,
           phx_secret_key_base,
+          token,
           env
         ]
 

--- a/app/win-config.bat
+++ b/app/win-config.bat
@@ -5,6 +5,6 @@ mkdir build > nul
 
 @echo "Generating project files..."
 cd build
-cmake -G "Visual Studio 16 2019" -A x64 ..\
+cmake -G "Visual Studio 17 2022" -A x64 ..\
 
 cd "%WORKING_DIR%"

--- a/app/win-pre-vcpkg.bat
+++ b/app/win-pre-vcpkg.bat
@@ -5,7 +5,7 @@ cd %~dp0
 REM Build vcpkg
 if not exist "vcpkg\" (
     echo Cloning vcpkg
-    git clone --depth 1 --branch 2021.05.12  https://github.com/microsoft/vcpkg.git vcpkg
+    git clone --depth 1 --branch 2022.02.02  https://github.com/microsoft/vcpkg.git vcpkg
 )
 
 if not exist "vcpkg\vcpkg.exe" (


### PR DESCRIPTION
Promote the 'kill token' to a more general 'comms token' which is a random int used to prefix all OSC args as a kind of session-id to restrict internal API usage to internal processes only. Public APIs such as the incoming OSC port (typically on 4560) are unaffected.

Note, the Spider API doesn't enforce that this token is valid at this point, this will be added in a future update.