### PR TITLE
Be less strict with initial capitals in function names

### DIFF
--- a/app/server/ruby/lib/sonicpi/lang/core.rb
+++ b/app/server/ruby/lib/sonicpi/lang/core.rb
@@ -2751,7 +2751,9 @@ end
           raise ArgumentError, "A function called #{name} is already part of Sonic Pi's core API. Please choose another name."
         end
 
-        raise ArgumentError, "Function names can't start with a capital letter." if name.to_s =~ /^[A-Z]/
+        if block.arity == 0 && name.to_s =~ /^[A-Z]/
+          raise ArgumentError, "Functions with no required parameters can't start with a capital letter."
+        end
 
         if already_defined
           __info "Redefining fn #{name.inspect}"

--- a/app/server/ruby/lib/sonicpi/lang/core.rb
+++ b/app/server/ruby/lib/sonicpi/lang/core.rb
@@ -2752,7 +2752,7 @@ end
         end
 
         if block.arity == 0 && name.to_s =~ /^[A-Z]/
-          raise ArgumentError, "Functions with no required parameters can't start with a capital letter."
+          __delayed_warning "Functions with no required parameters shouldn't start with a capital letter."
         end
 
         if already_defined

--- a/app/server/ruby/lib/sonicpi/lang/core.rb
+++ b/app/server/ruby/lib/sonicpi/lang/core.rb
@@ -2770,7 +2770,9 @@ end
           accepts_block:  true,
           requires_block: true,
           intro_fn:       true,
-          doc:            "Allows you to group a bunch of code and give it your own name for future re-use. Functions are very useful for structuring your code. They are also the gateway into live coding as you may redefine a function whilst a thread is calling it, and the next time the thread calls your function, it will use the latest definition.",
+          doc:            "Allows you to group a bunch of code and give it your own name for future re-use. Functions are very useful for structuring your code. They are also the gateway into live coding as you may redefine a function whilst a thread is calling it, and the next time the thread calls your function, it will use the latest definition.
+
+Note, it is not recommended to start a function name with a capital letter if it takes no parameters.",
           examples:       ["
   # Define a new function called foo
   define :foo do
@@ -2785,7 +2787,16 @@ end
   # For example, in a block:
   3.times do
     foo
-  end",]
+  end",
+
+  "
+  # Define a new function called play2, taking one parameter
+  define :play2 do |x|
+    play x, release: 2
+  end
+
+  # Call play2, passing in a value for the parameter
+  play2 42"]
 
 
 


### PR DESCRIPTION
It turns out that functions starting with an initial upper-case letter only cause an issue when called with no arguments.

Therefore, we only need to refuse to define functions starting with a capital letter when they have no required arguments.

This should still prevent the confusion that #3140 aimed to fix, while being less intrusive for people who already have functions defined with initial upper-case letters (like [here](in-thread.sonic-pi.net/t/4-0-2-gives-function-names-cant-start-with-a-capital-letter/6939/)).