### PR TITLE
Metre and micro-timing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -150,10 +150,3 @@ etc/synthdefs/designs/overtone/sonic-pi/native
 
 # Visual Studio settings folder.
 .vs
-.vscode
-
-# Temp
-debug.bat
-run.ps1
-start.bat
-buffer.rb

--- a/.gitignore
+++ b/.gitignore
@@ -150,3 +150,10 @@ etc/synthdefs/designs/overtone/sonic-pi/native
 
 # Visual Studio settings folder.
 .vs
+.vscode
+
+# Temp
+debug.bat
+run.ps1
+start.bat
+buffer.rb

--- a/app/server/ruby/lib/sonicpi/lang/sound.rb
+++ b/app/server/ruby/lib/sonicpi/lang/sound.rb
@@ -4159,6 +4159,21 @@ If you wish your synth to work with Sonic Pi's automatic stereo sound infrastruc
         # Sleep for the duration of the note
         sleep(metre.quarter_length_to_sonic_pi_beat(note_quarter_lengths))
       end
+      doc name:          :add_note,
+          introduced:    Version.new(4,0,3),
+          summary:       "Adds a note to the current bar",
+          doc:           "Plays a given note for a specified duration as part of the current bar on the current synthesizer. `level` specifies the metrical level the note should exist at, as defined by the current metre. Level `0` is the beat level. Levels `1`, `2`, etc. are division levels (e.g. quarter notes, eighth notes, etc.). Levels `-1`, `-2`, etc. are multiple levels (e.g. half notes, whole notes, etc.). `duration` specifies how many of these notes it should last for. This method must be called from within a bar block. The timing of the note will be shifted according to any micro-timing set in the current metre.",
+          args:          [[:note, :symbol_or_number], [:level, :number], [:duration, :number]],
+          opts:          DEFAULT_PLAY_OPTS,
+          accepts_block: true,
+          memoize:       true,
+          examples:      ["
+use_metre '4/4'
+bar do
+  add_note :C4, 1, 1 # Plays the C4 note for one quaver/eighth note
+  add_note :D4, 0, 3 # Plays the D4 note for three crotchet/quarter notes
+end"]
+          
 
       # Shorthand functions assume simple metre for beat level and above
       # Assumes simple or compound for division levels

--- a/app/server/ruby/lib/sonicpi/lang/sound.rb
+++ b/app/server/ruby/lib/sonicpi/lang/sound.rb
@@ -4143,7 +4143,30 @@ If you wish your synth to work with Sonic Pi's automatic stereo sound infrastruc
       def sample_find_candidates(*args)
         @sample_loader.find_candidates(*args)
       end
-    end
 
+      def add_note(n, level=0, duration=1, *args, &blk)
+        current_bar = __thread_locals.get(:sonic_pi_bar)
+        raise "add_note must be called inside a bar" unless current_bar
+        metre = __thread_locals.get(:sonic_pi_metre)
+        note_pulse_units = current_bar.note_to_pulse_units(level, duration)
+
+        current_bar.add_note(level, duration)
+        shift = 0
+        time_warp shift do
+          play(n, *args, &blk)
+        end
+        sleep(metre.to_beats(note_pulse_units))
+      end
+
+      def add_rest(level=0, duration=1)
+        current_bar = __thread_locals.get(:sonic_pi_bar)
+        raise "add_rest must be called inside a bar" unless current_bar
+        metre = __thread_locals.get(:sonic_pi_metre)
+        rest_pulse_units = current_bar.note_to_pulse_units(level, duration)
+        
+        current_bar.add_note(level, duration)
+        sleep(metre.to_beats(rest_pulse_units))
+      end
+    end
   end
 end

--- a/app/server/ruby/lib/sonicpi/lang/sound.rb
+++ b/app/server/ruby/lib/sonicpi/lang/sound.rb
@@ -4148,21 +4148,20 @@ If you wish your synth to work with Sonic Pi's automatic stereo sound infrastruc
         current_bar = __thread_locals.get(:sonic_pi_bar)
         raise "add_note must be called inside a bar" unless current_bar
         metre = __thread_locals.get(:sonic_pi_metre)
-        note_pulse_units = current_bar.note_to_pulse_units(level, duration)
 
-        current_beat = current_bar.current_beat
-        total_elapsed_pulse_units = current_bar.total_elapsed_pulse_units
-        # Call metre.sleep_time to convert the timing shift from pulse units to beats
-        shift = metre.sleep_time(metre.get_timing(current_beat, total_elapsed_pulse_units))
+        current_offset = current_bar.current_offset
+        shift = metre.quarter_length_to_sonic_pi_beat(metre.get_timing(current_offset))
+        note_quarter_lengths = current_bar.add_note(level, duration)
 
-        current_bar.add_note(level, duration)
         time_warp shift do
           play(n, *args, &blk)
         end
         # Sleep for the duration of the note
-        sleep(metre.sleep_time(note_pulse_units))
+        sleep(metre.quarter_length_to_sonic_pi_beat(note_quarter_lengths))
       end
 
+      # Shorthand functions assume simple metre for beat level and above
+      # Assumes simple or compound for division levels
       def add_whole(n, *args, &blk)
         add_note(n, 0, 4, *args, &blk)
       end
@@ -4176,7 +4175,7 @@ If you wish your synth to work with Sonic Pi's automatic stereo sound infrastruc
       end
 
       def add_quarter_d(n, *args, &blk)
-        add_note(n, -1, 3, *args, &blk)
+        add_note(n, 1, 3, *args, &blk)
       end
 
       def add_quarter(n, *args, &blk)
@@ -4184,15 +4183,15 @@ If you wish your synth to work with Sonic Pi's automatic stereo sound infrastruc
       end
 
       def add_8th_d(n, *args, &blk)
-        add_note(n, -2, 3, *args, &blk)
+        add_note(n, 2, 3, *args, &blk)
       end
 
       def add_8th(n, *args, &blk)
-        add_note(n, -1, 1, *args, &blk)
+        add_note(n, 1, 1, *args, &blk)
       end
 
       def add_16th(n, *args, &blk)
-        add_note(n, -2, 1, *args, &blk)
+        add_note(n, 2, 1, *args, &blk)
       end
 
       # British names
@@ -4209,7 +4208,7 @@ If you wish your synth to work with Sonic Pi's automatic stereo sound infrastruc
       end
 
       def add_crotchet_d(n, *args, &blk)
-        add_note(n, -1, 3, *args, &blk)
+        add_note(n, 1, 3, *args, &blk)
       end
 
       def add_crotchet(n, *args, &blk)
@@ -4217,15 +4216,15 @@ If you wish your synth to work with Sonic Pi's automatic stereo sound infrastruc
       end
 
       def add_quaver_d(n, *args, &blk)
-        add_note(n, -2, 3, *args, &blk)
+        add_note(n, 2, 3, *args, &blk)
       end
 
       def add_quaver(n, *args, &blk)
-        add_note(n, -1, 1, *args, &blk)
+        add_note(n, 1, 1, *args, &blk)
       end
 
       def add_semiquaver(n, *args, &blk)
-        add_note(n, -2, 1, *args, &blk)
+        add_note(n, 2, 1, *args, &blk)
       end
      
 
@@ -4233,28 +4232,26 @@ If you wish your synth to work with Sonic Pi's automatic stereo sound infrastruc
         current_bar = __thread_locals.get(:sonic_pi_bar)
         raise "add_sample must be called inside a bar" unless current_bar
         metre = __thread_locals.get(:sonic_pi_metre)
-        note_pulse_units = current_bar.note_to_pulse_units(level, duration)
 
-        current_beat = current_bar.current_beat
-        total_elapsed_pulse_units = current_bar.total_elapsed_pulse_units
-        shift = metre.sleep_time(metre.get_timing(current_beat, total_elapsed_pulse_units))
+        current_offset = current_bar.current_offset
+        shift = metre.quarter_length_to_sonic_pi_beat(metre.get_timing(current_offset))
+        note_quarter_lengths = current_bar.add_note(level, duration)
 
-        current_bar.add_note(level, duration)
         time_warp shift do
           sample(sample_name, *args, &blk)
         end
-        sleep(metre.sleep_time(note_pulse_units))
+        # Sleep for the duration of the note
+        sleep(metre.quarter_length_to_sonic_pi_beat(note_quarter_lengths))
       end
 
       def add_rest(level=0, duration=1)
         current_bar = __thread_locals.get(:sonic_pi_bar)
         raise "add_rest must be called inside a bar" unless current_bar
         metre = __thread_locals.get(:sonic_pi_metre)
-        rest_pulse_units = current_bar.note_to_pulse_units(level, duration)
         
         # Add the rest as a note to the bar to account for its duration
-        current_bar.add_note(level, duration)
-        sleep(metre.sleep_time(rest_pulse_units))
+        rest_quarter_lengths = current_bar.add_note(level, duration)
+        sleep(metre.quarter_length_to_sonic_pi_beat(rest_quarter_lengths))
       end
     end
   end

--- a/app/server/ruby/lib/sonicpi/lang/sound.rb
+++ b/app/server/ruby/lib/sonicpi/lang/sound.rb
@@ -4150,12 +4150,100 @@ If you wish your synth to work with Sonic Pi's automatic stereo sound infrastruc
         metre = __thread_locals.get(:sonic_pi_metre)
         note_pulse_units = current_bar.note_to_pulse_units(level, duration)
 
+        current_beat = current_bar.current_beat
+        total_elapsed_pulse_units = current_bar.total_elapsed_pulse_units
+        # Call metre.sleep_time to convert the timing shift from pulse units to beats
+        shift = metre.sleep_time(metre.get_timing(current_beat, total_elapsed_pulse_units))
+
         current_bar.add_note(level, duration)
-        shift = 0
         time_warp shift do
           play(n, *args, &blk)
         end
-        sleep(metre.to_beats(note_pulse_units))
+        # Sleep for the duration of the note
+        sleep(metre.sleep_time(note_pulse_units))
+      end
+
+      def add_whole(n, *args, &blk)
+        add_note(n, 0, 4, *args, &blk)
+      end
+
+      def add_half_d(n, *args, &blk)
+        add_note(n, 0, 3, *args, &blk)
+      end
+
+      def add_half(n, *args, &blk)
+        add_note(n, 0, 2, *args, &blk)
+      end
+
+      def add_quarter_d(n, *args, &blk)
+        add_note(n, -1, 3, *args, &blk)
+      end
+
+      def add_quarter(n, *args, &blk)
+        add_note(n, 0, 1, *args, &blk)
+      end
+
+      def add_8th_d(n, *args, &blk)
+        add_note(n, -2, 3, *args, &blk)
+      end
+
+      def add_8th(n, *args, &blk)
+        add_note(n, -1, 1, *args, &blk)
+      end
+
+      def add_16th(n, *args, &blk)
+        add_note(n, -2, 1, *args, &blk)
+      end
+
+      # British names
+      def add_semibreve(n, *args, &blk)
+        add_note(n, 0, 4, *args, &blk)
+      end
+
+      def add_minim_d(n, *args, &blk)
+        add_note(n, 0, 3, *args, &blk)
+      end
+
+      def add_minim(n, *args, &blk)
+        add_note(n, 0, 2, *args, &blk)
+      end
+
+      def add_crotchet_d(n, *args, &blk)
+        add_note(n, -1, 3, *args, &blk)
+      end
+
+      def add_crotchet(n, *args, &blk)
+        add_note(n, 0, 1, *args, &blk)
+      end
+
+      def add_quaver_d(n, *args, &blk)
+        add_note(n, -2, 3, *args, &blk)
+      end
+
+      def add_quaver(n, *args, &blk)
+        add_note(n, -1, 1, *args, &blk)
+      end
+
+      def add_semiquaver(n, *args, &blk)
+        add_note(n, -2, 1, *args, &blk)
+      end
+     
+
+      def add_sample(sample_name, level=0, duration=1, *args, &blk)
+        current_bar = __thread_locals.get(:sonic_pi_bar)
+        raise "add_sample must be called inside a bar" unless current_bar
+        metre = __thread_locals.get(:sonic_pi_metre)
+        note_pulse_units = current_bar.note_to_pulse_units(level, duration)
+
+        current_beat = current_bar.current_beat
+        total_elapsed_pulse_units = current_bar.total_elapsed_pulse_units
+        shift = metre.sleep_time(metre.get_timing(current_beat, total_elapsed_pulse_units))
+
+        current_bar.add_note(level, duration)
+        time_warp shift do
+          sample(sample_name, *args, &blk)
+        end
+        sleep(metre.sleep_time(note_pulse_units))
       end
 
       def add_rest(level=0, duration=1)
@@ -4164,8 +4252,9 @@ If you wish your synth to work with Sonic Pi's automatic stereo sound infrastruc
         metre = __thread_locals.get(:sonic_pi_metre)
         rest_pulse_units = current_bar.note_to_pulse_units(level, duration)
         
+        # Add the rest as a note to the bar to account for its duration
         current_bar.add_note(level, duration)
-        sleep(metre.to_beats(rest_pulse_units))
+        sleep(metre.sleep_time(rest_pulse_units))
       end
     end
   end

--- a/app/server/ruby/lib/sonicpi/lang/western_theory.rb
+++ b/app/server/ruby/lib/sonicpi/lang/western_theory.rb
@@ -1118,16 +1118,16 @@ play (chord_invert (chord :A3, \"M\"), 2) #Second inversion - (ring 64, 69, 73)
       memoize:       true,
       examples:      ["puts chord_names #=>  prints a list of all the chords"]
 
-      def use_metre(metre, &block)
+      def use_metre(metre, style=nil, &block)
         raise ArgumentError, "use_metre does not work with a block. Perhaps you meant with_metre" if block
-        new_metre = SynchronisedMetre.new(metre)
+        new_metre = SynchronisedMetre.new(metre, style)
         __thread_locals.set(:sonic_pi_metre, new_metre)
       end
 
-      def with_metre(metre, &block)
+      def with_metre(metre, style=nil, &block)
         raise ArgumentError, "with_metre must be called with a do/end block. Perhaps you meant use_metre" unless block
         original_metre = __thread_locals.get(:sonic_pi_metre)
-        new_metre = SynchronisedMetre.new(metre)
+        new_metre = SynchronisedMetre.new(metre, style)
         __thread_locals.set(:sonic_pi_metre, new_metre)
         block.call
         __thread_locals.set(:sonic_pi_metre, original_metre)
@@ -1141,9 +1141,9 @@ play (chord_invert (chord :A3, \"M\"), 2) #Second inversion - (ring 64, 69, 73)
         bar_object = Bar.new
         __thread_locals.set(:sonic_pi_bar, bar_object)
 
-        puts metre.timings
         block.call
-        sleep(metre.to_beats(bar_object.total_remaining_pulse_units))
+        # If the bar has any space remaining, sleep for that time
+        sleep(metre.sleep_time(bar_object.total_remaining_pulse_units))
         
         __thread_locals.set(:sonic_pi_bar, nil)
       end

--- a/app/server/ruby/lib/sonicpi/lang/western_theory.rb
+++ b/app/server/ruby/lib/sonicpi/lang/western_theory.rb
@@ -1143,7 +1143,7 @@ play (chord_invert (chord :A3, \"M\"), 2) #Second inversion - (ring 64, 69, 73)
 
         block.call
         # If the bar has any space remaining, sleep for that time
-        sleep(metre.sleep_time(bar_object.total_remaining_pulse_units))
+        sleep(metre.quarter_length_to_sonic_pi_beat(bar_object.remaining_quarter_lengths))
         
         __thread_locals.set(:sonic_pi_bar, nil)
       end

--- a/app/server/ruby/lib/sonicpi/lang/western_theory.rb
+++ b/app/server/ruby/lib/sonicpi/lang/western_theory.rb
@@ -1123,6 +1123,26 @@ play (chord_invert (chord :A3, \"M\"), 2) #Second inversion - (ring 64, 69, 73)
         new_metre = SynchronisedMetre.new(metre, style)
         __thread_locals.set(:sonic_pi_metre, new_metre)
       end
+      doc name:          :use_metre,
+          introduced:    Version.new(4,0,3),
+          summary:       "Sets the current metre",
+          doc:           "Sets the metre to be used for the current thread. A metre can be defined as a time signature string or a nested list of Rationals. The `style` argument specifies a micro-timing style to apply to music played in this metre.",
+          args:          [[:metre, :string_or_list], [:style, :symbol]],
+          accepts_block: true,
+          memoize:       true,
+          examples:      ["use_metre '4/4' # This uses a preset metre represented by a 4/4 time signature",
+            "use_metre [[1/8r,1/8r,1/8r], [1/8r,1/8r,1/8r]] # This creates a metre with two beats, each of which can be divided into three eighth notes (the 6/8 time signature)",
+            "use_metre '3/4', :viennese_waltz # Uses the micro-timing of the Viennese Waltz style. You should notice the second beat of each bar falls slightly early. Note that the style has to be compatible with the metre.",
+          "'2/4' # Supported time signatures
+'3/4'
+'4/4'
+'6/8'
+'9/8'
+'12/8'",
+          "# Supported styles
+:viennese_waltz # Second beat is slightly early. Typically uses a 3/4 time signature
+:jembe # Micro-timing of jembe music from Mali. Typically uses a 12/8 time signature
+:triplet_swing # Jazz swing. Typically uses a 4/4 time signature"]
 
       def with_metre(metre, style=nil, &block)
         raise ArgumentError, "with_metre must be called with a do/end block. Perhaps you meant use_metre" unless block
@@ -1132,6 +1152,13 @@ play (chord_invert (chord :A3, \"M\"), 2) #Second inversion - (ring 64, 69, 73)
         block.call
         __thread_locals.set(:sonic_pi_metre, original_metre)
       end
+      doc name:          :with_metre,
+          introduced:    Version.new(4,0,3),
+          summary:       "Sets the current metre",
+          doc:           "Uses the given metre for the `block`. See `use_metre` for details.",
+          args:          [[:metre, :string_or_list], [:style, :symbol]],
+          accepts_block: true,
+          memoize:       true
 
       def bar(&block)
         raise ArgumentError, "bar must be called with a do/end block" unless block
@@ -1147,6 +1174,20 @@ play (chord_invert (chord :A3, \"M\"), 2) #Second inversion - (ring 64, 69, 73)
         
         __thread_locals.set(:sonic_pi_bar, nil)
       end
+      doc name:          :bar,
+          introduced:    Version.new(4,0,3),
+          summary:       "Create a new bar",
+          doc:           "Creates a new bar in the current metre. All notes played with `add_note` inside the `block` argument will belong to this bar. You cannot add more notes than will fit into the bar's total duration. Bars cannot be nested. If all the notes in a bar don't fill its duration, then the bar automatically sleeps for the remaining time.",
+          args:          [],
+          accepts_block: true,
+          memoize:       true,
+          examples:      ["
+use_metre '4/4'
+bar do
+  add_note :C4, 1, 1 # Both notes are part of this bar
+  add_note :D4, 0, 3
+  # The bar automatically sleeps for the remaining 3 eighth notes
+end"]
 
     end
   end

--- a/app/server/ruby/lib/sonicpi/metre/bar.rb
+++ b/app/server/ruby/lib/sonicpi/metre/bar.rb
@@ -15,7 +15,7 @@ module SonicPi
       if previous_bar_number
         current_bar_number = @metre.request_bar(previous_bar_number + 1)
       else
-        current_bar_number = 0
+        current_bar_number = @metre.request_bar(0)
       end
       # Let other and future Bar objects know what the current bar number is
       __thread_locals.set(:sonic_pi_bar_number, current_bar_number)

--- a/app/server/ruby/lib/sonicpi/metre/bar.rb
+++ b/app/server/ruby/lib/sonicpi/metre/bar.rb
@@ -1,4 +1,6 @@
 module SonicPi
+
+  # Class for tracking notes being added to a bar
   class Bar
     
     attr_reader :current_beat, :current_pulse_unit, :metre
@@ -8,12 +10,15 @@ module SonicPi
       @current_beat = 0
       @current_pulse_unit = 0
 
+      # Calculate the next bar number and request it from the current metre
+      # If an old number is requested, metre.request_bar will return the current one
       previous_bar_number = __thread_locals.get(:sonic_pi_bar_number)
       if previous_bar_number
         current_bar_number = @metre.request_bar(previous_bar_number + 1)
       else
         current_bar_number = 0
       end
+      # Let other and future Bar objects know what the current bar number is
       __thread_locals.set(:sonic_pi_bar_number, current_bar_number)
     end
     
@@ -21,31 +26,37 @@ module SonicPi
       true
     end
     
+    # Calculate how many pulse units have elapsed so far in this bar
     def total_elapsed_pulse_units
       pulse_units = 0
       (0...@current_beat).each do |i|
-        pulse_units += @metre.beat_groupings[i]
+        pulse_units += @metre.beat_divisions[i]
       end
       pulse_units += @current_pulse_unit
-      pulse_units
+      return pulse_units
     end
     
     def total_remaining_pulse_units
       @metre.total_pulse_units - total_elapsed_pulse_units
     end
     
+    # Calculate how many pulse units remain in the current bar
     def beat_remaining_pulse_units
-      @metre.beat_groupings[@current_beat] - @current_pulse_unit
+      @metre.beat_divisions[@current_beat] - @current_pulse_unit
     end
 
+    # Calculate a note's duration in pulse units from its metrical level and its duration at that level
     def note_to_pulse_units(level, duration)
       @metre.note_to_pulse_units(@current_beat, level, duration)
     end
     
+    # Determines whether a note with the given metrical level and duration will fit in the remainder of the bar
     def fit_note?(level, duration)
       total_remaining_pulse_units >= note_to_pulse_units(level, duration)
     end
     
+    # Tries to add a note to the bar
+    # Increments the current_beat and current_pulse_unit (within the current beat) accordingly
     def add_note(level, duration)
       raise "Cannot fit a note of this length into the bar" unless fit_note?(level, duration)
       pulse_units_to_add = note_to_pulse_units(level, duration)

--- a/app/server/ruby/lib/sonicpi/metre/bar.rb
+++ b/app/server/ruby/lib/sonicpi/metre/bar.rb
@@ -1,0 +1,60 @@
+module SonicPi
+  class Bar
+    
+    attr_reader :current_beat, :current_pulse_unit, :metre
+    
+    def initialize
+      @metre = __thread_locals.get(:sonic_pi_metre)
+      @current_beat = 0
+      @current_pulse_unit = 0
+
+      previous_bar_number = __thread_locals.get(:sonic_pi_bar_number)
+      if previous_bar_number
+        current_bar_number = @metre.request_bar(previous_bar_number + 1)
+      else
+        current_bar_number = 0
+      end
+      __thread_locals.set(:sonic_pi_bar_number, current_bar_number)
+    end
+    
+    def sp_thread_safe?
+      true
+    end
+    
+    def total_elapsed_pulse_units
+      pulse_units = 0
+      (0...@current_beat).each do |i|
+        pulse_units += @metre.beat_groupings[i]
+      end
+      pulse_units += @current_pulse_unit
+      pulse_units
+    end
+    
+    def total_remaining_pulse_units
+      @metre.total_pulse_units - total_elapsed_pulse_units
+    end
+    
+    def beat_remaining_pulse_units
+      @metre.beat_groupings[@current_beat] - @current_pulse_unit
+    end
+
+    def note_to_pulse_units(level, duration)
+      @metre.note_to_pulse_units(@current_beat, level, duration)
+    end
+    
+    def fit_note?(level, duration)
+      total_remaining_pulse_units >= note_to_pulse_units(level, duration)
+    end
+    
+    def add_note(level, duration)
+      raise "Cannot fit a note of this length into the bar" unless fit_note?(level, duration)
+      pulse_units_to_add = note_to_pulse_units(level, duration)
+      while pulse_units_to_add > 0 and pulse_units_to_add >= beat_remaining_pulse_units do
+        pulse_units_to_add -= beat_remaining_pulse_units
+        @current_beat += 1
+        @current_pulse_unit = 0
+      end
+      @current_pulse_unit += pulse_units_to_add
+    end
+  end
+end

--- a/app/server/ruby/lib/sonicpi/metre/distribution.rb
+++ b/app/server/ruby/lib/sonicpi/metre/distribution.rb
@@ -1,0 +1,22 @@
+module SonicPi
+  class NormalDistribution
+    def initialize(mean=0, stddev=1)
+      @mean = mean
+      @stddev = stddev
+      @cached_result = nil
+    end
+
+    def sample
+      if @cached_result
+        result = @cached_result
+        @cached_result = nil
+      else
+        theta = 2 * Math::PI * SonicPi::Core::SPRand.rand!(1)
+        scale = @stddev * Math.sqrt(-2 * Math.log(1 - SonicPi::Core::SPRand.rand!(1)))
+        @cached_result = @mean + scale * Math.sin(theta)
+        result = @mean + scale * Math.cos(theta)
+      end
+      result
+    end
+  end
+end

--- a/app/server/ruby/lib/sonicpi/metre/distribution.rb
+++ b/app/server/ruby/lib/sonicpi/metre/distribution.rb
@@ -1,11 +1,16 @@
 module SonicPi
+
+  # Class representing a Normal distribution
   class NormalDistribution
-    def initialize(mean=0, stddev=1)
+    def initialize(mean=0, stddev=0)
       @mean = mean
       @stddev = stddev
       @cached_result = nil
     end
 
+    # Draw a random sample from the distribution
+    # Uses the Box-Muller transform for generating pairs of independent, normally distributed random numbers
+    # Uniform random number generation performed by Sonic Pi's SPRand module
     def sample
       if @cached_result
         result = @cached_result

--- a/app/server/ruby/lib/sonicpi/metre/metre.rb
+++ b/app/server/ruby/lib/sonicpi/metre/metre.rb
@@ -1,7 +1,9 @@
 require_relative "bar"
-require_relative "distribution"
+require_relative "style"
 
 module SonicPi
+
+  # Class for describing a particular metre
   class Metre
     
     TIME_SIGNATURE_LOOKUP = {
@@ -13,41 +15,78 @@ module SonicPi
       '12/8' => [3,3,3,3]
     }.freeze
     
-    attr_reader :beat_groupings, :total_beats, :total_pulse_units
+    attr_reader :beat_divisions, :total_beats, :total_pulse_units
     
+    # Metre can be a list of integers representing the number of pulse units each beat is divided into, or a time signature string (e.g. '4/4')
     def initialize(metre)
       if is_list_like?(metre)
-        @beat_groupings = metre
+        @beat_divisions = metre
       else
-        @beat_groupings = TIME_SIGNATURE_LOOKUP[metre]
+        @beat_divisions = TIME_SIGNATURE_LOOKUP[metre]
       end
-      @total_beats = @beat_groupings.length
-      @total_pulse_units = @beat_groupings.sum
+      @total_beats = @beat_divisions.length
+      @total_pulse_units = @beat_divisions.sum
     end
 
+    # Calculates the duration of a note in pulse units
     def note_to_pulse_units(current_beat, level, duration)
       if level == 0
         # Lookup number of pulse units in current beat
-        @beat_groupings[current_beat]
+        @beat_divisions[current_beat] * duration
       else
         # Assume pulse units are further divisible by 2
         (2 ** (level + 1)) * duration
       end
     end
 
-    def to_beats(pulse_units)
-      pulse_units.to_f / beat_groupings[0]
+    # Get the index of the current note at each metrical level (up to the lowest specified in the style)
+    # current_beat is the integer index of the current beat
+    # total_elapsed_pulse_units is a float describing how many pulse units have elapsed since the start of the bar
+    def metrical_level_indices(current_beat, total_elapsed_pulse_units, lowest_metrical_level)
+      indices = []
+      indices[0] = current_beat
+    
+      level = -1
+      position = total_elapsed_pulse_units
+      indices[-level] = position.floor
+    
+      (2..-lowest_metrical_level).each do
+        level -= 1
+        position *= 2
+        indices[-level] = position.floor
+      end
+      return indices
+    end
+
+    # Calculates the number of Sonic Pi beats to sleep for for a note/rest of duration pulse_units
+    def sleep_time(pulse_units)
+      pulse_units.to_f / beat_divisions[0]
     end
   end
 
 
+  # Class for controlling the synchronisation of all notes contained by this metre
   class SynchronisedMetre < Metre
     attr_reader :style, :timings
     
+    # Metre can be a list of integers representing the number of pulse units each beat is divided into, or a time signature string (e.g. '4/4')
+    # Style can be the symbol of a style preset to be looked up (see Style class), or a Style object
+    # The chosen/given style must have the same beat divisions as the metre
     def initialize(metre, style=nil)
       super(metre)
-      @style = style
-      @timings = Array.new(@total_pulse_units, 0)
+
+      if style
+        if style.is_a?(Style)
+          @style = style
+        else
+          @style = Style.lookup(style)
+        end
+        raise "Style #{@style.name} requires beat divisions #{@style.beat_divisions} but metre has #{@beat_divisions}" unless @beat_divisions == @style.beat_divisions
+        @timings = {}
+        recalculate_timings
+      end
+
+      # Initialise current_bar_number with the thread's most recent one so bar numbers continue to increment if a different metre came before
       @current_bar_number = __thread_locals.get(:sonic_pi_bar_number)
       @current_bar_number = 0 unless @current_bar_number
       @mutex = Mutex.new
@@ -57,23 +96,36 @@ module SonicPi
       true
     end
 
-    def get_timing(pulse_unit)
-      @timings[pulse_unit]
+    # Calculates the timing shift (in pulse units) to be applied to a note occurring total_elapsed_pulse_units into the cycle
+    # Includes contributions of all metrical levels down to the lowest_level specified by the Style
+    def get_timing(current_beat, total_elapsed_pulse_units)
+      return 0 unless @style
+      lowest_level = @style.lowest_metrical_level
+      indices = metrical_level_indices(current_beat, total_elapsed_pulse_units, lowest_level)
+      timing_shift = 0
+      (lowest_level..0).each do |level|
+        timing_shift += @timings[level][indices[-level]] if @timings[level]
+      end
+      return timing_shift
     end
     
+    # Request the next bar in sequence
+    # If this is the first time this bar number has been requested, the currently active timings (sampled from the style's distributions) are updated
+    # Synchronised on a mutex to avoid race conditions so all bars will have the same random micro-timing
     def request_bar(requested_bar_number)
       @mutex.synchronize do
         if requested_bar_number > @current_bar_number
-          recalculate_timings
+          recalculate_timings if @style
           @current_bar_number = requested_bar_number
         end
       end
       return @current_bar_number
     end
     
+    # Samples values for timing offsets for each note at each metrical level from the style's distributions
     private
     def recalculate_timings
-      @timings[0] = @timings[0] + 1
+      @timings = @style.sample_distributions
     end
   end
 

--- a/app/server/ruby/lib/sonicpi/metre/metre.rb
+++ b/app/server/ruby/lib/sonicpi/metre/metre.rb
@@ -41,7 +41,6 @@ module SonicPi
     def sp_thread_safe?
       true
     end
-
   end
 
   # A tree structure representing a metrical hierarchy
@@ -80,7 +79,7 @@ module SonicPi
     # Returns a new MetreSequence with a flat representation of the hierarchy
     def flat
       new_sequence = []
-      for m in @sequence do
+      for m in @sequence
         if m.is_a?(MetreTerminal)
           new_sequence.append(m)
         else
@@ -163,8 +162,6 @@ module SonicPi
       return indices
     end
 
-
-
     private
 
     # Length of a MetreSequence is the number of elements in its list
@@ -191,7 +188,7 @@ module SonicPi
     # Returns a flat MetreSequence at a given metrical level
     def _get_level(level)
       new_sequence = []
-      for m in @sequence do
+      for m in @sequence
         if m.is_a?(MetreTerminal)
           if level > 0
             new_sequence += m.subdivide(level).sequence
@@ -224,7 +221,6 @@ module SonicPi
         end
       end
     end
-
   end
 
 
@@ -244,10 +240,16 @@ module SonicPi
 
     attr_reader :beat_duration
 
-    # Sequence can either be a time signature string (e.g. '4/4'), or a list of MetreSequences and MetreTerminals
+    # Sequence can either be a time signature string (e.g. '4/4'),
+    # a multi-dimensional list of Rationals representing the metrical hierarchy (e.g. [[1/8r,1/8r,1/8r], [1/8r,1/8r,1/8r]] is 6/8),
+    # or a MetreSequence or MetreTerminal object
     def initialize(sequence)
-      if is_list_like?(sequence)
-        super(sequence)
+      if sequence.is_a?(MetreSequence)
+        super(sequence.sequence)
+      elsif sequence.is_a?(MetreTerminal)
+        super([sequence])
+      elsif is_list_like?(sequence)
+        super(Metre.parse_rational_list(sequence).sequence)
       else
         super(TIME_SIGNATURE_LOOKUP[sequence])
       end
@@ -259,6 +261,18 @@ module SonicPi
     # For simple time, @beat_duration = 1
     def quarter_length_to_sonic_pi_beat(duration)
       return duration / @beat_duration
+    end
+
+    def self.parse_rational_list(list)
+      new_sequence = []
+      for element in list
+        if is_list_like?(element)
+          new_sequence.append(Metre.parse_rational_list(element))
+        else
+          new_sequence.append(MetreTerminal.new(element))
+        end
+      end
+      return MetreSequence.new(new_sequence)
     end
   end
 

--- a/app/server/ruby/lib/sonicpi/metre/metre.rb
+++ b/app/server/ruby/lib/sonicpi/metre/metre.rb
@@ -1,0 +1,80 @@
+require_relative "bar"
+require_relative "distribution"
+
+module SonicPi
+  class Metre
+    
+    TIME_SIGNATURE_LOOKUP = {
+      '2/4' => [2,2],
+      '3/4' => [2,2,2],
+      '4/4' => [2,2,2,2],
+      '6/8' => [3,3],
+      '9/8' => [3,3,3],
+      '12/8' => [3,3,3,3]
+    }.freeze
+    
+    attr_reader :beat_groupings, :total_beats, :total_pulse_units
+    
+    def initialize(metre)
+      if is_list_like?(metre)
+        @beat_groupings = metre
+      else
+        @beat_groupings = TIME_SIGNATURE_LOOKUP[metre]
+      end
+      @total_beats = @beat_groupings.length
+      @total_pulse_units = @beat_groupings.sum
+    end
+
+    def note_to_pulse_units(current_beat, level, duration)
+      if level == 0
+        # Lookup number of pulse units in current beat
+        @beat_groupings[current_beat]
+      else
+        # Assume pulse units are further divisible by 2
+        (2 ** (level + 1)) * duration
+      end
+    end
+
+    def to_beats(pulse_units)
+      pulse_units.to_f / beat_groupings[0]
+    end
+  end
+
+
+  class SynchronisedMetre < Metre
+    attr_reader :style, :timings
+    
+    def initialize(metre, style=nil)
+      super(metre)
+      @style = style
+      @timings = Array.new(@total_pulse_units, 0)
+      @current_bar_number = __thread_locals.get(:sonic_pi_bar_number)
+      @current_bar_number = 0 unless @current_bar_number
+      @mutex = Mutex.new
+    end
+
+    def sp_thread_safe?
+      true
+    end
+
+    def get_timing(pulse_unit)
+      @timings[pulse_unit]
+    end
+    
+    def request_bar(requested_bar_number)
+      @mutex.synchronize do
+        if requested_bar_number > @current_bar_number
+          recalculate_timings
+          @current_bar_number = requested_bar_number
+        end
+      end
+      return @current_bar_number
+    end
+    
+    private
+    def recalculate_timings
+      @timings[0] = @timings[0] + 1
+    end
+  end
+
+end

--- a/app/server/ruby/lib/sonicpi/metre/metre.rb
+++ b/app/server/ruby/lib/sonicpi/metre/metre.rb
@@ -3,64 +3,262 @@ require_relative "style"
 
 module SonicPi
 
-  # Class for describing a particular metre
-  class Metre
-    
-    TIME_SIGNATURE_LOOKUP = {
-      '2/4' => [2,2],
-      '3/4' => [2,2,2],
-      '4/4' => [2,2,2,2],
-      '6/8' => [3,3],
-      '9/8' => [3,3,3],
-      '12/8' => [3,3,3,3]
-    }.freeze
-    
-    attr_reader :beat_divisions, :total_beats, :total_pulse_units
-    
-    # Metre can be a list of integers representing the number of pulse units each beat is divided into, or a time signature string (e.g. '4/4')
-    def initialize(metre)
-      if is_list_like?(metre)
-        @beat_divisions = metre
-      else
-        @beat_divisions = TIME_SIGNATURE_LOOKUP[metre]
-      end
-      @total_beats = @beat_divisions.length
-      @total_pulse_units = @beat_divisions.sum
+  # The leaf of the metrical tree structure
+  class MetreTerminal
+
+    attr_reader :fraction, :quarter_length
+
+    # <fraction> is a Rational representing the duration of the object
+    def initialize(fraction)
+      @fraction = fraction
+      @quarter_length = 4 * @fraction.to_f
     end
 
-    # Calculates the duration of a note in pulse units
-    def note_to_pulse_units(current_beat, level, duration)
-      if level == 0
-        # Lookup number of pulse units in current beat
-        @beat_divisions[current_beat] * duration
-      else
-        # Assume pulse units are further divisible by 2
-        (2 ** (level + 1)) * duration
-      end
+    def depth
+      return 0
     end
 
-    # Get the index of the current note at each metrical level (up to the lowest specified in the style)
-    # current_beat is the integer index of the current beat
-    # total_elapsed_pulse_units is a float describing how many pulse units have elapsed since the start of the bar
-    def metrical_level_indices(current_beat, total_elapsed_pulse_units, lowest_metrical_level)
-      indices = []
-      indices[0] = current_beat
+    def to_s
+      return @fraction.to_s
+    end
+
+    def ==(other)
+      @fraction == other.fraction
+    end
+
+    # Divides the MetreTerminal by two <subdivisions> times
+    # Returns a MetreSequence with 2**subdivisions MetreTerminals
+    def subdivide(subdivisions)
+      new_sequence = []
+      count = 2 ** subdivisions
+      new_frac = @fraction / count
+      count.times do
+        new_sequence.append(MetreTerminal.new(new_frac))
+      end
+      return MetreSequence.new(new_sequence)
+    end
+
+    def sp_thread_safe?
+      true
+    end
+
+  end
+
+  # A tree structure representing a metrical hierarchy
+  class MetreSequence
     
-      level = -1
-      position = total_elapsed_pulse_units
-      indices[-level] = position.floor
+    attr_reader :sequence, :length, :depth
+
+    # Sequence is a tree of metrical levels represented as a list of MetreSequences or MetreTerminals
+    def initialize(sequence)
+      @sequence = sequence.freeze
+      @length = self._length
+      @depth = self._depth
+      @level_cache = {}
+      @offset_indices_cache = {}
+    end
+
+    # Calculates the total duration of the metre as a single fraction
+    # Uses a cached value if it exists to reduce expensive .flat computations
+    def fraction
+      @fraction_cache = self._fraction unless @fraction_cache
+      return @fraction_cache
+    end
+
+    # Calculates the total duration of the metre in quarter lengths
+    # Uses a cached value if it exists to reduce expensive .flat computations
+    def quarter_length
+      @quarter_length_cache = self._quarter_length unless @quarter_length_cache
+      return @quarter_length_cache
+    end
     
-      (2..-lowest_metrical_level).each do
-        level -= 1
-        position *= 2
-        indices[-level] = position.floor
+    # Returns a string representation of the metrical hierarchy
+    def to_s
+      return '{' + @sequence.join('+') + '}'
+    end
+  
+    # Returns a new MetreSequence with a flat representation of the hierarchy
+    def flat
+      new_sequence = []
+      for m in @sequence do
+        if m.is_a?(MetreTerminal)
+          new_sequence.append(m)
+        else
+          new_sequence += m.flat.sequence
+        end
+      end
+      return MetreSequence.new(new_sequence)
+    end
+
+    # Returns a flat MetreSequence at a given metrical level
+    # Uses a cached value if it exists to reduce expensive recomputations
+    def get_level(level)
+      @level_cache[level] = self._get_level(level) unless @level_cache[level]
+      return @level_cache[level]
+    end
+
+    # Performs a very basic partition on the sequence
+    # Returns a new MetreSequence with the same duration/fraction but split into <count> equally-sized MetreTerminals
+    # Can only perform uniform partitioning
+    def partition(count)
+      fraction = self.fraction
+      if count == 1
+        return MetreSequence.new([fraction])
+      end
+      new_denom = fraction.denominator * (count.to_f / fraction.numerator)
+      new_frac = Rational(1, new_denom)
+      if new_denom % 1 == 0
+        # Can partition into <count> elements
+        new_sequence = []
+        count.times do
+          new_sequence.append(MetreTerminal.new(new_frac))
+        end
+        return MetreSequence.new(new_sequence)
+      else
+        # Can't make partition
+        return nil
+      end
+    end
+    
+    # Equality for MetreSequences is defined by its @sequence list
+    def ==(other)
+      return @sequence == other.sequence
+    end
+
+    # Returns the index of the active element in @sequence at an <offset> given in quarter lengths
+    # Uses a cached value if it exists to reduce expensive recomputations
+    def offset_to_index(offset)
+      @offset_indices_cache[offset] = self._offset_to_index(offset) unless @offset_indices_cache[offset]
+      return @offset_indices_cache[offset]
+    end
+
+    # Returns the duration (in quarter lengths) of the active element in @sequence at a given <offset>
+    def offset_to_quarter_length(offset)
+      @sequence[self.offset_to_index(offset)].quarter_length
+    end
+
+    def sp_thread_safe?
+      true
+    end
+
+    # Returns a Hash of metrical levels to the index of any event at that position which lies exactly on <offset>
+    # Gets all metrical events at <offset> up to a depth of <deepest_level>
+    def metrical_level_indices(offset, deepest_level)
+      raise "Offset #{offset} out of bounds for duration #{self.quarter_length}" if offset >= self.quarter_length or offset < 0
+      indices = {}
+      # For each metrical level used in the style
+      (0..deepest_level).each do |level|
+        seq = self.get_level(level)
+        position = 0
+        # Search through sequence for a MetreTerminal at exactly <offset>
+        seq.length.times do |i|
+          if position == offset
+            indices[level] = i
+            break
+          else
+            position += seq.sequence[i].quarter_length
+          end
+        end
       end
       return indices
     end
 
-    # Calculates the number of Sonic Pi beats to sleep for for a note/rest of duration pulse_units
-    def sleep_time(pulse_units)
-      pulse_units.to_f / beat_divisions[0]
+
+
+    private
+
+    # Length of a MetreSequence is the number of elements in its list
+    def _length
+      return @sequence.length
+    end
+
+    # Depth of a MetreSequence is the number of metrical levels defined in its hierarchy
+    # Recursively calls .depth on each MetreSequence or MetreTerminal in the list
+    def _depth
+      return @sequence.map{ |m| m.depth}.max + 1
+    end
+
+    # Calculates the total duration of the metre as a single fraction
+    def _fraction
+      return self.flat.sequence.map{ |terminal| terminal.fraction }.sum
+    end
+
+    # Calculates the total duration of the metre in quarter lengths
+    def _quarter_length
+      return self.flat.sequence.map{ |terminal| terminal.quarter_length }.sum
+    end
+
+    # Returns a flat MetreSequence at a given metrical level
+    def _get_level(level)
+      new_sequence = []
+      for m in @sequence do
+        if m.is_a?(MetreTerminal)
+          if level > 0
+            new_sequence += m.subdivide(level).sequence
+          else
+            new_sequence.append(m)
+          end
+        else
+          if level > 0
+            # Continue recursing
+            new_sequence += m.get_level(level - 1).sequence
+          else
+            # Base of recursion, combine all children of m into one MetreTerminal
+            new_sequence.append(MetreTerminal.new(m.fraction))
+          end
+        end
+      end
+      return MetreSequence.new(new_sequence)
+    end
+
+    # Returns the index of the active element in @sequence at an <offset> given in quarter lengths
+    # Raises exception if the offset is outside the range of the MetreSequence
+    def _offset_to_index(offset)
+      raise "Offset #{offset} out of bounds for duration #{self.quarter_length}" if offset >= self.quarter_length or offset < 0
+      position = 0
+      @sequence.length.times do |i|
+        if position <= offset and offset < (position + @sequence[i].quarter_length)
+          return i
+        else
+          position += @sequence[i].quarter_length
+        end
+      end
+    end
+
+  end
+
+
+
+
+  # Class for describing a particular metre
+  class Metre < MetreSequence
+
+    TIME_SIGNATURE_LOOKUP = {
+      '4/4' => [MetreTerminal.new(1/4r)] * 2,
+      '3/4' => [MetreTerminal.new(1/4r)] * 3,
+      '4/4' => [MetreTerminal.new(1/4r)] * 4,
+      '6/8' => [MetreSequence.new([MetreTerminal.new(1/8r)] * 3)] * 2,
+      '9/8' => [MetreSequence.new([MetreTerminal.new(1/8r)] * 3)] * 3,
+      '12/8' => [MetreSequence.new([MetreTerminal.new(1/8r)] * 3)] * 4
+    }.freeze
+
+    attr_reader :beat_duration
+
+    # Sequence can either be a time signature string (e.g. '4/4'), or a list of MetreSequences and MetreTerminals
+    def initialize(sequence)
+      if is_list_like?(sequence)
+        super(sequence)
+      else
+        super(TIME_SIGNATURE_LOOKUP[sequence])
+      end
+      # Beat duration is set to the duration of the first beat of the metre. Used for tempo purposes
+      @beat_duration = self.get_level(0).sequence[0].quarter_length
+    end
+
+    # Converts a duration in quarter lengths to be in Sonic Pi beats
+    # For simple time, @beat_duration = 1
+    def quarter_length_to_sonic_pi_beat(duration)
+      return duration / @beat_duration
     end
   end
 
@@ -69,9 +267,9 @@ module SonicPi
   class SynchronisedMetre < Metre
     attr_reader :style, :timings
     
-    # Metre can be a list of integers representing the number of pulse units each beat is divided into, or a time signature string (e.g. '4/4')
-    # Style can be the symbol of a style preset to be looked up (see Style class), or a Style object
-    # The chosen/given style must have the same beat divisions as the metre
+    # Metre can either be a time signature string (e.g. '4/4'), or a list of MetreSequences and MetreTerminals
+    # Style can be the symbol of a style preset to be looked up (see Style.lookup()), or a Style object
+    # The chosen/given style must be compatible with the metre (see Style.compatible_with?())
     def initialize(metre, style=nil)
       super(metre)
 
@@ -81,30 +279,26 @@ module SonicPi
         else
           @style = Style.lookup(style)
         end
-        raise "Style #{@style.name} requires beat divisions #{@style.beat_divisions} but metre has #{@beat_divisions}" unless @beat_divisions == @style.beat_divisions
+        raise "Style #{@style.name} incompatible with metre #{self.to_s}" unless @style.compatible_with?(self)
         @timings = {}
         recalculate_timings
       end
 
-      # Initialise current_bar_number with the thread's most recent one so bar numbers continue to increment if a different metre came before
+      # Initialise <current_bar_number> with the thread's most recent one so bar numbers continue to increment if a different metre came before
       @current_bar_number = __thread_locals.get(:sonic_pi_bar_number)
       @current_bar_number = 0 unless @current_bar_number
       @mutex = Mutex.new
     end
 
-    def sp_thread_safe?
-      true
-    end
-
-    # Calculates the timing shift (in pulse units) to be applied to a note occurring total_elapsed_pulse_units into the cycle
-    # Includes contributions of all metrical levels down to the lowest_level specified by the Style
-    def get_timing(current_beat, total_elapsed_pulse_units)
+    # Calculates the timing shift (in quarter lengths) to be applied to a note occurring <current_offset> into the cycle
+    # Includes contributions of all metrical levels down to the <deepest_level> specified by the Style
+    def get_timing(current_offset)
       return 0 unless @style
-      lowest_level = @style.lowest_metrical_level
-      indices = metrical_level_indices(current_beat, total_elapsed_pulse_units, lowest_level)
+      deepest_level = @style.deepest_metrical_level
+      indices = self.metrical_level_indices(current_offset, deepest_level)
       timing_shift = 0
-      (lowest_level..0).each do |level|
-        timing_shift += @timings[level][indices[-level]] if @timings[level]
+      (0..deepest_level).each do |level|
+        timing_shift += @timings[level][indices[level]] if @timings[level] and indices[level]
       end
       return timing_shift
     end

--- a/app/server/ruby/lib/sonicpi/metre/metre.rb
+++ b/app/server/ruby/lib/sonicpi/metre/metre.rb
@@ -230,7 +230,7 @@ module SonicPi
   class Metre < MetreSequence
 
     TIME_SIGNATURE_LOOKUP = {
-      '4/4' => [MetreTerminal.new(1/4r)] * 2,
+      '2/4' => [MetreTerminal.new(1/4r)] * 2,
       '3/4' => [MetreTerminal.new(1/4r)] * 3,
       '4/4' => [MetreTerminal.new(1/4r)] * 4,
       '6/8' => [MetreSequence.new([MetreTerminal.new(1/8r)] * 3)] * 2,

--- a/app/server/ruby/lib/sonicpi/metre/style.rb
+++ b/app/server/ruby/lib/sonicpi/metre/style.rb
@@ -5,42 +5,21 @@ module SonicPi
 
     STYLE_LOOKUP = {
       triplet_swing: {
-        1 => [NormalDistribution.new, NormalDistribution.new(0.33333),
-          NormalDistribution.new, NormalDistribution.new(0.33333),
-          NormalDistribution.new, NormalDistribution.new(0.33333),
-          NormalDistribution.new, NormalDistribution.new(0.33333)]
+        1 => [NormalDistribution.new, NormalDistribution.new(0.166667),
+          NormalDistribution.new, NormalDistribution.new(0.166667),
+          NormalDistribution.new, NormalDistribution.new(0.166667),
+          NormalDistribution.new, NormalDistribution.new(0.166667)]
       },
 
       viennese_waltz: {
         0 => [NormalDistribution.new, NormalDistribution.new(-0.3057, 0.0051), NormalDistribution.new(-0.0391, 0.1054)]
       },
 
-      jembe_suku: {
-        1 => [NormalDistribution.new(0, 0.0295), NormalDistribution.new(-0.0665, 0.0442), NormalDistribution.new(-0.0095, 0.0365),
-          NormalDistribution.new(0.0072, 0.0340), NormalDistribution.new(-0.0554, 0.0430), NormalDistribution.new(0.0001, 0.0475),
-          NormalDistribution.new(0.0195, 0.0351), NormalDistribution.new(-0.0607, 0.0424), NormalDistribution.new(-0.0088, 0.0386),
-          NormalDistribution.new(-0.0003, 0.0354), NormalDistribution.new(-0.0830, 0.0381), NormalDistribution.new(-0.0084, 0.0397)]
-      },
-
-      jembe_manjanin: {
-        1 => [NormalDistribution.new(0, 0.0369), NormalDistribution.new(-0.0815, 0.0579), NormalDistribution.new(0.0057, 0.0416),
-          NormalDistribution.new(0.0056, 0.0413), NormalDistribution.new(-0.0791, 0.0448), NormalDistribution.new(0.0071, 0.0479),
-          NormalDistribution.new(0.0052, 0.0411), NormalDistribution.new(-0.0695, 0.0548), NormalDistribution.new(-0.0063, 0.0462),
-          NormalDistribution.new(0.0046, 0.0438), NormalDistribution.new(-0.1078, 0.0442), NormalDistribution.new(-0.0056, 0.0558)]
-      },
-
-      jembe_maraka: {
-        1 => [NormalDistribution.new(0, 0.0325), NormalDistribution.new(0.0740, 0.0425), NormalDistribution.new(0.0798, 0.0363),
-          NormalDistribution.new(0.0004, 0.0379), NormalDistribution.new(0.0900, 0.0439), NormalDistribution.new(0.0823, 0.0519),
-          NormalDistribution.new(-0.0134, 0.0384), NormalDistribution.new(0.0899, 0.0407), NormalDistribution.new(0.0731, 0.0386),
-          NormalDistribution.new(-0.0133, 0.0375), NormalDistribution.new(0.0779, 0.0393), NormalDistribution.new(0.0511, 0.0446)]
-      },
-
-      jembe_woloso: {
-        1 => [NormalDistribution.new(0, 0.0339), NormalDistribution.new(-0.1076, 0.0547), NormalDistribution.new(-0.0294, 0.0373),
-          NormalDistribution.new(0.0045, 0.0401), NormalDistribution.new(-0.0942, 0.0460), NormalDistribution.new(-0.0248, 0.0415),
-          NormalDistribution.new(0.0053, 0.0409), NormalDistribution.new(-0.0932, 0.0450), NormalDistribution.new(-0.0273, 0.0402),
-          NormalDistribution.new(0.0045, 0.0409), NormalDistribution.new(-0.1042, 0.0418), NormalDistribution.new(-0.0501, 0.0446)]
+      jembe: {
+        1 => [NormalDistribution.new(0, 0.0334), NormalDistribution.new(-0.1352, 0.0523), NormalDistribution.new(-0.1111, 0.0385),
+          NormalDistribution.new(0.0058, 0.0385), NormalDistribution.new(-0.1262, 0.0446), NormalDistribution.new(-0.1059, 0.0456),
+          NormalDistribution.new(0.0100, 0.0390), NormalDistribution.new(-0.1245, 0.0474), NormalDistribution.new(-0.1141, 0.0417),
+          NormalDistribution.new(0.0029, 0.0401), NormalDistribution.new(-0.1483, 0.0413), NormalDistribution.new(-0.1213, 0.0467)]
       }
     }
 

--- a/app/server/ruby/lib/sonicpi/metre/style.rb
+++ b/app/server/ruby/lib/sonicpi/metre/style.rb
@@ -23,7 +23,7 @@ module SonicPi
       }
     }
 
-    attr_reader :name, :deepest_metrical_level
+    attr_reader :name, :deepest_metrical_level, :highest_metrical_level
 
     # Distributions is a hash of metrical levels (e.g. 0, 1, etc.) to a list containing a distribution for each metrical location in that level
     # Any probability distribution can be used as long as its class has a sample() method
@@ -31,6 +31,7 @@ module SonicPi
       @name = name
       @distributions = distributions
       @deepest_metrical_level = @distributions.keys.max
+      @highest_metrical_level = @distributions.keys.min
     end
 
     # Generate samples from each distribution for each metrical level
@@ -46,7 +47,7 @@ module SonicPi
     # Tests to see if this style is compatible with a given metre object
     # Returns true if the style has the same number of distributions as the metre has events at each level
     def compatible_with?(metre)
-      (0..@deepest_metrical_level).each do |level|
+      (@highest_metrical_level..@deepest_metrical_level).each do |level|
         metre_at_level = metre.get_level(level)
         return false if @distributions[level] and @distributions[level].length != metre_at_level.length
       end

--- a/app/server/ruby/lib/sonicpi/metre/style.rb
+++ b/app/server/ruby/lib/sonicpi/metre/style.rb
@@ -1,0 +1,95 @@
+require_relative "distribution"
+
+module SonicPi
+  class Style
+
+    STYLE_LOOKUP = {
+      triplet_swing: {
+        :beat_divisions => [2,2,2,2],
+        :distributions => {
+          -1 => [NormalDistribution.new, NormalDistribution.new(0.33333),
+            NormalDistribution.new, NormalDistribution.new(0.33333),
+            NormalDistribution.new, NormalDistribution.new(0.33333),
+            NormalDistribution.new, NormalDistribution.new(0.33333)]
+        }
+      },
+
+      viennese_waltz: {
+        :beat_divisions => [2,2,2],
+        :distributions => {
+          0 => [NormalDistribution.new, NormalDistribution.new(-0.6114, 0.02036), NormalDistribution.new(-0.07811, 0.2109)]
+        }
+      },
+
+      jembe_suku: {
+        :beat_divisions => [3,3,3,3],
+        :distributions => {
+          -1 => [NormalDistribution.new(0, 0.0589), NormalDistribution.new(-0.2331, 0.0885), NormalDistribution.new(-0.2191, 0.0731),
+            NormalDistribution.new(0.0145, 0.0680), NormalDistribution.new(-0.2108, 0.0860), NormalDistribution.new(-0.1998, 0.0950),
+            NormalDistribution.new(0.0391, 0.0703), NormalDistribution.new(-0.2214, 0.0849), NormalDistribution.new(-0.2175, 0.0772),
+            NormalDistribution.new(-0.0005, 0.0709), NormalDistribution.new(-0.2659, 0.0761), NormalDistribution.new(-0.2168, 0.0794)]
+        }
+      },
+
+      jembe_manjanin: {
+        :beat_divisions => [3,3,3,3],
+        :distributions => {
+          -1 => [NormalDistribution.new(0, 0.0737), NormalDistribution.new(-0.2630, 0.1158), NormalDistribution.new(-0.1885, 0.0832),
+            NormalDistribution.new(0.0113, 0.0827), NormalDistribution.new(-0.2582, 0.0897), NormalDistribution.new(-0.1858, 0.09586),
+            NormalDistribution.new(0.0103, 0.0822), NormalDistribution.new(-0.2390, 0.1096), NormalDistribution.new(-0.2125, 0.0924),
+            NormalDistribution.new(0.0091, 0.0877), NormalDistribution.new(-0.3156, 0.0885), NormalDistribution.new(-0.2111, 0.1115)]
+        }
+      },
+
+      jembe_maraka: {
+        :beat_divisions => [3,3,3,3],
+        :distributions => {
+          -1 => [NormalDistribution.new(0, 0.0651), NormalDistribution.new(0.0481, 0.0850), NormalDistribution.new(-0.0404, 0.0726),
+            NormalDistribution.new(0.0009, 0.0758), NormalDistribution.new(0.0799, 0.0877), NormalDistribution.new(-0.0354, 0.1039),
+            NormalDistribution.new(-0.0268, 0.0768), NormalDistribution.new(0.0797, 0.0813), NormalDistribution.new(-0.0538, 0.0771),
+            NormalDistribution.new(-0.0266, 0.0751), NormalDistribution.new(0.0558, 0.0785), NormalDistribution.new(-0.0978, 0.0892)]
+        }
+      },
+
+      jembe_woloso: {
+        :beat_divisions => [3,3,3,3],
+        :distributions => {
+          -1 => [NormalDistribution.new(0, 0.0677), NormalDistribution.new(-0.3152, 0.1094), NormalDistribution.new(-0.2588, 0.0745),
+            NormalDistribution.new(0.0090, 0.0802), NormalDistribution.new(-0.2883, 0.0920), NormalDistribution.new(-0.2496, 0.0829),
+            NormalDistribution.new(0.0105, 0.0818), NormalDistribution.new(-0.2865, 0.0900), NormalDistribution.new(-0.2545, 0.0804),
+            NormalDistribution.new(0.0091, 0.0818), NormalDistribution.new(-0.3084, 0.0835), NormalDistribution.new(-0.3001, 0.0893)]
+        }
+      }
+    }
+
+    attr_reader :name, :beat_divisions, :lowest_metrical_level
+
+    # Beat divisions is a list of integers representing the number of pulse units each beat is divided into
+    # Distributions is a hash of metrical levels (e.g. 0, -1, etc.) to a list containing a distribution for each metrical location in that level
+    # Any probability distribution can be used as long as its class has a sample() method
+    def initialize(name, beat_divisions, distributions)
+      @name = name
+      @beat_divisions = beat_divisions
+      @distributions = distributions
+      @lowest_metrical_level = @distributions.keys.min
+    end
+
+    # Generate samples from each distribution for each metrical level
+    # Returns a hash of metrical levels to lists of samples
+    def sample_distributions
+      samples = {}
+      @distributions.each do |metrical_level, dist_array|
+        samples[metrical_level] = dist_array.map { |dist| dist.sample }
+      end
+      return samples
+    end
+
+    # Static method to lookup a style preset from its symbol
+    # Creates and returns the corresponding Style object
+    def self.lookup(style_name)
+      s = STYLE_LOOKUP[style_name]
+      raise "Unknown style #{style_name}" unless s
+      return Style.new(style_name, s[:beat_divisions], s[:distributions])
+    end
+  end
+end

--- a/app/server/ruby/lib/sonicpi/metre/style.rb
+++ b/app/server/ruby/lib/sonicpi/metre/style.rb
@@ -5,73 +5,53 @@ module SonicPi
 
     STYLE_LOOKUP = {
       triplet_swing: {
-        :beat_divisions => [2,2,2,2],
-        :distributions => {
-          -1 => [NormalDistribution.new, NormalDistribution.new(0.33333),
-            NormalDistribution.new, NormalDistribution.new(0.33333),
-            NormalDistribution.new, NormalDistribution.new(0.33333),
-            NormalDistribution.new, NormalDistribution.new(0.33333)]
-        }
+        1 => [NormalDistribution.new, NormalDistribution.new(0.33333),
+          NormalDistribution.new, NormalDistribution.new(0.33333),
+          NormalDistribution.new, NormalDistribution.new(0.33333),
+          NormalDistribution.new, NormalDistribution.new(0.33333)]
       },
 
       viennese_waltz: {
-        :beat_divisions => [2,2,2],
-        :distributions => {
-          0 => [NormalDistribution.new, NormalDistribution.new(-0.6114, 0.02036), NormalDistribution.new(-0.07811, 0.2109)]
-        }
+        0 => [NormalDistribution.new, NormalDistribution.new(-0.3057, 0.0051), NormalDistribution.new(-0.0391, 0.1054)]
       },
 
       jembe_suku: {
-        :beat_divisions => [3,3,3,3],
-        :distributions => {
-          -1 => [NormalDistribution.new(0, 0.0589), NormalDistribution.new(-0.2331, 0.0885), NormalDistribution.new(-0.2191, 0.0731),
-            NormalDistribution.new(0.0145, 0.0680), NormalDistribution.new(-0.2108, 0.0860), NormalDistribution.new(-0.1998, 0.0950),
-            NormalDistribution.new(0.0391, 0.0703), NormalDistribution.new(-0.2214, 0.0849), NormalDistribution.new(-0.2175, 0.0772),
-            NormalDistribution.new(-0.0005, 0.0709), NormalDistribution.new(-0.2659, 0.0761), NormalDistribution.new(-0.2168, 0.0794)]
-        }
+        1 => [NormalDistribution.new(0, 0.0295), NormalDistribution.new(-0.0665, 0.0442), NormalDistribution.new(-0.0095, 0.0365),
+          NormalDistribution.new(0.0072, 0.0340), NormalDistribution.new(-0.0554, 0.0430), NormalDistribution.new(0.0001, 0.0475),
+          NormalDistribution.new(0.0195, 0.0351), NormalDistribution.new(-0.0607, 0.0424), NormalDistribution.new(-0.0088, 0.0386),
+          NormalDistribution.new(-0.0003, 0.0354), NormalDistribution.new(-0.0830, 0.0381), NormalDistribution.new(-0.0084, 0.0397)]
       },
 
       jembe_manjanin: {
-        :beat_divisions => [3,3,3,3],
-        :distributions => {
-          -1 => [NormalDistribution.new(0, 0.0737), NormalDistribution.new(-0.2630, 0.1158), NormalDistribution.new(-0.1885, 0.0832),
-            NormalDistribution.new(0.0113, 0.0827), NormalDistribution.new(-0.2582, 0.0897), NormalDistribution.new(-0.1858, 0.09586),
-            NormalDistribution.new(0.0103, 0.0822), NormalDistribution.new(-0.2390, 0.1096), NormalDistribution.new(-0.2125, 0.0924),
-            NormalDistribution.new(0.0091, 0.0877), NormalDistribution.new(-0.3156, 0.0885), NormalDistribution.new(-0.2111, 0.1115)]
-        }
+        1 => [NormalDistribution.new(0, 0.0369), NormalDistribution.new(-0.0815, 0.0579), NormalDistribution.new(0.0057, 0.0416),
+          NormalDistribution.new(0.0056, 0.0413), NormalDistribution.new(-0.0791, 0.0448), NormalDistribution.new(0.0071, 0.0479),
+          NormalDistribution.new(0.0052, 0.0411), NormalDistribution.new(-0.0695, 0.0548), NormalDistribution.new(-0.0063, 0.0462),
+          NormalDistribution.new(0.0046, 0.0438), NormalDistribution.new(-0.1078, 0.0442), NormalDistribution.new(-0.0056, 0.0558)]
       },
 
       jembe_maraka: {
-        :beat_divisions => [3,3,3,3],
-        :distributions => {
-          -1 => [NormalDistribution.new(0, 0.0651), NormalDistribution.new(0.0481, 0.0850), NormalDistribution.new(-0.0404, 0.0726),
-            NormalDistribution.new(0.0009, 0.0758), NormalDistribution.new(0.0799, 0.0877), NormalDistribution.new(-0.0354, 0.1039),
-            NormalDistribution.new(-0.0268, 0.0768), NormalDistribution.new(0.0797, 0.0813), NormalDistribution.new(-0.0538, 0.0771),
-            NormalDistribution.new(-0.0266, 0.0751), NormalDistribution.new(0.0558, 0.0785), NormalDistribution.new(-0.0978, 0.0892)]
-        }
+        1 => [NormalDistribution.new(0, 0.0325), NormalDistribution.new(0.0740, 0.0425), NormalDistribution.new(0.0798, 0.0363),
+          NormalDistribution.new(0.0004, 0.0379), NormalDistribution.new(0.0900, 0.0439), NormalDistribution.new(0.0823, 0.0519),
+          NormalDistribution.new(-0.0134, 0.0384), NormalDistribution.new(0.0899, 0.0407), NormalDistribution.new(0.0731, 0.0386),
+          NormalDistribution.new(-0.0133, 0.0375), NormalDistribution.new(0.0779, 0.0393), NormalDistribution.new(0.0511, 0.0446)]
       },
 
       jembe_woloso: {
-        :beat_divisions => [3,3,3,3],
-        :distributions => {
-          -1 => [NormalDistribution.new(0, 0.0677), NormalDistribution.new(-0.3152, 0.1094), NormalDistribution.new(-0.2588, 0.0745),
-            NormalDistribution.new(0.0090, 0.0802), NormalDistribution.new(-0.2883, 0.0920), NormalDistribution.new(-0.2496, 0.0829),
-            NormalDistribution.new(0.0105, 0.0818), NormalDistribution.new(-0.2865, 0.0900), NormalDistribution.new(-0.2545, 0.0804),
-            NormalDistribution.new(0.0091, 0.0818), NormalDistribution.new(-0.3084, 0.0835), NormalDistribution.new(-0.3001, 0.0893)]
-        }
+        1 => [NormalDistribution.new(0, 0.0339), NormalDistribution.new(-0.1076, 0.0547), NormalDistribution.new(-0.0294, 0.0373),
+          NormalDistribution.new(0.0045, 0.0401), NormalDistribution.new(-0.0942, 0.0460), NormalDistribution.new(-0.0248, 0.0415),
+          NormalDistribution.new(0.0053, 0.0409), NormalDistribution.new(-0.0932, 0.0450), NormalDistribution.new(-0.0273, 0.0402),
+          NormalDistribution.new(0.0045, 0.0409), NormalDistribution.new(-0.1042, 0.0418), NormalDistribution.new(-0.0501, 0.0446)]
       }
     }
 
-    attr_reader :name, :beat_divisions, :lowest_metrical_level
+    attr_reader :name, :deepest_metrical_level
 
-    # Beat divisions is a list of integers representing the number of pulse units each beat is divided into
-    # Distributions is a hash of metrical levels (e.g. 0, -1, etc.) to a list containing a distribution for each metrical location in that level
+    # Distributions is a hash of metrical levels (e.g. 0, 1, etc.) to a list containing a distribution for each metrical location in that level
     # Any probability distribution can be used as long as its class has a sample() method
-    def initialize(name, beat_divisions, distributions)
+    def initialize(name, distributions)
       @name = name
-      @beat_divisions = beat_divisions
       @distributions = distributions
-      @lowest_metrical_level = @distributions.keys.min
+      @deepest_metrical_level = @distributions.keys.max
     end
 
     # Generate samples from each distribution for each metrical level
@@ -84,12 +64,22 @@ module SonicPi
       return samples
     end
 
+    # Tests to see if this style is compatible with a given metre object
+    # Returns true if the style has the same number of distributions as the metre has events at each level
+    def compatible_with?(metre)
+      (0..@deepest_metrical_level).each do |level|
+        metre_at_level = metre.get_level(level)
+        return false if @distributions[level] and @distributions[level].length != metre_at_level.length
+      end
+      return true
+    end
+
     # Static method to lookup a style preset from its symbol
     # Creates and returns the corresponding Style object
     def self.lookup(style_name)
       s = STYLE_LOOKUP[style_name]
       raise "Unknown style #{style_name}" unless s
-      return Style.new(style_name, s[:beat_divisions], s[:distributions])
+      return Style.new(style_name, s)
     end
   end
 end

--- a/app/server/ruby/test/test_metre.rb
+++ b/app/server/ruby/test/test_metre.rb
@@ -1,0 +1,101 @@
+require_relative "./setup_test"
+require_relative "../lib/sonicpi/util"
+include SonicPi::Util
+require_relative "../lib/sonicpi/metre/metre"
+
+module SonicPi
+  class MetreTester < Minitest::Test
+
+    def test_flat
+      four_four = Metre.new([[1/8r, 1/8r], [1/8r, 1/8r], [1/8r, 1/8r], [1/8r, 1/8r]])
+      ten_eight = Metre.new([[1/8r, 1/8r, 1/8r], [1/8r, 1/8r, 1/8r], [1/8r, 1/8r], [1/8r, 1/8r]])
+      eleven_eight = Metre.new([[1/8r, 1/8r], [1/8r, 1/8r], 1/8r, 3/4r])
+      assert_equal(four_four.flat.to_s, "{1/8+1/8+1/8+1/8+1/8+1/8+1/8+1/8}")
+      assert_equal(ten_eight.flat.to_s, "{1/8+1/8+1/8+1/8+1/8+1/8+1/8+1/8+1/8+1/8}")
+      assert_equal(eleven_eight.flat.to_s, "{1/8+1/8+1/8+1/8+1/8+3/4}")
+    end
+
+    def test_fraction
+      four_four = Metre.new([[1/8r, 1/8r], [1/8r, 1/8r], [1/8r, 1/8r], [1/8r, 1/8r]])
+      ten_eight = Metre.new([[1/8r, 1/8r, 1/8r], [1/8r, 1/8r, 1/8r], [1/8r, 1/8r], [1/8r, 1/8r]])
+      eleven_eight = Metre.new([[1/8r, 1/8r], [1/8r, 1/8r], 1/8r, 3/4r])
+      assert_equal(four_four.fraction, 1/1r)
+      assert_equal(ten_eight.fraction, 5/4r)
+      assert_equal(eleven_eight.fraction, 11/8r)
+    end
+
+    def test_quarter_length
+      four_four = Metre.new([[1/8r, 1/8r], [1/8r, 1/8r], [1/8r, 1/8r], [1/8r, 1/8r]])
+      ten_eight = Metre.new([[1/8r, 1/8r, 1/8r], [1/8r, 1/8r, 1/8r], [1/8r, 1/8r], [1/8r, 1/8r]])
+      eleven_eight = Metre.new([[1/8r, 1/8r], [1/8r, 1/8r], 1/8r, 3/4r])
+      assert_equal(four_four.quarter_length, 4.0)
+      assert_equal(ten_eight.quarter_length, 5.0)
+      assert_equal(eleven_eight.quarter_length, 5.5)
+    end
+
+    def test_depth
+      four_four = Metre.new([[1/8r, 1/8r], [1/8r, 1/8r], [1/8r, 1/8r], [1/8r, 1/8r]])
+      ten_eight = Metre.new([[1/8r, 1/8r, 1/8r], [1/8r, 1/8r, 1/8r], [1/8r, 1/8r], [1/8r, 1/8r]])
+      eleven_eight = Metre.new([[1/8r, 1/8r], [1/8r, 1/8r], 1/8r, 3/4r])
+      assert_equal(four_four.depth, 2)
+      assert_equal(ten_eight.depth, 2)
+      assert_equal(eleven_eight.depth, 2)
+    end
+
+    def test_get_level
+      four_four = Metre.new([[1/8r, 1/8r], [1/8r, 1/8r], [1/8r, 1/8r], [1/8r, 1/8r]])
+      ten_eight = Metre.new([[1/8r, 1/8r, 1/8r], [1/8r, 1/8r, 1/8r], [1/8r, 1/8r], [1/8r, 1/8r]])
+      eleven_eight = Metre.new([[1/8r, 1/8r], [1/8r, 1/8r], 1/8r, 3/4r])
+      assert_equal(four_four.get_level(0).to_s, "{1/4+1/4+1/4+1/4}")
+      assert_equal(ten_eight.get_level(0).to_s, "{3/8+3/8+1/4+1/4}")
+      assert_equal(eleven_eight.get_level(0).to_s, "{1/4+1/4+1/8+3/4}")
+
+      assert_equal(four_four.get_level(1).to_s, "{1/8+1/8+1/8+1/8+1/8+1/8+1/8+1/8}")
+      assert_equal(ten_eight.get_level(1).to_s, "{1/8+1/8+1/8+1/8+1/8+1/8+1/8+1/8+1/8+1/8}")
+      assert_equal(eleven_eight.get_level(1).to_s, "{1/8+1/8+1/8+1/8+1/16+1/16+3/8+3/8}")
+    end
+
+    def test_offset_to_index
+      four_four = Metre.new([[1/8r, 1/8r], [1/8r, 1/8r], [1/8r, 1/8r], [1/8r, 1/8r]])
+      ten_eight = Metre.new([[1/8r, 1/8r, 1/8r], [1/8r, 1/8r, 1/8r], [1/8r, 1/8r], [1/8r, 1/8r]])
+      eleven_eight = Metre.new([[1/8r, 1/8r], [1/8r, 1/8r], 1/8r, 3/4r])
+      assert_equal(four_four.offset_to_index(0), 0)
+      assert_equal(ten_eight.offset_to_index(0), 0)
+      assert_equal(eleven_eight.offset_to_index(0), 0)
+
+      assert_equal(four_four.offset_to_index(1), 1)
+      assert_equal(ten_eight.offset_to_index(1), 0)
+      assert_equal(eleven_eight.offset_to_index(1), 1)
+
+      assert_equal(four_four.offset_to_index(3.5), 3)
+      assert_equal(ten_eight.offset_to_index(3.5), 2)
+      assert_equal(eleven_eight.offset_to_index(3.5), 3)
+
+      assert_raises RuntimeError do
+        four_four.offset_to_index(4)
+      end
+      assert_raises RuntimeError do
+        four_four.offset_to_index(10)
+      end
+    end
+
+    def test_metrical_level_indices
+      four_four = Metre.new([[1/8r, 1/8r], [1/8r, 1/8r], [1/8r, 1/8r], [1/8r, 1/8r]])
+      ten_eight = Metre.new([[1/8r, 1/8r, 1/8r], [1/8r, 1/8r, 1/8r], [1/8r, 1/8r], [1/8r, 1/8r]])
+      eleven_eight = Metre.new([[1/8r, 1/8r], [1/8r, 1/8r], 1/8r, 3/4r])
+      assert_equal(four_four.metrical_level_indices(0, 2), {0=>0, 1=>0, 2=>0})
+      assert_equal(ten_eight.metrical_level_indices(0, 2), {0=>0, 1=>0, 2=>0})
+      assert_equal(eleven_eight.metrical_level_indices(0, 2), {0=>0, 1=>0, 2=>0})
+
+      assert_equal(four_four.metrical_level_indices(1, 2), {0=>1, 1=>2, 2=>4})
+      assert_equal(ten_eight.metrical_level_indices(1, 2), {1=>2, 2=>4})
+      assert_equal(eleven_eight.metrical_level_indices(1, 2), {0=>1, 1=>2, 2=>4})
+
+      assert_equal(four_four.metrical_level_indices(3.5, 2), {1=>7, 2=>14})
+      assert_equal(ten_eight.metrical_level_indices(3.5, 2), {1=>7, 2=>14})
+      assert_equal(eleven_eight.metrical_level_indices(3.5, 2), {})
+    end
+
+
+  end
+end

--- a/app/server/ruby/test/test_metre.rb
+++ b/app/server/ruby/test/test_metre.rb
@@ -53,6 +53,14 @@ module SonicPi
       assert_equal(four_four.get_level(1).to_s, "{1/8+1/8+1/8+1/8+1/8+1/8+1/8+1/8}")
       assert_equal(ten_eight.get_level(1).to_s, "{1/8+1/8+1/8+1/8+1/8+1/8+1/8+1/8+1/8+1/8}")
       assert_equal(eleven_eight.get_level(1).to_s, "{1/8+1/8+1/8+1/8+1/16+1/16+3/8+3/8}")
+
+      assert_equal(four_four.get_level(-1).to_s, "{1/2+1/2}")
+      assert_equal(ten_eight.get_level(-1).to_s, "{3/4+1/2}")
+      assert_equal(eleven_eight.get_level(-1).to_s, "{1/2+7/8}")
+
+      assert_equal(four_four.get_level(-2).to_s, "{1/1}")
+      assert_equal(ten_eight.get_level(-2).to_s, "{5/4}")
+      assert_equal(eleven_eight.get_level(-2).to_s, "{11/8}")
     end
 
     def test_offset_to_index
@@ -83,17 +91,17 @@ module SonicPi
       four_four = Metre.new([[1/8r, 1/8r], [1/8r, 1/8r], [1/8r, 1/8r], [1/8r, 1/8r]])
       ten_eight = Metre.new([[1/8r, 1/8r, 1/8r], [1/8r, 1/8r, 1/8r], [1/8r, 1/8r], [1/8r, 1/8r]])
       eleven_eight = Metre.new([[1/8r, 1/8r], [1/8r, 1/8r], 1/8r, 3/4r])
-      assert_equal(four_four.metrical_level_indices(0, 2), {0=>0, 1=>0, 2=>0})
-      assert_equal(ten_eight.metrical_level_indices(0, 2), {0=>0, 1=>0, 2=>0})
-      assert_equal(eleven_eight.metrical_level_indices(0, 2), {0=>0, 1=>0, 2=>0})
+      assert_equal(four_four.metrical_level_indices(0, 0, 2), {0=>0, 1=>0, 2=>0})
+      assert_equal(ten_eight.metrical_level_indices(0, 0, 2), {0=>0, 1=>0, 2=>0})
+      assert_equal(eleven_eight.metrical_level_indices(0, 0, 2), {0=>0, 1=>0, 2=>0})
 
-      assert_equal(four_four.metrical_level_indices(1, 2), {0=>1, 1=>2, 2=>4})
-      assert_equal(ten_eight.metrical_level_indices(1, 2), {1=>2, 2=>4})
-      assert_equal(eleven_eight.metrical_level_indices(1, 2), {0=>1, 1=>2, 2=>4})
+      assert_equal(four_four.metrical_level_indices(1, 0, 2), {0=>1, 1=>2, 2=>4})
+      assert_equal(ten_eight.metrical_level_indices(1, 0, 2), {1=>2, 2=>4})
+      assert_equal(eleven_eight.metrical_level_indices(1, 0, 2), {0=>1, 1=>2, 2=>4})
 
-      assert_equal(four_four.metrical_level_indices(3.5, 2), {1=>7, 2=>14})
-      assert_equal(ten_eight.metrical_level_indices(3.5, 2), {1=>7, 2=>14})
-      assert_equal(eleven_eight.metrical_level_indices(3.5, 2), {})
+      assert_equal(four_four.metrical_level_indices(3.5, 0, 2), {1=>7, 2=>14})
+      assert_equal(ten_eight.metrical_level_indices(3.5, 0, 2), {1=>7, 2=>14})
+      assert_equal(eleven_eight.metrical_level_indices(3.5, 0, 2), {})
     end
 
 


### PR DESCRIPTION
Hi!

As part of my undergraduate dissertation, I have written an implementation of musical metre for Sonic Pi. This would be an alternative way of playing music to using `play` and `sleep`. Metre has been designed to be very generalisable to allow almost any metrical hierarchy to be represented. An example of using this approach could be:
```ruby
use_metre '4/4'
bar do
  add_note :C4, 1, 1 # Plays the C4 note for one quaver/eighth note
  add_note :D4, 0, 3 # Plays the D4 note for three crotchets/quarter notes
  add_note :E4, 2, 1
  add_note :C4, 2, 1
end
```

Aside from metre being useful in its own right, this was necessary for the second part of my project, which was to add style-specific probabilistic micro-timing (like those found in swing rhythms or Viennese waltz music). We define a probability distribution for each metric event and use `time_warp` to adjust the timing of notes played on those events.

I'd be really grateful if someone could take a look and let me know if this is something that might be useful to have in Sonic Pi? I'm very open to any feedback/questions you might have about this.

Thanks! 🙂 