### PR TITLE
Build - update vcpkg versions and fix the VCPKG_ROOT variable that GHA now sets

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,12 +32,6 @@ jobs:
     # Get the code
     - uses: actions/checkout@v2
 
-    # hardcode cmake version
-    - name: Setup cmake
-      uses: jwlawson/actions-setup-cmake@v1.12
-      with:
-        cmake-version: '3.22.3'
-
     # Install Ruby for the windows build
     - uses: ruby/setup-ruby@v1
       id: ruby-inst

--- a/app/linux-pre-vcpkg.sh
+++ b/app/linux-pre-vcpkg.sh
@@ -30,8 +30,10 @@ cd "${SCRIPT_DIR}"
 # Build vcpkg
 if [ ! -d "vcpkg" ]; then
     echo "Cloning vcpkg"
-    git clone --depth 1 --branch "${VCPKG_BRANCH:-2022.06.16.1}" https://github.com/microsoft/vcpkg.git vcpkg
+    git clone --depth 1 --branch "${VCPKG_BRANCH:-2022.08.15}" https://github.com/microsoft/vcpkg.git vcpkg
 fi
+
+export VCPKG_ROOT="$SCRIPT_DIR/vcpkg"
 
 if [ ! -f "vcpkg/vcpkg" ]; then
     echo "Building vcpkg"

--- a/app/mac-pre-vcpkg.sh
+++ b/app/mac-pre-vcpkg.sh
@@ -30,8 +30,10 @@ cd "${SCRIPT_DIR}"
 # Build vcpkg
 if [ ! -d "vcpkg" ]; then
     echo "Cloning vcpkg"
-    git clone --depth 1 --branch 2022.06.16.1 https://github.com/microsoft/vcpkg.git vcpkg
+    git clone --depth 1 --branch 2022.08.15 https://github.com/microsoft/vcpkg.git vcpkg
 fi
+
+export VCPKG_ROOT="$SCRIPT_DIR/vcpkg"
 
 if [ ! -f "vcpkg/vcpkg" ]; then
     echo "Building vcpkg"

--- a/app/win-pre-vcpkg.bat
+++ b/app/win-pre-vcpkg.bat
@@ -8,6 +8,8 @@ if not exist "vcpkg\" (
     git clone --depth 1 --branch 2022.08.15 https://github.com/microsoft/vcpkg.git vcpkg
 )
 
+set VCPKG_ROOT=%~dp0/vcpkg
+
 if not exist "vcpkg\vcpkg.exe" (
     cd vcpkg
     echo Building vcpkg


### PR DESCRIPTION
We need to set the VCPKG_ROOT env variable now since the most recent GitHub Actions now set it to something that isn't our vcpkg checkout. This fixes the CI issues that started a few days ago

Ref: actions/runner-images#6192, actions/runner-images#6195, actions/runner-images#6196