### PR TITLE
Build - record APP_INSTALL_ROOT in config.h

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -22,6 +22,9 @@ if(APPLE)
 endif()
 
 set(APP_ROOT ${CMAKE_CURRENT_LIST_DIR})
+if (NOT APP_INSTALL_ROOT)
+    set(APP_INSTALL_ROOT ${APP_ROOT})
+endif()
 
 # Different triplet for windows
 if (WIN32)

--- a/app/cmake/config.h.cmake
+++ b/app/cmake/config.h.cmake
@@ -1,4 +1,5 @@
 #cmakedefine APP_ROOT "${APP_ROOT}"
+#cmakedefine APP_INSTALL_ROOT "${APP_INSTALL_ROOT}"
 #cmakedefine QT_OLD_API ${QT_OLD_API}
 #cmakedefine RASPBERRY_PI ${RASPBERRY_PI}
 

--- a/app/gui/imgui/CMakeLists.txt
+++ b/app/gui/imgui/CMakeLists.txt
@@ -95,12 +95,6 @@ target_link_directories(${APP_NAME}
 	 )
 endif()
 
-if (APP_INSTALL_ROOT)
-    target_compile_definitions(${APP_NAME} PRIVATE APP_INSTALL_ROOT="${APP_INSTALL_ROOT}")
-else()
-    target_compile_definitions(${APP_NAME} PRIVATE APP_INSTALL_ROOT="${APP_ROOT}")
-endif()
-
 target_link_libraries (${APP_NAME}
     PRIVATE
     SonicPi::API


### PR DESCRIPTION
This should fix the issue @karlsson is having in #3083 by just capturing `APP_INSTALL_ROOT` earlier and recording it in config.h like `APP_ROOT` is

I had mostly split that out in #3066 so the ImGui interface could optionally be included in packaging (since it hard-codes the app path unlike the Qt app which discovers it based on detected executable location)

Closes #3083