### PR TITLE
Build - allow using system qscintilla

### DIFF
--- a/app/gui/qt/CMakeLists.txt
+++ b/app/gui/qt/CMakeLists.txt
@@ -1,23 +1,23 @@
 cmake_minimum_required(VERSION 3.2)
 
-message(STATUS " CMakeLists: Sonic Pi")
+message(STATUS "CMakeLists: Sonic Pi Qt GUI")
 
 project("Sonic Pi"
-    LANGUAGES CXX C
+  LANGUAGES CXX C
   DESCRIPTION "A code-based music creation and performance tool"
-  VERSION 3.3.1
+  VERSION 4.0.1
   HOMEPAGE_URL "https://sonic-pi.net"
-  )
+)
 
 if(APPLE)
   set(CMAKE_OSX_DEPLOYMENT_TARGET "10.15")
 endif()
 
-
-
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
 set(QTAPP_ROOT ${CMAKE_CURRENT_LIST_DIR})
+
+list(APPEND CMAKE_MODULE_PATH ${QTAPP_ROOT}/cmake)
 
 # Set cmake prefix path so it can find the Qt libraries
 if((${BUILD_32BIT}) AND (DEFINED ENV{QT_INSTALL_LOCATION32}))
@@ -59,9 +59,13 @@ endif()
 
 find_package(Threads REQUIRED)
 
-# We build QScintilla as part of the main project to make it easy to debug/fix
-# It is not built as part of externals
-add_subdirectory(QScintilla_src-2.13.3)
+if(USE_SYSTEM_LIBS)
+  find_package(QScintilla REQUIRED)
+else()
+  # We build QScintilla as part of the main project to make it easy to debug/fix
+  # It is not built as part of externals
+  add_subdirectory(QScintilla_src-2.13.3)
+endif()
 
 set(APP_NAME sonic-pi)
 set(MACOS_APP_NAME "Sonic Pi")

--- a/app/gui/qt/cmake/FindQScintilla.cmake
+++ b/app/gui/qt/cmake/FindQScintilla.cmake
@@ -1,0 +1,44 @@
+if(QSCINTILLA_INCLUDE_DIR)
+  set(QSCINTILLA_FIND_QUIETLY TRUE)
+endif()
+
+find_path(QSCINTILLA_INCLUDE_DIR Qsci/qsciscintilla.h
+  HINTS ${QSCINTILLA_ROOT} ${QSCINTILLA_ROOT}/include)
+
+find_library(QSCINTILLA_LIBRARY
+  NAMES
+    qscintilla2
+    qscintilla2_qt6
+    qscintilla2_qt5
+    libqscintilla2
+    libqscintilla2_qt6
+    libqscintilla2_qt5
+  HINTS ${QSCINTILLA_ROOT} ${QSCINTILLA_ROOT}/lib)
+
+if(QSCINTILLA_INCLUDE_DIR AND EXISTS "${QSCINTILLA_INCLUDE_DIR}/Qsci/qsciglobal.h")
+  file(STRINGS "${QSCINTILLA_INCLUDE_DIR}/Qsci/qsciglobal.h" qscintilla_version_str REGEX "^#define[\t ]+QSCINTILLA_VERSION_STR[\t ]+\".*\"")
+  string(REGEX REPLACE "^.*QSCINTILLA_VERSION_STR[\t ]+\"([^\"]*)\".*$" "\\1" QSCINTILLA_VERSION "${qscintilla_version_str}")
+  unset(qscintilla_version_str)
+endif()
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(QScintilla
+  REQUIRED_VARS
+    QSCINTILLA_LIBRARY
+    QSCINTILLA_INCLUDE_DIR
+  VERSION_VAR
+    QSCINTILLA_VERSION)
+
+if(QSCINTILLA_FOUND)
+  set(QSCINTILLA_LIBRARIES ${QSCINTILLA_LIBRARY})
+  set(QSCINTILLA_INCLUDE_DIRS ${QSCINTILLA_INCLUDE_DIR})
+
+  if(NOT TARGET QScintilla)
+    add_library(QScintilla UNKNOWN IMPORTED)
+    set_target_properties(QScintilla PROPERTIES
+      INTERFACE_INCLUDE_DIRECTORIES "${QSCINTILLA_INCLUDE_DIRS}"
+      IMPORTED_LOCATION "${QSCINTILLA_LIBRARIES}")
+  endif()
+endif()
+
+mark_as_advanced(QSCINTILLA_INCLUDE_DIR QSCINTILLA_LIBRARY)


### PR DESCRIPTION
When `USE_SYSTEM_LIBS` is enabled, this PR will make the build use the system QScintilla library, which makes the build much faster and Linux distros won't have to sketchily patch it out like most of them have been doing already

I also did minor drive-by touch-ups to the CMakeLists file while I was at it too, but those can be adjusted or removed from this PR if they are a problem

I'm also making progress with the Linux packaging guide, which will just give Linux packagers the tips and info they need to create a distributable and reproducible build of Sonic Pi using their flavor of packager. It's especially relevant for the 4.0 release since the build system has a lot more moving parts now and requires Elixir stuff. I've still to finish writing that guide, though, so that will be a later PR