### PR TITLE
Config - use pipewire by default on linux/Raspberry Pi

### DIFF
--- a/app/config/user-examples/audio-settings.toml
+++ b/app/config/user-examples/audio-settings.toml
@@ -121,6 +121,15 @@
 # num_random_seeds = 64
 
 
+## ===========
+## Linux Audio
+## ===========
+#
+# By default Sonic Pi uses pipewire for Audio on Linux
+# If you wish to fall back to pulse audio, "use_pipewire" to false.
+
+# linux_use_pipewire = true
+
 
 ## ============
 ## Escape hatch


### PR DESCRIPTION
add new audio-settings config "linux_use_pipewire" which if set to false will revert the audio back to pulse audio.