### PR TITLE
Update the load_synthdefs function in sound.rb

### DIFF
--- a/app/server/ruby/lib/sonicpi/lang/sound.rb
+++ b/app/server/ruby/lib/sonicpi/lang/sound.rb
@@ -3288,6 +3288,7 @@ kill bar"]
       def load_synthdefs(path=Paths.synthdef_path)
         path = File.expand_path(path)
         raise "No directory exists called #{path.inspect}" unless File.exist? path
+        raise "Expects a path to a directory (not the synthdef file itself).\nGot: #{path} instead" if File.file?(path)
         @mod_sound_studio.load_synthdefs(path)
         __info "Loaded synthdefs in path #{path}"
       end


### PR DESCRIPTION
Added a raise to notice the user that the input path should be a path to directory instead of a file, as mentioned by @ethancrawford in Issue #3006 