### PR TITLE
GUI - add missing include for QThread

### DIFF
--- a/app/gui/qt/main.cpp
+++ b/app/gui/qt/main.cpp
@@ -19,6 +19,7 @@
 #include <QBitmap>
 #include <QLabel>
 #include <QLibraryInfo>
+#include <QThread>
 
 #include <singleapplication.h>
 #include "mainwindow.h"

--- a/app/gui/qt/mainwindow.cpp
+++ b/app/gui/qt/mainwindow.cpp
@@ -42,6 +42,7 @@
 #include <QStyle>
 #include <QTextBrowser>
 #include <QTextStream>
+#include <QThread>
 #include <QToolBar>
 #include <QToolButton>
 #include <QPushButton>

--- a/app/gui/qt/widgets/sonicpimetro.cpp
+++ b/app/gui/qt/widgets/sonicpimetro.cpp
@@ -17,6 +17,7 @@
 #include <QStyleOption>
 #include <QPainter>
 #include <QSpacerItem>
+#include <QThread>
 #include "dpi.h"
 
 SonicPiMetro::SonicPiMetro(std::shared_ptr<SonicPi::QtAPIClient> spClient, std::shared_ptr<SonicPi::SonicPiAPI> spAPI, SonicPiTheme *theme, QWidget* parent)


### PR DESCRIPTION
The code works by chance now in Qt 6 but there is no guarantee it will continue working without including the header. The relevant documentation pages ([Qt 6](https://doc.qt.io/qt-6/qthread.html), [Qt 5](https://doc.qt.io/qt-5/qthread.html)) indicate the `<QThread>` header is required and currently the code fails to compile in main.cpp on my system because the QThread type is not fully qualified