### PR TITLE
Update BUILD-WINDOWS.md

### DIFF
--- a/BUILD-WINDOWS.md
+++ b/BUILD-WINDOWS.md
@@ -64,7 +64,7 @@ Note that you need to enable the "Desktop development with C++" workload. See: h
 Install the latest version of Qt6 (note that Qt5 may work on Windows but isn't supported) - ensure
 you pick 64 bit options for msvc:
 
-https://download.qt.io/official_releases/qt/6.4/6.4.1/single/qt-everywhere-src-6.4.1.zip
+https://download.qt.io/archive/qt/6.4/6.4.1/single/qt-everywhere-src-6.4.1.zip
 
 When selecting Qt components you need: 
 


### PR DESCRIPTION
> qt installer link updated from broken to new archive url for qt 6.4.1

Trying to setup the build environment on windows 10, previously had issues with 6.4.2.
Updated source url for qt resources, in case it's important to have this specific version.