### PR TITLE
Stop spread from hanging when num_accents is 0

### DIFF
--- a/app/server/ruby/lib/sonicpi/lang/core.rb
+++ b/app/server/ruby/lib/sonicpi/lang/core.rb
@@ -1635,6 +1635,12 @@ end"
           res = [true] * size
           return res.ring
         end
+        # if someone requests 0 accents, return a ring with no accents
+        if num_accents.zero?
+          res = [false] * size
+          return res.ring
+        end
+
 
         # new part
         v1 = [[true]] * num_accents


### PR DESCRIPTION
The `spread` function currently hangs when the first argument (`num_accents`) is 0. This has bitten me a few times: there's no error message, but Sonic Pi eventually falls too far behind and ends the run. This is slightly beyond the scope of the Toussaint article cited in [the previous discussion](https://github.com/sonic-pi-net/sonic-pi/issues/1593) of `spread`, but it would be nice for Sonic Pi to handle this more gracefully.

This change makes it so `spread(0, 2)` returns `(ring false, false)`.  By analogy, note that `spread (3, 2)` gives `(ring true, true)`, so the function isn't currently throwing errors for slightly nonsensical arguments. :smile: 