### PR TITLE
Also include priv/static/assets for live reload

### DIFF
--- a/app/server/beam/tau/config/dev.exs
+++ b/app/server/beam/tau/config/dev.exs
@@ -49,6 +49,7 @@ config :tau, TauWeb.Endpoint,
   live_reload: [
     patterns: [
       ~r"priv/static/.*(js|css|png|jpeg|jpg|gif|svg)$",
+      ~r"priv/static/assets/.*(js|css)$",
       ~r"priv/gettext/.*(po)$",
       ~r"lib/tau_web/(live|views)/.*(ex)$",
       ~r"lib/tau_web/templates/.*(eex)$",

--- a/app/server/beam/tau/config/runtime.exs
+++ b/app/server/beam/tau/config/runtime.exs
@@ -54,7 +54,7 @@ config :tau, TauWeb.Endpoint,
 if config_env() == :dev do
   secret_key_base =
     System.get_env("SECRET_KEY_BASE") ||
-    "pDakDMi+9PfJKYIHcdf7MGIog4NRPiuws5eUT6M6Kcg3Wad69hT+tVwOccyjfYJ"
+    "ppDakDMi+9PfJKYIHcdf7MGIog4NRPiuws5eUT6M6Kcg3Wad69hT+tVwOccyjfYJ"
 
   config :tau, TauWeb.Endpoint,
     secret_key_base: secret_key_base


### PR DESCRIPTION
Hi :wave: ,

You asked on Discord why you the Live Reload doesn't work, so I played around a bit and this seems to have solved it for me (using a Linux machine):

Tailwind compiles the assets/CSS to priv/static/assets folder which wasn't included in the list of folders to watch for live_reload.
This change (together with installing inotify-tools) seems to trigger live reloading when CSS gets changed.

I also include a tiny change for the next person who tries to run it without setting up correct ENV vars beforehand

Hope it helps,
Tonći