### PR TITLE
Add missing config files folder to release build

### DIFF
--- a/app/mac-release.sh
+++ b/app/mac-release.sh
@@ -16,6 +16,7 @@ cd "macOS_Release/Sonic Pi.app/Contents/Resources"
 rm app etc server
 mkdir app
 cp -R ../../../../../../app/server app/server
+cp -R ../../../../../../app/config app/config
 cp -R ../../../../../../etc .
 ln -s app/server .
 


### PR DESCRIPTION
These files are needed for first time run to install files to user machine ~/.sonic-pi/config folder