### PR TITLE
Ensure current_time returns a time (and not a Rational)

### DIFF
--- a/app/server/ruby/lib/sonicpi/lang/core.rb
+++ b/app/server/ruby/lib/sonicpi/lang/core.rb
@@ -3961,7 +3961,7 @@ Unlike `Time.now`, Multiple calls to `current_time` with no interleaved calls to
           opts:          nil,
           accepts_block: false,
           examples:      ["
-  puts current_time # 2017-03-19 23:37:57 +0000",
+  puts current_time # 2017-03-19 23:37:57.324 +0000",
 "
 # The difference between current_time and Time.now
 # See that Time.now is continuous and current_time is discrete

--- a/app/server/ruby/lib/sonicpi/lang/core.rb
+++ b/app/server/ruby/lib/sonicpi/lang/core.rb
@@ -21,12 +21,6 @@ require 'active_support/inflector'
 
 ## TODO: create _* equivalents of all fns - for silent (i.e computation) versions
 
-class Time
-  def inspect()
-    strftime "%Y-%m-%d %H:%M:%S.%L %z"
-  end
-end
-
 module SonicPi
   module Lang
 
@@ -55,6 +49,17 @@ module SonicPi
 
         def [](*args)
           @blk.call(*args)
+        end
+      end
+
+      # Wrap Time so that it always displays to millisecond precision
+      class MilliTime < Time
+        def at(*args)
+          MilliTime.new Time.at(*args)
+        end
+
+        def inspect()
+          strftime "%Y-%m-%d %H:%M:%S.%L %z"
         end
       end
 
@@ -3944,7 +3949,7 @@ end
 
 
       def current_time
-        Time.at(__get_spider_time)
+        MilliTime.at(__get_spider_time)
       end
       doc name:          :current_time,
           introduced:    Version.new(3,0,0),

--- a/app/server/ruby/lib/sonicpi/lang/core.rb
+++ b/app/server/ruby/lib/sonicpi/lang/core.rb
@@ -21,6 +21,12 @@ require 'active_support/inflector'
 
 ## TODO: create _* equivalents of all fns - for silent (i.e computation) versions
 
+class Time
+  def inspect()
+    strftime "%Y-%m-%d %H:%M:%S.%L %z"
+  end
+end
+
 module SonicPi
   module Lang
 

--- a/app/server/ruby/lib/sonicpi/lang/core.rb
+++ b/app/server/ruby/lib/sonicpi/lang/core.rb
@@ -3938,7 +3938,7 @@ end
 
 
       def current_time
-        __get_spider_time
+        Time.at(__get_spider_time)
       end
       doc name:          :current_time,
           introduced:    Version.new(3,0,0),


### PR DESCRIPTION
Fixes #3145

## Note: I've added a monkey-patched `Time.inspect`:

Printing a `Time` in Sonic Pi appears to print the result of calling `.inspect` on the time object.
In most cases, this will print the sub-second part as a rational (e.g. `2022-07-21 23:14:06 3267887/4194304 +0100`), which is not very intuitive.
Therefore I monkey-patched the `Time.inspect` method to print the time as a decimal fraction to the nearest millisecond (so the previous example appears as `2022-07-21 23:14:06.779 +0100`).


### Leaving my initial notes below for context:

#### ~~BEFORE MERGING, Note that there is some strange behaviour that I don't understand~~
For some reason, the fractional seconds are still printed as a rational:
```ruby
puts Time.at(current_time) # 2022-07-21 23:12:38 8989/524288 +0100
#                                                ^^^^^^^^^^^
```

Even if I ensure it's converted to a float first:
```ruby
puts Time.at(current_time.to_f) # 2022-07-21 23:13:25 3979463/4194304 +0100
#                                                     ^^^^^^^^^^^^^^^
```

Even explicitly converting a literal float to a Time:
```ruby
puts Time.at(1658441646.779125) # 2022-07-21 23:14:06 3267887/4194304 +0100
#                                                     ^^^^^^^^^^^^^^^
```

Although I have found a few values are printed as a decimal (where the fractional part is an inverse power of two like 0.5, 0.25, 0.125... or small multiples of them like 0.75 or 0.875):
```ruby
puts Time.at(1658441646.125) # 2022-07-21 23:14:06.125 +0100
#                                                 ^^^^
```

I tried with plain ruby on the command line, and there the fractional part is ignored:
```bash
> echo 'puts Time.at(1658441646.779125)' | /Applications/Sonic\ Pi.app/Contents/Resources/app/server/native/ruby/bin/ruby
2022-07-21 23:14:06 +0100
```

Anyone have any idea what's going on here?

---

I've investigated a bit, and it looks like it's normal that the sub-second part of a `Time` can be rational ([docs](https://ruby-doc.org/core-3.1.2/Time.html#method-i-subsec)). I think the values that were printed as decimal must be ones that are exactly representable in floating point.

It's still a bit strange that it's displayed as a ratio. Is there something in Sonic Pi that's changing the the way `Time`s are formatted by default?

---

OK, I think I've worked out what's happening!

Printing the time is calling `.inspect` on it, which does print the sub-seconds as a rational (even from bare Ruby on the command line).

So this seems to be working as designed.

However, I do wonder whether it might be clearer to print out times with decimal fractions of seconds. One way to achieve this would be to monkey-patch the `inspect` method on `Time` like this (to print to nearest millisecond):
```ruby
class Time
  def inspect()
    strftime "%Y-%m-%d %H:%M:%S.%L %z"
  end
end
```

Is that reasonable, or is there a better way? If it's OK, where would be the bets place to put this?