### PR TITLE
Non-maps should be not equal to map

### DIFF
--- a/app/server/ruby/core.rb
+++ b/app/server/ruby/core.rb
@@ -408,7 +408,7 @@ module SonicPi
 
 
       def ==(other)
-        other.map == @map
+        other.respond_to?(:map) && other.map == @map
       end
 
       def >(other)

--- a/app/server/ruby/core.rb
+++ b/app/server/ruby/core.rb
@@ -408,7 +408,7 @@ module SonicPi
 
 
       def ==(other)
-        other.respond_to?(:map) && other.map == @map
+        other.class == self.class && other.map == @map
       end
 
       def >(other)


### PR DESCRIPTION
This aims to fix the issue reported [here](https://in-thread.sonic-pi.net/t/testing-a-supposed-map-for-being-nil-crashes-sp/7879), where comparing a map to nil results in a crash.