### PR TITLE
i18n: Fix system language detection for generic English & improve dialog box and detail text when using system language

### DIFF
--- a/app/gui/qt/utils/sonicpi_i18n.cpp
+++ b/app/gui/qt/utils/sonicpi_i18n.cpp
@@ -26,7 +26,6 @@ SonicPii18n::~SonicPii18n() {
 
 QString SonicPii18n::determineUILanguage(QString lang_pref) {
   QStringList available_languages = getAvailableLanguages();
-  //std::cout << available_languages.join("\n").toUtf8().constData() << std::endl;
   QLocale locale;
 
   if (lang_pref != "system_language") {
@@ -45,7 +44,7 @@ QString SonicPii18n::determineUILanguage(QString lang_pref) {
   } else {
     QStringList preferred_languages = locale.uiLanguages();
     // If the setting is set to system_language...
-      // ...run through the list of preferred languages
+    // ...run through the list of preferred languages
     std::cout << "[GUI] [i18n] - Looping through preferred ui languages" << std::endl;
 
     QString l;
@@ -53,9 +52,10 @@ QString SonicPii18n::determineUILanguage(QString lang_pref) {
       l = preferred_languages[i];
       l.replace("-", "_");
 
-      //std::cout << preferred_languages[i].toUtf8().constData() << std::endl;
       if (available_languages.contains(l)) {
-          return l;
+        return l;
+      } else if (l == "en" || l == "C") { // Catch generic English lang codes
+        return "en";
       }
     }
   }

--- a/app/gui/qt/widgets/settingswidget.cpp
+++ b/app/gui/qt/widgets/settingswidget.cpp
@@ -622,11 +622,7 @@ void SettingsWidget::updateUILanguage(int index) {
         QString old_lang = sonicPii18n->getNativeLanguageName(piSettings->language);
         QString new_lang = sonicPii18n->getNativeLanguageName(lang);
 
-        // Load new language
-        //QString language = sonicPii18n->determineUILanguage(lang);
-        //sonicPii18n->loadTranslations(language);
-        //QString title_new = tr("Updated the UI language from %s to %s").arg();
-
+        // Show confirmation box
         QMessageBox msgBox(this);
         msgBox.setText(QString(tr("You've selected a new language: %1")).arg(new_lang));
         QString info_text = (
@@ -636,7 +632,9 @@ void SettingsWidget::updateUILanguage(int index) {
         );
 
         if (lang == "system_language") {
-          info_text = tr("System languages found: %1").arg(sonicPii18n->getNativeLanguageNames(sonicPii18n->getSystemLanguages()).join(", ")) + "\n" + info_text;
+            // Determine the actual language to load
+            QString actual_lang = sonicPii18n->determineUILanguage(lang);
+            info_text = tr("System language found: %1").arg(sonicPii18n->getNativeLanguageName(actual_lang)) + "\n" + info_text;
         }
 
         msgBox.setInformativeText(info_text);

--- a/app/gui/qt/widgets/settingswidget.cpp
+++ b/app/gui/qt/widgets/settingswidget.cpp
@@ -918,10 +918,7 @@ void SettingsWidget::settingsChanged() {
       language_detail_text += "<b>Failed to load language translation. Using English (UK).</b>";
     }
     if (piSettings->language == "system_language") {
-      language_detail_text += (
-        tr("System languages: %1\n").arg(sonicPii18n->getNativeLanguageNames(sonicPii18n->getSystemLanguages()).join(", "))
-        + tr("Current UI language: %1\n").arg(sonicPii18n->getNativeLanguageName(sonicPii18n->currentlyLoadedLanguage()))
-      );
+      language_detail_text += tr("System language: %1\n").arg(sonicPii18n->getNativeLanguageName(sonicPii18n->currentlyLoadedLanguage()));
     }
     language_details_label->setText(language_detail_text);
 

--- a/app/server/ruby/bin/qt-doc.rb
+++ b/app/server/ruby/bin/qt-doc.rb
@@ -31,6 +31,7 @@ include SonicPi::Util
 
 # List of all languages with GUI translation files
 @lang_names = Hash[
+  "ar" => "اَلْعَرَبِيَّةُ", # Arabic
   "bg" => "български", # Bulgarian
   "bn" => "বাংলা", # Bengali/Bangla
   "bs" => "Bosanski", # Bosnian


### PR DESCRIPTION
This PR fixes a few issues when using the system language:
* Fix system language detection when the system language is generic English (i.e. has the lang code of "en") - should hopefully fix #3215 and fix #3290 
* Only show the language that will be loaded in the confirmation dialog when switching to the system language
* Only show the language that is currently loaded in the text below the language setting when using the system language
* Also, add native language name for Arabic