### PR TITLE
Build - fix raspberry pi build and update docs a little bit

### DIFF
--- a/BUILD-LINUX.md
+++ b/BUILD-LINUX.md
@@ -58,7 +58,7 @@ few dependencies:
 ### 1.1 Debian
 The following is a rough list of Debian packages that are needed that can serve as a starting position:
 ```bash
-sudo apt-get install -y build-essential git libssl-dev ruby-dev elixir erlang-dev erlang-xmerl qttools5-dev qttools5-dev-tools libqt5svg5-dev libqt5opengl5-dev supercollider-server sc3-plugins-server alsa-utils jackd2 libjack-jackd2-dev libjack-jackd2-0 libasound2-dev librtmidi-dev pulseaudio-module-jack cmake ninja-build
+sudo apt-get install -y build-essential git libssl-dev ruby-dev elixir erlang-dev erlang-xmerl qttools5-dev qttools5-dev-tools libqt5svg5-dev libqt5opengl5-dev supercollider-server sc3-plugins-server alsa-utils jackd2 libjack-jackd2-dev libjack-jackd2-0 libasound2-dev pulseaudio-module-jack cmake ninja-build
 ```
 
 *Note:* The main repositories may not have a recent enough version of 

--- a/BUILD-RASPBERRY-PI.md
+++ b/BUILD-RASPBERRY-PI.md
@@ -11,7 +11,7 @@ etc., you can fetch, build and start Sonic Pi with the following:
 ```
 git clone https://github.com/sonic-pi-net/sonic-pi.git
 cd sonic-pi/app
-sudo ./pi-setup.sh
+./pi-setup.sh
 ./pi-install-elixir.sh
 ```
 
@@ -84,12 +84,10 @@ cd ~/Development/sonic-pi
 
 ## 2. Fetch the Development Dependencies
 
-Now we're ready to fetch all the development dependencies. You can do
-this by running the following script with `sudo` (this is necessary as
-it calls `apt-get` to install your packages)
+Now we're ready to fetch all the development dependencies.
 
 ```
-sudo ./app/pi-setup.sh
+./app/pi-setup.sh
 ```
 
 The versions of Erlang and Elixir installed by default are not currently

--- a/app/linux-pre-vcpkg.sh
+++ b/app/linux-pre-vcpkg.sh
@@ -43,9 +43,9 @@ fi
 cd vcpkg
 
 if [ "$no_imgui" == true ]; then
-    ./vcpkg install libsndfile kissfft crossguid platform-folders reproc catch2 --recurse
+    ./vcpkg install libsndfile[core,external-libs] kissfft crossguid platform-folders reproc catch2 --recurse
 else
-    ./vcpkg install libsndfile kissfft fmt crossguid sdl2[x11] gl3w reproc gsl-lite concurrentqueue platform-folders catch2 --recurse
+    ./vcpkg install libsndfile[core,external-libs] kissfft fmt crossguid sdl2[x11] gl3w reproc gsl-lite concurrentqueue platform-folders catch2 --recurse
 fi
 
 

--- a/app/mac-pre-vcpkg.sh
+++ b/app/mac-pre-vcpkg.sh
@@ -44,9 +44,9 @@ cd vcpkg
 triplet=(x64-osx)
 
 if [ "$no_imgui" == true ]; then
-    ./vcpkg install libsndfile kissfft crossguid platform-folders reproc catch2 --triplet ${triplet[0]} --recurse
+    ./vcpkg install libsndfile[core,external-libs] kissfft crossguid platform-folders reproc catch2 --triplet ${triplet[0]} --recurse
 else
-    ./vcpkg install libsndfile kissfft fmt sdl2 gl3w reproc gsl-lite concurrentqueue platform-folders catch2 --triplet ${triplet[0]} --recurse
+    ./vcpkg install libsndfile[core,external-libs] kissfft fmt sdl2 gl3w reproc gsl-lite concurrentqueue platform-folders catch2 --triplet ${triplet[0]} --recurse
 fi
 
 

--- a/app/pi-build-all.sh
+++ b/app/pi-build-all.sh
@@ -7,6 +7,6 @@ WORKING_DIR="$(pwd)"
 "${SCRIPT_DIR}"/pi-prebuild.sh -n
 "${SCRIPT_DIR}"/pi-config.sh -n
 "${SCRIPT_DIR}"/pi-build-gui.sh
-“${SCRIPT_DIR}”/pi-post-tau-prod-release.sh
+"${SCRIPT_DIR}"/pi-post-tau-prod-release.sh
 
 cd "${WORKING_DIR}"

--- a/app/pi-prebuild.sh
+++ b/app/pi-prebuild.sh
@@ -3,7 +3,7 @@
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 WORKING_DIR="$(pwd)"
 
-VCPKG_FORCE_SYSTEM_BINARIES=1 "${SCRIPT_DIR}"/linux-prebuild.sh "$@"
+VCPKG_FORCE_SYSTEM_BINARIES=1 CC="$(type -p clang)" CXX="$(type -p clang++)" "${SCRIPT_DIR}"/linux-prebuild.sh "$@"
 
 # Restore working directory as it was prior to this script running...
 cd "${WORKING_DIR}"

--- a/app/pi-setup.sh
+++ b/app/pi-setup.sh
@@ -3,7 +3,7 @@
 echo "Fetching dependencies via apt..."
 
 sudo apt-get update
-sudo apt-get install -y curl build-essential libssl-dev git ruby-dev elixir erlang-dev erlang-xmerl qttools5-dev qttools5-dev-tools libqt5svg5-dev supercollider-server sc3-plugins-server alsa-utils jackd2 libjack-jackd2-0 pulseaudio-module-jack librtmidi-dev cmake ninja-build
+sudo apt-get install -y curl build-essential libssl-dev git ruby-dev elixir erlang-dev erlang-xmerl qttools5-dev qttools5-dev-tools libqt5svg5-dev supercollider-server sc3-plugins-server alsa-utils jackd2 libjack-jackd2-0 pulseaudio-module-jack libasound2-dev clang cmake ninja-build
 
 # Dependencies for building Erlang/Elixir via asdf...
 sudo apt-get -y install build-essential autoconf m4 libncurses5-dev libwxgtk3.0-gtk3-dev libgl1-mesa-dev libglu1-mesa-dev libpng-dev libssh-dev unixodbc-dev xsltproc fop

--- a/app/win-pre-vcpkg.bat
+++ b/app/win-pre-vcpkg.bat
@@ -17,6 +17,6 @@ if not exist "vcpkg\vcpkg.exe" (
 
 cd vcpkg
 @echo Installing Libraries
-vcpkg install libsndfile kissfft fmt crossguid sdl2 gl3w reproc gsl-lite concurrentqueue platform-folders catch2 --triplet x64-windows-static-md --recurse
+vcpkg install libsndfile[core,external-libs] kissfft fmt crossguid sdl2 gl3w reproc gsl-lite concurrentqueue platform-folders catch2 --triplet x64-windows-static-md --recurse
 
 cd %WORKING_DIR%


### PR DESCRIPTION
Summary of changes:
* remove librtmidi-dev (but make sure we still get libasound2-dev) from linux/pi build stuff
* remove `sudo` from pi instructions since those scripts themselves call `sudo`
* only use `libsndfile[core,external-libs]` instead of the (default) `libsndfile[core,external-libs,mpeg]`
* use clang on raspberry pi (fixes issues with vcpkg opus, until those fixes can be upstreamed)
* replace smart quotes with normal quotes in `pi-build-all.sh`