### PR TITLE
GitHub - add issue and pull request templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/COMPILING-ISSUE-FORM.yml
+++ b/.github/ISSUE_TEMPLATE/COMPILING-ISSUE-FORM.yml
@@ -43,7 +43,8 @@ body:
         Provide as much detail as possible - such as:
         - Software dependencies you set up for the build - versions, places they were downloaded from, etc
         - Any build steps you took that were different to those described in the build guides ([BUILD-LINUX.md](https://github.com/sonic-pi-net/sonic-pi/blob/dev/BUILD-LINUX.md), [BUILD-MAC.md](https://github.com/sonic-pi-net/sonic-pi/blob/dev/BUILD-MAC.md), [BUILD-RASPBERRY-PI.md](https://github.com/sonic-pi-net/sonic-pi/blob/dev/BUILD-RASPBERRY-PI.md) or [BUILD-WINDOWS.md](https://github.com/sonic-pi-net/sonic-pi/blob/dev/BUILD-WINDOWS.md)) - including the order you performed them 
-        For any steps you ran in the command line terminal, write or copy them here. Please use code formatting when you do so - if you're not sure how, please see the 'Code' examples at GitHub's [Mastering Markdown examples](https://guides.github.com/features/mastering-markdown/#examples).
+        For any steps you ran in the command line terminal, write or copy them here. Please use code formatting when you do so - if you're not sure how, please see GitHub's guide: [Quoting code](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#quoting-code).
+
       placeholder: "Example: I followed BUILD-LINUX.md, installing Qt 6.2.3 from https://www.qt.io/download-thank-you?os=linux&hsLang=en ..."
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/COMPILING-ISSUE-FORM.yml
+++ b/.github/ISSUE_TEMPLATE/COMPILING-ISSUE-FORM.yml
@@ -1,0 +1,80 @@
+name: A problem with compiling Sonic Pi
+description: I had a problem when compiling my own build of Sonic Pi from the source code.
+labels: ["triage", "developer experience"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Hello! Thank you for wanting to raise an issue for us, so that we know what's not working for you.
+
+        Sorry you're having issues compiling Sonic Pi! We're always working to improve the build experience.
+
+        The core Sonic Pi development team is fairly small and made up of volunteers (with the exception of Sam Aaron, who relies much on crowd-funding) so the more help we can receive to manage, troubleshoot and hopefully fix your issues for you the better - help us to help you! Please follow the checklist below - that way you might not even need to raise an issue after all :smile:
+  - type: checkboxes
+    id: read-troubleshooting-guide
+    attributes:
+      label: Prerequisites
+      options:
+        - label: I've read the [Sonic Pi troubleshooting guide](https://github.com/sonic-pi-net/sonic-pi/wiki/Troubleshooting-Issues) and followed its suggestions where relevant
+          required: true
+  - type: input
+    id: dev-commit
+    attributes:
+      label: Git commit id
+      description: "What was the Git commit id of the code you were trying to compile from?"
+      placeholder: "Example: 00f737e"
+    validations:
+      required: true
+  - type: input
+    id: os-version
+    attributes:
+      label: Operating System
+      description: "What Operating System (and which version) were you using?"
+      placeholder: "Example: Windows 10"
+    validations:
+      required: true
+  - type: textarea
+    id: build-steps
+    attributes:
+      label: What steps did you take to set up and to try to compile Sonic Pi?
+      description: |
+        You can drag related images into the description if you like.
+        When attempting to compile Sonic Pi, what steps did you take?
+        Provide as much detail as possible - such as:
+        - Software dependencies you set up for the build - versions, places they were downloaded from, etc
+        - Any build steps you took that were different to those described in the build guides ([BUILD-LINUX.md](https://github.com/sonic-pi-net/sonic-pi/blob/dev/BUILD-LINUX.md), [BUILD-MAC.md](https://github.com/sonic-pi-net/sonic-pi/blob/dev/BUILD-MAC.md), [BUILD-RASPBERRY-PI.md](https://github.com/sonic-pi-net/sonic-pi/blob/dev/BUILD-RASPBERRY-PI.md) or [BUILD-WINDOWS.md](https://github.com/sonic-pi-net/sonic-pi/blob/dev/BUILD-WINDOWS.md)) - including the order you performed them 
+        For any steps you ran in the command line terminal, write or copy them here. Please use code formatting when you do so - if you're not sure how, please see the 'Code' examples at GitHub's [Mastering Markdown examples](https://guides.github.com/features/mastering-markdown/#examples).
+      placeholder: "Example: I followed BUILD-LINUX.md, installing Qt 6.2.3 from https://www.qt.io/download-thank-you?os=linux&hsLang=en ..."
+    validations:
+      required: true
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: |
+        You can drag related images into the description if you like.
+        Copy the results of the build process here, including errors. If there is an error message that you feel has a clear cause or explanation, you can paste just the error plus a small amount of the messages around it for context. If in doubt however, the more information you can give us the better - such as the entire build process output, in case more detailed investigation is necessary.
+      placeholder: |
+        Example: When I run `cmake --build . --config Release` I get the following result:
+        ```
+        c++: fatal error: Killed signal terminated program cc1plus
+        compilation terminated.
+        make[2]: *** [gui/qt/CMakeFiles/sonic-pi.dir/build.make:3658: gui/qt/CMakeFiles/sonic-pi.dir/sonic-pi_autogen/EWIEGA46WW/qrc_SonicPi.cpp.o] Error 1
+        make[1]: *** [CMakeFiles/Makefile2:184: gui/qt/CMakeFiles/sonic-pi.dir/all] Error 2
+        make: *** [Makefile:84: all] Error 2
+        ```
+    validations:
+      required: true
+  - type: textarea
+    id: other-details
+    attributes:
+      label: Other Details
+      description: |
+        You can drag related images into the description if you like.
+        Feel free to provide any other relevant information about the issue if you have it, or can get it:
+        - Ideas about possible root causes
+        - Workarounds or potential solutions (or even better, send us a pull request!)
+        - Etc...
+      placeholder: "Example: Could this be related to X? Maybe we could add the foo software package as a dependency in BUILD-LINUX.md?"
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/FEATURE-REQUEST-FORM.yml
+++ b/.github/ISSUE_TEMPLATE/FEATURE-REQUEST-FORM.yml
@@ -26,7 +26,20 @@ body:
         - What problem would this feature solve, or benefit would it provide?
         - What drawbacks or undesirable aspects might it have?
         - If the feature has visible parts to it, (such as a new GUI widget or a new function for the language), what might they look like and how might they be used? Images and code examples encouraged! (Please use code formatting for code examples - if you're not sure how, please see GitHub's guide: [Quoting code](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#quoting-code)).
-      placeholder: "Example: I think a foo feature is useful for Sonic Pi because..."
+      placeholder: |
+        Example:
+        ## Motivations
+        I think a foo feature is useful for Sonic Pi because...
+
+        ## How it might look
+        We could have a function `bar` that could be used like this:
+        ```
+        play (bar 1, 2, 3)
+        ```
+        Where `1`, `2`, and `3` are the baz parameters and...
+
+        ## Drawbacks
+        There's a chance that ...
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/FEATURE-REQUEST-FORM.yml
+++ b/.github/ISSUE_TEMPLATE/FEATURE-REQUEST-FORM.yml
@@ -22,10 +22,10 @@ body:
     attributes:
       label: Feature Description
       description: |
-        - Add as much detail as you can about your idea.
-        - What problem would this feature solve, or benefit would it provide? 
-        - If it relates to new functions or changes in the language, give small examples of what you might write in Sonic Pi. Please use code formatting for the examples - if you're not sure how, please see the 'Code' examples at GitHub's [Mastering Markdown examples](https://guides.github.com/features/mastering-markdown/#examples).
-        - You can drag related images into the description if useful - (for example, showing the design or layout of potential features or enhancements in the GUI).
+        Add as much detail as you can about your idea. Here's a few things to get you started:
+        - What problem would this feature solve, or benefit would it provide?
+        - What drawbacks or undesirable aspects might it have?
+        - If the feature has visible parts to it, (such as a new GUI widget or a new function for the language), what might they look like and how might they be used? Images and code examples encouraged! (For code examples, please use code formatting - if you're not sure how, please see the 'Code' examples at GitHub's [Mastering Markdown examples](https://guides.github.com/features/mastering-markdown/#examples)).
       placeholder: "Example: I think a foo feature is useful for Sonic Pi because..."
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/FEATURE-REQUEST-FORM.yml
+++ b/.github/ISSUE_TEMPLATE/FEATURE-REQUEST-FORM.yml
@@ -25,7 +25,7 @@ body:
         Add as much detail as you can about your idea. Here's a few things to get you started:
         - What problem would this feature solve, or benefit would it provide?
         - What drawbacks or undesirable aspects might it have?
-        - If the feature has visible parts to it, (such as a new GUI widget or a new function for the language), what might they look like and how might they be used? Images and code examples encouraged! (For code examples, please use code formatting - if you're not sure how, please see the 'Code' examples at GitHub's [Mastering Markdown examples](https://guides.github.com/features/mastering-markdown/#examples)).
+        - If the feature has visible parts to it, (such as a new GUI widget or a new function for the language), what might they look like and how might they be used? Images and code examples encouraged! (Please use code formatting for code examples - if you're not sure how, please see GitHub's guide: [Quoting code](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#quoting-code)).
       placeholder: "Example: I think a foo feature is useful for Sonic Pi because..."
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/FEATURE-REQUEST-FORM.yml
+++ b/.github/ISSUE_TEMPLATE/FEATURE-REQUEST-FORM.yml
@@ -1,0 +1,43 @@
+name: A feature request
+description: Describe a new feature or enhancement that you would like to see in Sonic Pi.
+labels: ["Feature Request"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Hello! Thank you for your interest in improving Sonic Pi.
+
+        The core Sonic Pi development team is fairly small and made up of volunteers (with the exception of Sam Aaron, who relies much on crowd-funding) so the more help we can receive to manage your ideas the better - help us to help you! Please follow the checklist below - that way you might not even need to raise a feature request after all :smile:
+  - type: checkboxes
+    id: prerequisites
+    attributes:
+      label: Prerequisites
+      options:
+        - label: I've searched the [Sonic Pi features project](https://github.com/orgs/sonic-pi-net/projects/1) for similar existing feature requests
+          required: true
+        - label: To the best of my knowledge, this feature would fit within the [project guidelines](https://github.com/sonic-pi-net/sonic-pi/blob/dev/CONTRIBUTING.md#project-and-development-process-guidelines) 
+          required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: Feature Description
+      description: |
+        - Add as much detail as you can about your idea.
+        - What problem would this feature solve, or benefit would it provide? 
+        - If it relates to new functions or changes in the language, give small examples of what you might write in Sonic Pi. Please use code formatting for the examples - if you're not sure how, please see the 'Code' examples at GitHub's [Mastering Markdown examples](https://guides.github.com/features/mastering-markdown/#examples).
+        - You can drag related images into the description if useful - (for example, showing the design or layout of potential features or enhancements in the GUI).
+      placeholder: "Example: I think a foo feature is useful for Sonic Pi because..."
+    validations:
+      required: true
+  - type: textarea
+    id: other-details
+    attributes:
+      label: Other Details
+      description: |
+        Feel free to provide any other relevant information about the feature if you have it, or can get it, such as:
+        - Places where you have seen similar features being used
+        - Ideas about possible ways to build the feature
+        - Etc...
+      placeholder: "Example: We could build the foo feature by adding a bar to the baz panel..."
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/RUNNING-ISSUE-FORM.yml
+++ b/.github/ISSUE_TEMPLATE/RUNNING-ISSUE-FORM.yml
@@ -59,7 +59,14 @@ body:
       description: |
         You can drag related images into the description if you like.
         If Sonic Pi gave you an error, please share it below along with the stacktrace so that we can use it to investigate the cause.
-      placeholder: "Example: Sonic Pi gave me an error. It said: Undefined variable or method `foobar` for Runtime:SonicPiLang, workspace_nine:1:in `block (2 levels) in __spider_eval'"
+      placeholder: |
+        Example: Sonic Pi gave me an error. It said:
+        ```
+        Runtime Error: [buffer 0, line 1] - NameError
+        Thread death!
+        undefined local variable or method `foobar' for Runtime:SonicPiLang
+        workspace_seven:1:in `block (2 levels) in __spider_eval'
+        ```
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/RUNNING-ISSUE-FORM.yml
+++ b/.github/ISSUE_TEMPLATE/RUNNING-ISSUE-FORM.yml
@@ -1,0 +1,117 @@
+name: A problem while Sonic Pi is running 
+description: Sonic Pi starts up, but behaves unexpectedly during use.
+labels: ["triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Hello! Thank you for wanting to raise an issue for us, so that we know what's not working for you.
+
+        Sorry you're having issues while Sonic Pi is running! We're always working to improve its behaviour.
+
+        The core Sonic Pi development team is fairly small and made up of volunteers (with the exception of Sam Aaron, who relies much on crowd-funding) so the more help we can receive to manage, troubleshoot and hopefully fix your issues for you the better - help us to help you! Please follow the checklist below - that way you might not even need to raise an issue after all :smile:
+  - type: checkboxes
+    id: read-troubleshooting-guide
+    attributes:
+      label: Prerequisites
+      options:
+        - label: I've read the [Sonic Pi troubleshooting guide](https://github.com/sonic-pi-net/sonic-pi/wiki/Troubleshooting-Issues) and followed its suggestions where relevant
+          required: true
+  - type: dropdown
+    id: sonic-pi-version
+    attributes:
+      label: Sonic Pi Version
+      description: |
+        What version of Sonic Pi were you running?
+        (Was it a release version, Beta, or a version you compiled from source yourself?)
+      options:
+        - Self compiled
+        - v4.0-Beta5
+        - v4.0-Beta4
+        - v4.0-Beta3
+        - v4.0-Beta2
+        - v4.0-Beta1
+        - v3.3.1
+        - v3.3
+        - v3.2.2
+        - v3.2.1
+        - v3.2
+        - v3.1
+        - v3.0.1
+        - v3.0
+        - v2.11.1
+        - v2.11
+        - v2.10
+        - v2.9
+        - v2.8
+        - v2.7
+        - v2.6
+        - v2.5
+        - v2.4
+        - v2.3
+        - v2.2
+        - v2.1.1
+        - v2.1
+        - v2.0.1
+        - v2.0
+    validations:
+      required: true
+  - type: input
+    id: dev-commit
+    attributes:
+      label: Self compiled commit id
+      description: "If you were using a version of Sonic Pi that you compiled yourself, what was the Git commit id of the code?"
+      placeholder: "Example: 00f737e"
+    validations:
+      required: false
+  - type: input
+    id: os-version
+    attributes:
+      label: Operating System
+      description: "What Operating System (and which version) were you using?"
+      placeholder: "Example: Windows 10"
+    validations:
+      required: true
+  - type: textarea
+    id: repro-steps
+    attributes:
+      label: What were you doing when Sonic Pi behaved unexpectedly?
+      description: |
+        You can drag related images into the description if you like.
+        If you were trying to run some code when Sonic Pi behaved unexpectedly, please share a _small_ code example here that demonstrates the unexpected behaviour. (The simpler it is the better).
+        Please use code formatting for the example - if you're not sure how, please see the 'Code' examples at GitHub's [Mastering Markdown examples](https://guides.github.com/features/mastering-markdown/#examples).
+      placeholder: "Example: I typed the following code into Sonic Pi, and then hit 'Run': `play foobar`"
+    validations:
+      required: true
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: |
+        You can drag related images into the description if you like.
+        If Sonic Pi gave you an error, please share it below along with the stacktrace so that we can use it to investigate the cause.
+      placeholder: "Example: Sonic Pi gave me an error. It said: Undefined variable or method `foobar` for Runtime:SonicPiLang, workspace_nine:1:in `block (2 levels) in __spider_eval'"
+    validations:
+      required: true
+  - type: textarea
+    id: expecting
+    attributes:
+      label: What were you expecting to happen instead?
+      description: "You can drag related images into the description if you like"      
+      placeholder: "Example: I was expecting a sound to play."
+    validations:
+      required: true
+  - type: textarea
+    id: other-details
+    attributes:
+      label: Other Details
+      description: |
+        You can drag related images into the description if you like.
+        Feel free to provide any other relevant information about the issue if you have it, or can get it:
+        - Ideas about possible root causes
+        - Links to the problematic commit or location in the source code on GitHub
+        - Workarounds or potential solutions (or even better, send us a pull request!)
+        - Etc...
+      placeholder: "Example: Could this be related to X? Maybe it might be fixed by editing the foo file."
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/RUNNING-ISSUE-FORM.yml
+++ b/.github/ISSUE_TEMPLATE/RUNNING-ISSUE-FORM.yml
@@ -17,43 +17,12 @@ body:
       options:
         - label: I've read the [Sonic Pi troubleshooting guide](https://github.com/sonic-pi-net/sonic-pi/wiki/Troubleshooting-Issues) and followed its suggestions where relevant
           required: true
-  - type: dropdown
+  - type: input
     id: sonic-pi-version
     attributes:
       label: Sonic Pi Version
-      description: |
-        What version of Sonic Pi were you running?
-        (Was it a release version, Beta, or a version you compiled from source yourself?)
-      options:
-        - Self compiled
-        - v4.0-Beta5
-        - v4.0-Beta4
-        - v4.0-Beta3
-        - v4.0-Beta2
-        - v4.0-Beta1
-        - v3.3.1
-        - v3.3
-        - v3.2.2
-        - v3.2.1
-        - v3.2
-        - v3.1
-        - v3.0.1
-        - v3.0
-        - v2.11.1
-        - v2.11
-        - v2.10
-        - v2.9
-        - v2.8
-        - v2.7
-        - v2.6
-        - v2.5
-        - v2.4
-        - v2.3
-        - v2.2
-        - v2.1.1
-        - v2.1
-        - v2.0.1
-        - v2.0
+      description: "What version of Sonic Pi were you running? Was it a release version, Beta, or a version you compiled from source yourself?"
+      placeholder: "Examples: 'v4.0-Beta5', 'self compiled dev build', 'v3.3.1' ..."
     validations:
       required: true
   - type: input

--- a/.github/ISSUE_TEMPLATE/RUNNING-ISSUE-FORM.yml
+++ b/.github/ISSUE_TEMPLATE/RUNNING-ISSUE-FORM.yml
@@ -48,7 +48,7 @@ body:
       description: |
         You can drag related images into the description if you like.
         If you were trying to run some code when Sonic Pi behaved unexpectedly, please share a _small_ code example here that demonstrates the unexpected behaviour. (The simpler it is the better).
-        Please use code formatting for the example - if you're not sure how, please see the 'Code' examples at GitHub's [Mastering Markdown examples](https://guides.github.com/features/mastering-markdown/#examples).
+        Please use code formatting for the example - if you're not sure how, please see GitHub's guide: [Quoting code](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#quoting-code).
       placeholder: "Example: I typed the following code into Sonic Pi, and then hit 'Run': `play foobar`"
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/STARTUP-ISSUE-FORM.yml
+++ b/.github/ISSUE_TEMPLATE/STARTUP-ISSUE-FORM.yml
@@ -1,0 +1,98 @@
+name: A Sonic Pi start up issue
+description: Sonic Pi doesn't start up successfully.
+labels: ["triage", "boot"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Hello! Thank you for wanting to raise an issue for us, so that we know what's not working for you.
+
+        Sorry you're having issues getting Sonic pi to start up! We're always working to improve the success rate.
+
+        The core Sonic Pi development team is fairly small and made up of volunteers (with the exception of Sam Aaron, who relies much on crowd-funding) so the more help we can receive to manage, troubleshoot and hopefully fix your issues for you the better - help us to help you! Please follow the checklist below - that way you might not even need to raise an issue after all :smile:
+  - type: checkboxes
+    id: read-troubleshooting-guide
+    attributes:
+      label: Prerequisites
+      options:
+        - label: I've read the [Sonic Pi troubleshooting guide](https://github.com/sonic-pi-net/sonic-pi/wiki/Troubleshooting-Issues) and followed its suggestions where relevant
+          required: true
+  - type: dropdown
+    id: sonic-pi-version
+    attributes:
+      label: Sonic Pi Version
+      description: |
+        What version of Sonic Pi were you running?
+        (Was it a release version, Beta, or a version you compiled from source yourself?)
+      options:
+        - Self compiled
+        - v4.0-Beta5
+        - v4.0-Beta4
+        - v4.0-Beta3
+        - v4.0-Beta2
+        - v4.0-Beta1
+        - v3.3.1
+        - v3.3
+        - v3.2.2
+        - v3.2.1
+        - v3.2
+        - v3.1
+        - v3.0.1
+        - v3.0
+        - v2.11.1
+        - v2.11
+        - v2.10
+        - v2.9
+        - v2.8
+        - v2.7
+        - v2.6
+        - v2.5
+        - v2.4
+        - v2.3
+        - v2.2
+        - v2.1.1
+        - v2.1
+        - v2.0.1
+        - v2.0
+    validations:
+      required: true
+  - type: input
+    id: dev-commit
+    attributes:
+      label: Self compiled commit id
+      description: "If you were using a version of Sonic Pi that you compiled yourself, what was the Git commit id of the code?"
+      placeholder: "Example: 00f737e"
+    validations:
+      required: false
+  - type: input
+    id: os-version
+    attributes:
+      label: Operating System
+      description: "What Operating System (and which version) were you using?"
+      placeholder: "Example: Windows 10"
+    validations:
+      required: true
+  - type: textarea
+    id: log-details
+    attributes:
+      label: Log file details
+      description: |
+        Please paste in the error report or log file details as outlined in the troubleshooting guide.
+        If the `.sonic-pi/log` directory doesn't exist, then Sonic Pi probably doesn't even load far enough to be able to create it. Please tell us if this is the case!
+      render: shell
+    validations:
+      required: true
+  - type: textarea
+    id: other-details
+    attributes:
+      label: Other Details
+      description: |
+        You can drag related images into the description if you like.
+        Feel free to provide any other relevant information about the issue if you have it, or can get it:
+        - Ideas about possible root causes
+        - Links to the problematic commit or location in the source code on GitHub
+        - Workarounds or potential solutions (or even better, send us a pull request!)
+        - Etc...
+      placeholder: "Example: Could this be related to X? Maybe it might be fixed by editing the foo file."
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/STARTUP-ISSUE-FORM.yml
+++ b/.github/ISSUE_TEMPLATE/STARTUP-ISSUE-FORM.yml
@@ -17,43 +17,12 @@ body:
       options:
         - label: I've read the [Sonic Pi troubleshooting guide](https://github.com/sonic-pi-net/sonic-pi/wiki/Troubleshooting-Issues) and followed its suggestions where relevant
           required: true
-  - type: dropdown
+  - type: input
     id: sonic-pi-version
     attributes:
       label: Sonic Pi Version
-      description: |
-        What version of Sonic Pi were you running?
-        (Was it a release version, Beta, or a version you compiled from source yourself?)
-      options:
-        - Self compiled
-        - v4.0-Beta5
-        - v4.0-Beta4
-        - v4.0-Beta3
-        - v4.0-Beta2
-        - v4.0-Beta1
-        - v3.3.1
-        - v3.3
-        - v3.2.2
-        - v3.2.1
-        - v3.2
-        - v3.1
-        - v3.0.1
-        - v3.0
-        - v2.11.1
-        - v2.11
-        - v2.10
-        - v2.9
-        - v2.8
-        - v2.7
-        - v2.6
-        - v2.5
-        - v2.4
-        - v2.3
-        - v2.2
-        - v2.1.1
-        - v2.1
-        - v2.0.1
-        - v2.0
+      description: "What version of Sonic Pi were you running? Was it a release version, Beta, or a version you compiled from source yourself?"
+      placeholder: "Examples: 'v4.0-Beta5', 'self compiled dev build', 'v3.3.1' ..."
     validations:
       required: true
   - type: input

--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,0 +1,23 @@
+Hello! We're so glad you're interested in improving Sonic Pi.
+
+The core Sonic Pi development team is fairly small and made up of volunteers (with the exception of Sam Aaron, who relies much on crowd-funding) so the more help we can receive to manage your pull requests the better! Please follow the checklist below - that way, the process of reviewing and potentially merging your contribution can be streamlined :smile:
+
+- [ ] I've followed the project guidelines and ideal contribution process described in [CONTRIBUTING.md](https://github.com/sonic-pi-net/sonic-pi/blob/dev/CONTRIBUTING.md) where relevant.
+
+## Type of change
+Please delete options that are not relevant.
+
+- [ ] A bug fix
+- [ ] A new feature
+- [ ] A breaking change (a bug fix or new feature that would cause existing functionality to not work as expected)
+- [ ] A documentation update
+
+## Description
+- Provide details about the update such as:
+  - The reason for the change (provide context with links to discussions, GitHub issues, or other resources if available. **Note:** if this is a bug fix, you can link this PR to the bug so that it closes the bug when merged, by writing something in your PR comment like: fixes #1234 (where 1234 is the issue number)).
+  - Where relevant, the reason for the particular way this change has been built.
+  - Where relevant, a description of new behaviour.
+  - Screenshots, animated gifs or videos, if the change affects the GUI.
+
+## Other information
+Provide any other information that may be relevant to this PR.


### PR DESCRIPTION
This change add a pull request template, as well as issue template forms for
Sonic Pi startup issues, runtime issues, compiling issues and feature requests.