### PR TITLE
Build - set default cmake config type to Release

### DIFF
--- a/app/linux-config.sh
+++ b/app/linux-config.sh
@@ -4,7 +4,7 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 WORKING_DIR="$(pwd)"
 
 args=("$@")
-config=""
+config="Release"
 no_imgui=false
 system_libs=false
 

--- a/app/mac-config.sh
+++ b/app/mac-config.sh
@@ -4,7 +4,7 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 WORKING_DIR="$(pwd)"
 
 args=("$@")
-config=""
+config="Release"
 no_imgui=false
 
 # extract options and their arguments into variables.

--- a/app/pi-config.sh
+++ b/app/pi-config.sh
@@ -4,7 +4,7 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 WORKING_DIR="$(pwd)"
 
 args=("$@")
-config=""
+config="Release"
 no_imgui=false
 system_libs=false
 


### PR DESCRIPTION
Fixes an issue @rbnpi was having with the Linux builds now that `CMAKE_BUILD_TYPE` is passed through to the sp_midi and sp_link builds properly