### PR TITLE
Fix handling of scsynth_opts from audio-settings.toml

### DIFF
--- a/app/server/ruby/bin/daemon.rb
+++ b/app/server/ruby/bin/daemon.rb
@@ -1129,7 +1129,7 @@ module SonicPi
         Util.log "Unified Audio Settings toml hash: #{opts.inspect}"
         opts = scsynth_inputs_hash.merge(opts)
         Util.log "Combined Audio Settings toml hash with GUI scsynth inputs hash: #{opts.inspect}"
-        opts = merge_opts(opts)
+        opts = merge_opts(toml_opts_hash, opts)
         Util.log "Merged Audio Settings toml hash: #{opts.inspect}"
         @num_inputs = opts["-i"].to_i
         @num_outputs = opts["-o"].to_i
@@ -1279,10 +1279,10 @@ module SonicPi
         opts
       end
 
-      def merge_opts(opts)
+      def merge_opts(toml_opts_hash, opts)
         # extract scsynth opts override
         begin
-          clobber_opts_a = Shellwords.split(opts.fetch(:scsynth_opts_override, ""))
+          clobber_opts_a = Shellwords.split(toml_opts_hash.fetch(:scsynth_opts_override, ""))
           scsynth_opts_override = clobber_opts_a.each_slice(2).to_h
         rescue
           scsynth_opts_override = {}
@@ -1290,7 +1290,7 @@ module SonicPi
 
         # extract scsynth opts
         begin
-          scsynth_opts_a = Shellwords.split(opts.fetch(:scsynth_opts, ""))
+          scsynth_opts_a = Shellwords.split(toml_opts_hash.fetch(:scsynth_opts, ""))
           scsynth_opts = scsynth_opts_a.each_slice(2).to_h
         rescue
           scsynth_opts = {}


### PR DESCRIPTION
Hi! I was trying to change the "max logins" scsynth option through the `scsynth_opts` from audio-settings.toml and after some attempts I noticed changing this option and `scsynth_opts_override` had no effect.

After some investigation I discovered it's caused by a bug in `daemon.rb`. Both `scsynth_opts` and `scynth_opts_override` were being discarded as `unify_toml_opts_hash` maps options to scsynth command args through `OPTS_TOML_KEY_CONVERSION`, which doesn't contain such keys.

The fix involves simply passing the original TOML options hash down to `merge_opts` so it can correctly extract the `scsynth_*` opts.