### PR TITLE
Build - update vcpkg to 2022.06.16.1 and migrate catch2 for v3 API

### DIFF
--- a/app/api-tests/CMakeLists.txt
+++ b/app/api-tests/CMakeLists.txt
@@ -8,8 +8,7 @@ set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
 set(THREADS_PREFER_PTHREAD_FLAG TRUE)
 
 list(APPEND TEST_SOURCES
-    ${TESTS_ROOT}/CMakeLists.txt
-    ${TESTS_ROOT}/main.cpp)
+    ${TESTS_ROOT}/CMakeLists.txt)
 
 file(GLOB_RECURSE FOUND_TEST_SOURCES "${APP_ROOT}/*.test.cpp")
 
@@ -38,7 +37,7 @@ endif()
 target_link_libraries(${PROJECT_NAME}
     PRIVATE
         SonicPi::API
-        Catch2::Catch2
+        Catch2::Catch2WithMain
         ${PLATFORM_LINKLIBS}
         ${CMAKE_THREAD_LIBS_INIT})
 

--- a/app/api-tests/main.cpp
+++ b/app/api-tests/main.cpp
@@ -1,2 +1,0 @@
-#define CATCH_CONFIG_MAIN 
-#include "catch2/catch.hpp"

--- a/app/api/src/sonicpi_api.test.cpp
+++ b/app/api/src/sonicpi_api.test.cpp
@@ -1,6 +1,6 @@
 #include <cassert>
 #include <iostream>
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 #include <api/sonicpi_api.h>
 #include <api/logger.h>

--- a/app/linux-pre-vcpkg.sh
+++ b/app/linux-pre-vcpkg.sh
@@ -30,7 +30,7 @@ cd "${SCRIPT_DIR}"
 # Build vcpkg
 if [ ! -d "vcpkg" ]; then
     echo "Cloning vcpkg"
-    git clone --depth 1 --branch "${VCPKG_BRANCH:-2022.05.10}" https://github.com/microsoft/vcpkg.git vcpkg
+    git clone --depth 1 --branch "${VCPKG_BRANCH:-2022.06.16.1}" https://github.com/microsoft/vcpkg.git vcpkg
 fi
 
 if [ ! -f "vcpkg/vcpkg" ]; then

--- a/app/mac-pre-vcpkg.sh
+++ b/app/mac-pre-vcpkg.sh
@@ -30,7 +30,7 @@ cd "${SCRIPT_DIR}"
 # Build vcpkg
 if [ ! -d "vcpkg" ]; then
     echo "Cloning vcpkg"
-    git clone --depth 1 --branch 2022.02.02  https://github.com/microsoft/vcpkg.git vcpkg
+    git clone --depth 1 --branch 2022.06.16.1 https://github.com/microsoft/vcpkg.git vcpkg
 fi
 
 if [ ! -f "vcpkg/vcpkg" ]; then

--- a/app/win-pre-vcpkg.bat
+++ b/app/win-pre-vcpkg.bat
@@ -5,7 +5,7 @@ cd %~dp0
 REM Build vcpkg
 if not exist "vcpkg\" (
     echo Cloning vcpkg
-    git clone --depth 1 --branch 2022.02.02  https://github.com/microsoft/vcpkg.git vcpkg
+    git clone --depth 1 --branch 2022.06.16.1 https://github.com/microsoft/vcpkg.git vcpkg
 )
 
 if not exist "vcpkg\vcpkg.exe" (


### PR DESCRIPTION
I'm going to let CI run and see if it succeeds with this. It seems to have worked locally for upgrading vcpkg to 2022.06.16.1 and using catch2 v3.0.1 (ref: https://github.com/sonic-pi-net/sonic-pi/issues/3112#issuecomment-1178991352 and https://github.com/catchorg/Catch2/blob/v3.0.1/docs/migrate-v2-to-v3.md)