### PR TITLE
Server - rework how the Pi modname is generated/used

### DIFF
--- a/app/server/ruby/lib/sonicpi/util.rb
+++ b/app/server/ruby/lib/sonicpi/util.rb
@@ -63,7 +63,7 @@ module SonicPi
         return rp
       end
 
-      code = `awk '/^Revision/ { print $3}' /proc/cpuinfo`.delete!("\n")
+      code = `cat /proc/cpuinfo |awk '/Revision/ {print $3}'`.strip
       model = detect_pimodel.call(code)
 
       @@raspberry_pi_model = model

--- a/app/server/ruby/lib/sonicpi/util.rb
+++ b/app/server/ruby/lib/sonicpi/util.rb
@@ -151,52 +151,6 @@ module SonicPi
       end
     end
 
-
-def host_platform_desc
-      case os
-      when :raspberry
-        if raspberry_pi_2?
-          "Raspberry Pi 2B"
-        elsif raspberry_pi_3?
-          "Raspberry Pi 3B"
-        elsif raspberry_pi_3bplus?
-          "Raspberry Pi 3B+"
-        elsif raspberry_pi_3_64?
-          "Raspberry Pi 3B 64bit OS"
-        elsif raspberry_pi_3bplus_64?
-          "Raspberry Pi 3B+ 64bit OS"
-        elsif raspberry_pi_4_1gb?
-          "Raspberry Pi 4B:1Gb"
-        elsif raspberry_pi_4_2gb?
-          "Raspberry Pi 4B:2Gb"
-        elsif raspberry_pi_4_4gb?
-          "Raspberry Pi 4B:4Gb"
-        elsif raspberry_pi_4_8gb?
-          "Raspberry Pi 4B:8Gb"
-        elsif raspberry_pi_4_1gb_64?
-          "Raspberry Pi 4B:1Gb 64bit OS"
-        elsif raspberry_pi_4_2gb_64?
-          "Raspberry Pi 4B:2Gb 64bit OS"
-        elsif raspberry_pi_4_4gb_64?
-          "Raspberry Pi 4B:4Gb 64bit OS"
-        elsif raspberry_pi_4_8gb_64?
-          "Raspberry Pi 4B:8Gb 64bit OS"
-        elsif raspberry_pi_400?
-          "Raspberry Pi 400:4Gb"
-        elsif raspberry_pi_400_64?
-          "Raspberry Pi 400:4Gb 64bit OS"
-        else
-          "Raspberry Pi"
-        end
-      when :linux
-        "Linux"
-      when :osx
-        "Mac"
-      when :windows
-        "Win"
-      end
-    end
-
     def default_control_delta
       if raspberry_pi?
         0.013


### PR DESCRIPTION
The pi's modname is currently used for 2 things:

1. To determine the default sched ahead time (depending on whether it's pi 2, pi 3 or something later).
2. To generate the user-readable host name displayed in the bottom right of the GUI.

We now use a smarter way of determining the info for the Pi (code submitted by Robin Newman) rather than relying on an ever-growing list of codes. This is then used to generate the readable host name from which we can easily determine if it's a pi2, pi3 or something else.