### PR TITLE
Update sound.rb

### DIFF
--- a/app/server/ruby/lib/sonicpi/lang/sound.rb
+++ b/app/server/ruby/lib/sonicpi/lang/sound.rb
@@ -92,6 +92,7 @@ module SonicPi
             buf_lookup = lambda do |name, duration=nil|
               # scale duration to the current BPM
               duration ||= 8
+              raise ArgumentError, "Buffer duration should be a numerical value. You used #{duration}" unless !duration.is_a?(Numeric)
               raise ArgumentError, "Buffer duration should be a numerical value greater than zero. You used #{duration}" unless duration.is_a?(Numeric) && duration.positive?
               duration = duration * (__get_spider_sleep_mul || 1)
               name = name.to_sym


### PR DESCRIPTION
Adding a "raise" to detect when the input is not numeric. This issue is raised in #2940. Now instead of a "timeout", an error will be raised due to the non-numeric input.