### PR TITLE
Added comment/uncomment line or selection shortcut config

### DIFF
--- a/app/gui/qt/mainwindow.cpp
+++ b/app/gui/qt/mainwindow.cpp
@@ -436,6 +436,9 @@ void MainWindow::setupWindowStructure()
     connect(settingsWidget, SIGNAL(enableScsynthInputsChanged()), this, SLOT(changeEnableScsynthInputs()));
     connect(settingsWidget, SIGNAL(midiSettingsChanged()), this, SLOT(toggleMidi()));
     connect(settingsWidget, SIGNAL(resetMidi()), this, SLOT(resetMidi()));
+
+    connect(settingsWidget, SIGNAL(shortcutsChanged()), this, SLOT(changeShortcuts()));
+
     connect(settingsWidget, SIGNAL(oscSettingsChanged()), this, SLOT(toggleOSCServer()));
     connect(settingsWidget, SIGNAL(showLineNumbersChanged()), this, SLOT(changeShowLineNumbers()));
     connect(settingsWidget, SIGNAL(showAutoCompletionChanged()), this, SLOT(changeShowAutoCompletion()));
@@ -618,7 +621,11 @@ void MainWindow::setupWindowStructure()
         connect(pasteToBufferEmacs, SIGNAL(activated()), workspace, SLOT(sp_paste()));
 
         //comment line
-        QShortcut* toggleLineComment = new QShortcut(metaKey('/'), workspace);
+        QString tlc = piSettings->commentUncomment_shrtc_key;
+        if(tlc == ""){
+            tlc == "/"; // default
+        }
+        QShortcut* toggleLineComment = new QShortcut(metaKey(tlc.toStdString()[0]), workspace);
         connect(toggleLineComment, SIGNAL(activated()), this, SLOT(toggleCommentInCurrentWorkspace()));
 
         //upcase next word
@@ -2036,6 +2043,11 @@ void MainWindow::changeScopeKindVisibility(QString name)
     }
 
     scopeWindow->EnableScope(name, piSettings->isScopeActive(name));
+}
+
+void MainWindow::changeShortcuts()
+{
+    emit writeSettings();
 }
 
 void MainWindow::scopeKindVisibilityMenuChanged()
@@ -3517,6 +3529,8 @@ void MainWindow::readSettings()
     piSettings->enable_external_synths = gui_settings->value("prefs/enable-external-synths", false).toBool();
     piSettings->synth_trigger_timing_guarantees = gui_settings->value("prefs/synth-trigger-timing-guarantees", false).toBool();
 
+    piSettings->commentUncomment_shrtc_key = gui_settings->value("prefs/commentShortcut", "").toString();
+
     piSettings->main_volume = gui_settings->value("prefs/system-vol", 80).toInt();
     piSettings->mixer_force_mono = gui_settings->value("prefs/mixer-force-mono", false).toBool();
     piSettings->mixer_invert_stereo = gui_settings->value("prefs/mixer-invert-stereo", false).toBool();
@@ -3564,6 +3578,8 @@ void MainWindow::writeSettings()
     gui_settings->setValue("prefs/midi-enable", piSettings->midi_enabled);
     gui_settings->setValue("prefs/osc-public", piSettings->osc_public);
     gui_settings->setValue("prefs/osc-enabled", piSettings->osc_server_enabled);
+
+    gui_settings->setValue("prefs/commentShortcut", piSettings->commentUncomment_shrtc_key);
 
     gui_settings->setValue("prefs/check-args", piSettings->check_args);
     gui_settings->setValue("prefs/log-synths", piSettings->log_synths);

--- a/app/gui/qt/mainwindow.h
+++ b/app/gui/qt/mainwindow.h
@@ -305,6 +305,8 @@ signals:
         void focusBPMScrubber();
         void focusTimeWarpScrubber();
 
+        void changeShortcuts();
+
 private:
         SonicPiScintilla* getCurrentWorkspace();
         SonicPiEditor* getCurrentEditor();

--- a/app/gui/qt/model/settings.h
+++ b/app/gui/qt/model/settings.h
@@ -44,6 +44,9 @@ public:
     bool show_context;
     SonicPiTheme::Style themeStyle;
 
+    // ShortcutsSettings TODO: add more configurable shortcuts
+    QString commentUncomment_shrtc_key;
+
     // UpdateSettings;
     bool check_updates;
 

--- a/app/gui/qt/widgets/settingswidget.h
+++ b/app/gui/qt/widgets/settingswidget.h
@@ -45,6 +45,7 @@ private slots:
     void toggleOscServer();
     void toggleMidi();
     void forceMidiReset();
+    void toggleShortcuts(QString c);
     void changeMainVolume(int);
     void toggleLineNumbers();
     void showAutoCompletion();
@@ -85,6 +86,7 @@ signals:
     void oscSettingsChanged();
     void midiSettingsChanged();
     void resetMidi();
+    void shortcutsChanged();
     void volumeChanged(int vol);
     void showLineNumbersChanged();
     void showAutoCompletionChanged();
@@ -179,6 +181,10 @@ private:
     QSlider *system_vol_slider;
     QSlider *gui_transparency_slider;
 
+    QLabel  *shortcuts_option_label;
+    QLabel  *commentUncommentKey_label;
+    QLineEdit *commentUncommentKey_select;
+
     QComboBox *language_combo;
     QLabel *language_option_label;
     QLabel *language_details_label;
@@ -188,6 +194,7 @@ private:
     QGroupBox* createAudioPrefsTab();
     QGroupBox* createIoPrefsTab();
     QGroupBox* createEditorPrefsTab();
+    QGroupBox* createShortcutsPrefsTab();
     QGroupBox* createVisualizationPrefsTab();
     QGroupBox* createUpdatePrefsTab();
     QGroupBox* createLanguagePrefsTab();


### PR DESCRIPTION
( select your preferred key ) to solve international keyboard problem with special characters ```\ { } [ ] < >``` shortcuts


![Screenshot from 2023-10-21 10-19-30](https://github.com/sonic-pi-net/sonic-pi/assets/141075/53754dfd-8fde-4780-b593-0b839113161e)

reference:  #1693 and #3162