### PR TITLE
Remove temporary GCC workaround

### DIFF
--- a/app/linux-prebuild.sh
+++ b/app/linux-prebuild.sh
@@ -28,7 +28,6 @@ cd "${SCRIPT_DIR}"
 
 if [ ! "$system_libs" == true ]; then
   "${SCRIPT_DIR}"/linux-pre-vcpkg.sh "${args[@]}"
-	export CC=gcc-12 CXX=g++-12 # Use gcc-12 as the default compiler, since gcc-13 fails to build vcpkg
 	"${SCRIPT_DIR}"/linux-pre-vcpkg.sh "${args[@]}"
 fi
 


### PR DESCRIPTION
This reverts one workaround  which was added in #3305. The issue with #3292 does not occur anymore. Vcpkg now also builds with gcc13.

I have tested this on my laptop and desktop (arm64)