### PR TITLE
Build - use Qt5::<lib> targets for Qt 5.12 compatibility

### DIFF
--- a/app/gui/qt/CMakeLists.txt
+++ b/app/gui/qt/CMakeLists.txt
@@ -288,24 +288,39 @@ target_link_libraries(${APP_NAME}
     PRIVATE
     SonicPi::API
     QScintilla
-    Qt::Core
-    Qt::Gui
-    Qt::Widgets
-    Qt::OpenGL
-    Qt::Concurrent
-    Qt::Network
     Threads::Threads)
 
-if(Qt6_FOUND)
+if(Qt5_FOUND)
   target_link_libraries(${APP_NAME}
   PRIVATE
+  Qt5::Core
+  Qt5::Gui
+  Qt5::Widgets
+  Qt5::OpenGL
+  Qt5::Concurrent
+  Qt5::Network)
+else()
+  target_link_libraries(${APP_NAME}
+  PRIVATE
+  Qt::Core
+  Qt::Gui
+  Qt::Widgets
+  Qt::OpenGL
+  Qt::Concurrent
+  Qt::Network
   Qt::OpenGLWidgets)
 endif()
 
 if(WITH_QT_GUI_WEBENGINE)
-  target_link_libraries(${APP_NAME}
-  PRIVATE
-  Qt::WebEngineWidgets)
+  if(Qt5_FOUND)
+    target_link_libraries(${APP_NAME}
+    PRIVATE
+    Qt5::WebEngineWidgets)
+  else()
+    target_link_libraries(${APP_NAME}
+    PRIVATE
+    Qt::WebEngineWidgets)
+  endif()
 endif()
 
 

--- a/app/gui/qt/QScintilla_src-2.13.3/CMakeLists.txt
+++ b/app/gui/qt/QScintilla_src-2.13.3/CMakeLists.txt
@@ -290,13 +290,23 @@ target_include_directories(QScintilla
   src
 )
 
-target_link_libraries(QScintilla
-PUBLIC
-Qt::PrintSupport
-Qt::Widgets
-Qt::OpenGL
-Qt::Xml
-)
+if(Qt5_FOUND)
+  target_link_libraries(QScintilla
+  PUBLIC
+  Qt5::PrintSupport
+  Qt5::Widgets
+  Qt5::OpenGL
+  Qt5::Xml
+  )
+else()
+  target_link_libraries(QScintilla
+  PUBLIC
+  Qt::PrintSupport
+  Qt::Widgets
+  Qt::OpenGL
+  Qt::Xml
+  )
+endif()
 
 target_compile_definitions(QScintilla PRIVATE -DSCINTILLA_QT)
 target_compile_definitions(QScintilla PRIVATE -DSCI_LEXER)
@@ -324,7 +334,7 @@ elseif(${CMAKE_SYSTEM_NAME} MATCHES Darwin) # macOS
     find_package(Qt5 COMPONENTS MacExtras REQUIRED)
     target_link_libraries(QScintilla
       PUBLIC
-      Qt::MacExtras
+      Qt5::MacExtras
       )
   endif()
 


### PR DESCRIPTION
Required for Ubuntu 20.04 support

This should probably be reverted when we drop support for Ubuntu 20.04 (the current LTS 22.04 does not need this)

Fixes #3124