### PR TITLE
Update util.rb for Pi5 and better model matching

### DIFF
--- a/app/server/ruby/bin/daemon.rb
+++ b/app/server/ruby/bin/daemon.rb
@@ -1228,10 +1228,24 @@ module SonicPi
           end
         end
       end
-
+            
       def run_post_start_commands
         case Util.os
-        when :linux, :raspberry
+        #modify case if you want linux as well as raspberry pi to use pipewire
+        when :raspberry #,:linux
+          Thread.new do
+            Kernel.sleep 5
+             hdmiL=`/usr/bin/pw-link -iI |grep -P '(hdmi).*(playback_FL)'|awk '{ print $1 }'`
+             hdmiR=`/usr/bin/pw-link -iI |grep -P '(hdmi).*(playback_FR)'|awk '{ print $1 }'`
+  
+             sco1=`/usr/bin/pw-link -oI |grep -P '(SuperCollider:out_1)' |awk '{ print $1 }'`
+             sco2=`/usr/bin/pw-link -oI |grep -P '(SuperCollider:out_2)' |awk '{ print $1 }'`
+  
+             system("pw-link  #{sco1.strip} #{hdmiL.strip}")
+             system("pw-link  #{sco2.strip} #{hdmiR.strip}")
+          end
+        #comment out this when section if you want linux to use pulseaudio as raspberry-pi above
+        when :linux
           Thread.new do
             Kernel.sleep 5
             # Note:

--- a/app/server/ruby/lib/sonicpi/util.rb
+++ b/app/server/ruby/lib/sonicpi/util.rb
@@ -37,21 +37,46 @@ module SonicPi
     @@current_uuid = nil
     @@home_dir = nil
     @@util_lock = Mutex.new
-    @@raspberry_pi_2 = RUBY_PLATFORM.match(/.*arm.*-linux.*/) && ['a01040','a01041','a22042'].include?(`awk '/^Revision/ { print $3}' /proc/cpuinfo`.delete!("\n"))
-    @@raspberry_pi_3 = RUBY_PLATFORM.match(/.*arm.*-linux.*/) && ['a02082','a22082','a32082'].include?(`awk '/^Revision/ { print $3}' /proc/cpuinfo`.delete!("\n"))
-    @@raspberry_pi_3bplus = RUBY_PLATFORM.match(/.*arm.*-linux.*/) && ['a020d3'].include?(`awk '/^Revision/ { print $3}' /proc/cpuinfo`.delete!("\n"))
-    @@raspberry_pi_3_64 = RUBY_PLATFORM.match(/aarch64.*-linux.*/) && ['a02082','a22082','a32082'].include?(`awk '/^Revision/ { print $3}' /proc/cpuinfo`.delete!("\n"))
-    @@raspberry_pi_3bplus_64 = RUBY_PLATFORM.match(/aarch64.*-linux.*/) && ['a020d3'].include?(`awk '/^Revision/ { print $3}' /proc/cpuinfo`.delete!("\n"))
-    @@raspberry_pi_4_1gb =  RUBY_PLATFORM.match(/.*arm.*-linux.*/) && ['a03111'].include?(`awk '/^Revision/ { print $3}' /proc/cpuinfo`.delete!("\n"))
-    @@raspberry_pi_4_2gb =  RUBY_PLATFORM.match(/.*arm.*-linux.*/) && ['b03111','b03112'].include?(`awk '/^Revision/ { print $3}' /proc/cpuinfo`.delete!("\n"))
-    @@raspberry_pi_4_4gb =  RUBY_PLATFORM.match(/.*arm.*-linux.*/) && ['c03111','c03112'].include?(`awk '/^Revision/ { print $3}' /proc/cpuinfo`.delete!("\n"))
-    @@raspberry_pi_4_8gb =  RUBY_PLATFORM.match(/.*arm.*-linux.*/) && ['d03114'].include?(`awk '/^Revision/ { print $3}' /proc/cpuinfo`.delete!("\n"))
-    @@raspberry_pi_4_1gb_64 =  RUBY_PLATFORM.match(/aarch64.*-linux.*/) && ['a03111'].include?(`awk '/^Revision/ { print $3}' /proc/cpuinfo`.delete!("\n"))
-    @@raspberry_pi_4_2gb_64 =  RUBY_PLATFORM.match(/aarch64.*-linux.*/) && ['b03111','b03112'].include?(`awk '/^Revision/ { print $3}' /proc/cpuinfo`.delete!("\n"))
-    @@raspberry_pi_4_4gb_64 =  RUBY_PLATFORM.match(/aarch64.*-linux.*/) && ['c03111','c03112'].include?(`awk '/^Revision/ { print $3}' /proc/cpuinfo`.delete!("\n"))
-    @@raspberry_pi_4_8gb_64 =  RUBY_PLATFORM.match(/aarch64.*linux.*/) && ['d03114'].include?(`awk '/^Revision/ { print $3}' /proc/cpuinfo`.delete!("\n"))
-    @@raspberry_pi_400 =  RUBY_PLATFORM.match(/.*arm.*-linux.*/) && ['c03130'].include?(`awk '/^Revision/ { print $3}' /proc/cpuinfo`.delete!("\n"))
-    @@raspberry_pi_400_64 =  RUBY_PLATFORM.match(/aarch64.*linux.*/) && ['c03130'].include?(`awk '/^Revision/ { print $3}' /proc/cpuinfo`.delete!("\n"))
+    @@revision=`cat /proc/cpuinfo |awk '/Revision/ {print $3}'`.strip
+    @@code = @@revision.to_i(base=16)
+    @@new = (@@code >> 23) &0x1 #must be one for valid new revision code
+    @@model = (@@code >> 4) & 0xff
+    @@mem = (@@code >> 20) & 0x7
+    
+    @@raspberry_pi_2 = RUBY_PLATFORM.match(/.*arm.*-linux.*/) && @@new==1 && @@model== 4 && @@mem == 2
+    @@raspberry_pi_3 = RUBY_PLATFORM.match(/.*arm.*-linux.*/) && @@new == 1 && @@model== 8 && @@mem == 2
+    @@raspberry_pi_3bplus = RUBY_PLATFORM.match(/.*arm.*-linux.*/) && @@new == 1 && @@model== 13 && @@mem == 2
+    @@raspberry_pi_4_1gb = RUBY_PLATFORM.match(/.*arm.*-linux.*/) && @@new == 1 && @@model== 17 && @@mem == 2
+    @@raspberry_pi_4_2gb = RUBY_PLATFORM.match(/.*arm.*-linux.*/) && @@new == 1 && @@model== 17 && @@mem == 3
+    @@raspberry_pi_4_4gb = RUBY_PLATFORM.match(/.*arm.*-linux.*/) && @@new == 1 && @@model== 17 && @@mem == 4
+    @@raspberry_pi_4_8gb = RUBY_PLATFORM.match(/.*arm.*-linux.*/) && @@new == 1 && @@model== 17 && @@mem == 5
+    @@raspberry_pi_400 = RUBY_PLATFORM.match(/.*arm.*-linux.*/) && @@new == 1 && @@model== 19 && @@mem == 4
+
+    @@raspberry_pi_3_64 = RUBY_PLATFORM.match(/aarch64.*-linux.*/) && @@new == 1 && @@model== 8 && @@mem == 2
+    @@raspberry_pi_3bplus_64 = RUBY_PLATFORM.match(/aarch64.*-linux.*/) && @@new == 1 && @@model== 13 && @@mem == 2
+    @@raspberry_pi_4_1gb_64 = RUBY_PLATFORM.match(/aarch64.*-linux.*/) && @@new == 1 && @@model== 17 && @@mem == 2
+    @@raspberry_pi_4_2gb_64 = RUBY_PLATFORM.match(/aarch64.*-linux.*/) && @@new == 1 && @@model== 17 && @@mem == 3
+    @@raspberry_pi_4_4gb_64 = RUBY_PLATFORM.match(/aarch64.*-linux.*/) && @@new == 1 && @@model== 17 && @@mem == 4
+    @@raspberry_pi_4_8gb_64 = RUBY_PLATFORM.match(/aarch64.*-linux.*/) && @@new == 1 && @@model== 17 && @@mem == 5
+    @@raspberry_pi_400_64 = RUBY_PLATFORM.match(/aarch64.*-linux.*/) && @@new == 1 && @@model== 19 && @@mem == 4
+    @@raspberry_pi_5_4gb_64 = RUBY_PLATFORM.match(/aarch64.*-linux.*/) && @@new == 1 && @@model== 23 && @@mem == 4
+    @@raspberry_pi_5_8gb_64 = RUBY_PLATFORM.match(/aarch64.*-linux.*/) && @@new == 1 && @@model== 23 && @@mem == 5
+
+#     @@raspberry_pi_2 = RUBY_PLATFORM.match(/.*arm.*-linux.*/) && ['a01040','a01041','a22042'].include?(`awk '/^Revision/ { print $3}' /proc/cpuinfo`.delete!("\n"))
+#     @@raspberry_pi_3 = RUBY_PLATFORM.match(/.*arm.*-linux.*/) && ['a02082','a22082','a32082'].include?(`awk '/^Revision/ { print $3}' /proc/cpuinfo`.delete!("\n"))
+#     @@raspberry_pi_3bplus = RUBY_PLATFORM.match(/.*arm.*-linux.*/) && ['a020d3'].include?(`awk '/^Revision/ { print $3}' /proc/cpuinfo`.delete!("\n"))
+#     @@raspberry_pi_3_64 = RUBY_PLATFORM.match(/aarch64.*-linux.*/) && ['a02082','a22082','a32082'].include?(`awk '/^Revision/ { print $3}' /proc/cpuinfo`.delete!("\n"))
+#     @@raspberry_pi_3bplus_64 = RUBY_PLATFORM.match(/aarch64.*-linux.*/) && ['a020d3'].include?(`awk '/^Revision/ { print $3}' /proc/cpuinfo`.delete!("\n"))
+#     @@raspberry_pi_4_1gb =  RUBY_PLATFORM.match(/.*arm.*-linux.*/) && ['a03111'].include?(`awk '/^Revision/ { print $3}' /proc/cpuinfo`.delete!("\n"))
+#     @@raspberry_pi_4_2gb =  RUBY_PLATFORM.match(/.*arm.*-linux.*/) && ['b03111','b03112'].include?(`awk '/^Revision/ { print $3}' /proc/cpuinfo`.delete!("\n"))
+#     @@raspberry_pi_4_4gb =  RUBY_PLATFORM.match(/.*arm.*-linux.*/) && ['c03111','c03112'].include?(`awk '/^Revision/ { print $3}' /proc/cpuinfo`.delete!("\n"))
+#     @@raspberry_pi_4_8gb =  RUBY_PLATFORM.match(/.*arm.*-linux.*/) && ['d03114'].include?(`awk '/^Revision/ { print $3}' /proc/cpuinfo`.delete!("\n"))
+#     @@raspberry_pi_4_1gb_64 =  RUBY_PLATFORM.match(/aarch64.*-linux.*/) && ['a03111'].include?(`awk '/^Revision/ { print $3}' /proc/cpuinfo`.delete!("\n"))
+#     @@raspberry_pi_4_2gb_64 =  RUBY_PLATFORM.match(/aarch64.*-linux.*/) && ['b03111','b03112'].include?(`awk '/^Revision/ { print $3}' /proc/cpuinfo`.delete!("\n"))
+#     @@raspberry_pi_4_4gb_64 =  RUBY_PLATFORM.match(/aarch64.*-linux.*/) && ['c03111','c03112'].include?(`awk '/^Revision/ { print $3}' /proc/cpuinfo`.delete!("\n"))
+#     @@raspberry_pi_4_8gb_64 =  RUBY_PLATFORM.match(/aarch64.*linux.*/) && ['d03114'].include?(`awk '/^Revision/ { print $3}' /proc/cpuinfo`.delete!("\n"))
+#     @@raspberry_pi_400 =  RUBY_PLATFORM.match(/.*arm.*-linux.*/) && ['c03130'].include?(`awk '/^Revision/ { print $3}' /proc/cpuinfo`.delete!("\n"))
+#     @@raspberry_pi_400_64 =  RUBY_PLATFORM.match(/aarch64.*linux.*/) && ['c03130'].include?(`awk '/^Revision/ { print $3}' /proc/cpuinfo`.delete!("\n"))
 
 
     begin
@@ -141,6 +166,14 @@ module SonicPi
       os == :raspberry && @@raspberry_pi_400_64
     end
 
+    def raspberry_pi_5_4gb_64?
+      os == :raspberry && @@raspberry_pi_5_4gb_64
+    end
+
+    def raspberry_pi_5_8gb_64?
+      os == :raspberry && @@raspberry_pi_5_8gb_64
+    end
+
     def unify_tilde_dir(path)
       if os == :windows
         path
@@ -201,6 +234,10 @@ module SonicPi
           "Raspberry Pi 400:4Gb"
         elsif raspberry_pi_400_64?
           "Raspberry Pi 400:4Gb 64bit OS"
+        elsif raspberry_pi_5_4gb_64?
+          "Raspberry Pi 5:4Gb 64bit OS"
+        elsif raspberry_pi_5_8gb_64?
+          "Raspberry Pi 5:8Gb 64bit OS"
         else
           "Raspberry Pi"
         end


### PR DESCRIPTION
instead of using whole revision code from procinfo extract only the bits to give model and memory. Also check if new format revision code. Doing all this allows for different board revisions or manufacturer of the same model to be accommodated. Also add new codes for Pi5