### PR TITLE
fix a typo in A.14-amplitude-modulation.md

### DIFF
--- a/etc/doc/tutorial/A.14-amplitude-modulation.md
+++ b/etc/doc/tutorial/A.14-amplitude-modulation.md
@@ -166,7 +166,7 @@ with_fx :slicer, phase: 0.125 do
 end
 ```
 
-This allows us to take any sample and create new rhythmical possibilites
+This allows us to take any sample and create new rhythmical possibilities
 which is a lot of fun. However, one thing to be careful about is to make
 sure that the tempo of the sample matches the current BPM in Sonic Pi
 otherwise the slicing will sound totally off. For example, try swapping


### PR DESCRIPTION
fix a typo 'possibilites' to 'possibilities' in A.14-amplitude-modulation.md