### PR TITLE
"#if WIN32" fails with Fatal Error C1017 - use #ifdef instead

### DIFF
--- a/app/api/include/api/process_utils.h
+++ b/app/api/include/api/process_utils.h
@@ -10,7 +10,7 @@ namespace SonicPi
 inline void raise_process_priority(int pid)
 {
 
-#if WIN32
+#ifdef WIN32
     auto hProcess = OpenProcess(PROCESS_SET_INFORMATION, TRUE, pid);
     if (hProcess)
     {


### PR DESCRIPTION
This fails with "fatal error C1017: invalid integer constant expression". See https://docs.microsoft.com/en-us/cpp/error-messages/compiler-errors-1/fatal-error-c1017