### PR TITLE
Refuse to define functions starting with a capital letter.

### DIFF
--- a/app/server/ruby/lib/sonicpi/lang/core.rb
+++ b/app/server/ruby/lib/sonicpi/lang/core.rb
@@ -2751,6 +2751,8 @@ end
           raise ArgumentError, "A function called #{name} is already part of Sonic Pi's core API. Please choose another name."
         end
 
+        raise ArgumentError, "Function names can't start with a capital letter." if name.to_s =~ /^[A-Z]/
+
         if already_defined
           __info "Redefining fn #{name.inspect}"
         else


### PR DESCRIPTION
Functions with an initial upper case letter must always be followed by parentheses, otherwise Ruby will assume they are constants, leading to confusing errors. 