### PR TITLE
Update OSC (broken, and redirected) links

### DIFF
--- a/app/api/include/api/osc/osc_pkt.hh
+++ b/app/api/include/api/osc/osc_pkt.hh
@@ -1,7 +1,7 @@
-/** @mainpage OSCPKT : a minimalistic OSC ( http://opensoundcontrol.org ) c++ library 
+/** @mainpage OSCPKT : a minimalistic OSC ( https://opensoundcontrol.stanford.edu/ ) c++ library 
 
   Before using this file please take the time to read the OSC spec, it
-  is short and not complicated: http://opensoundcontrol.org/spec-1_0
+  is short and not complicated: https://opensoundcontrol.stanford.edu/spec-1_0.html
 
   Features: 
     - handles basic OSC types: TFihfdsb

--- a/app/external/sp_midi/src/utils.cpp
+++ b/app/external/sp_midi/src/utils.cpp
@@ -41,7 +41,7 @@ void downcase(string& str)
 void safeOscString(string& str)
 {
   /*ASCII characters not allowed in names of OSC paths
-    See: http://opensoundcontrol.org/spec-1_0
+    See: https://opensoundcontrol.stanford.edu/spec-1_0.html
     ' ' space             32
     #   number sign       35
     *   asterisk          42

--- a/app/gui/html/public/bower_components/osc.js/README.md
+++ b/app/gui/html/public/bower_components/osc.js/README.md
@@ -1,7 +1,7 @@
 osc.js
 ======
 
-osc.js is a library for reading and writing [Open Sound Control](http://opensoundcontrol.org) messages in JavaScript. It works in both Node.js and in a web browser.
+osc.js is a library for reading and writing [Open Sound Control](https://opensoundcontrol.stanford.edu/) messages in JavaScript. It works in both Node.js and in a web browser.
 
 Why osc.js?
 -----------

--- a/app/server/ruby/lib/sonicpi/lang/core.rb
+++ b/app/server/ruby/lib/sonicpi/lang/core.rb
@@ -779,7 +779,7 @@ Finally, it is also very useful to send OSC messages to other programs on the sa
 
 See `osc_send` for a version which allows you to specify the hostname and port directly (ignoring any values set via `use_osc` or `with_osc`).
 
-For further information see the OSC spec: [http://opensoundcontrol.org/spec-1_0.html](http://opensoundcontrol.org/spec-1_0.html)
+For further information see the OSC spec: [https://opensoundcontrol.stanford.edu/spec-1_0.html](https://opensoundcontrol.stanford.edu/spec-1_0.html)
 ",
       examples: [
 " # Send a simple OSC message to another program on the same machine

--- a/app/server/ruby/lib/sonicpi/osc/oscdecode.rb
+++ b/app/server/ruby/lib/sonicpi/osc/oscdecode.rb
@@ -43,7 +43,7 @@ module SonicPi
       def decode_single_message(m)
         ## Note everything is inlined here for effienciency to remove the
         ## cost of method dispatch. Apologies if this makes it harder to
-        ## read & understand. See http://opensoundcontrol.org for spec.
+        ## read & understand. See https://opensoundcontrol.stanford.edu/ for spec.
 
         m.force_encoding(@binary_encoding)
 

--- a/app/server/ruby/lib/sonicpi/osc/oscencode.rb
+++ b/app/server/ruby/lib/sonicpi/osc/oscencode.rb
@@ -16,7 +16,7 @@ module SonicPi
     class OscEncode
       # Apologies for the density of this code - I've inlined a lot of the
       # code to reduce method dispatch overhead and to increase efficiency.
-      # See http://opensoundcontrol.org for spec.
+      # See https://opensoundcontrol.stanford.edu/ for spec.
 
       def initialize(use_cache = false, cache_size=1000)
         @literal_binary_str = "BINARY".freeze

--- a/etc/doc/tutorial/10.3-Pattern-Matching.md
+++ b/etc/doc/tutorial/10.3-Pattern-Matching.md
@@ -130,4 +130,4 @@ cue "/foo/beans/a/b/c/d/e/bark/quux/"
 
 For those curious, these matching rules are based on the Open Sound
 Control pattern matching specification which is explained in detail
-here: http://opensoundcontrol.org/spec-1_0
+here: https://opensoundcontrol.stanford.edu/spec-1_0.html


### PR DESCRIPTION
There are two changes:
1. To working links, now pointing to the `.stanford.edu` URL, instead of redirecting there
2. To broken links, that did not have the required `.html` ending, which caused 404s