### PR TITLE
Note location of config directory

### DIFF
--- a/app/config/user-examples/README.md
+++ b/app/config/user-examples/README.md
@@ -3,6 +3,9 @@
 The files in this directory are configuration files for modifying the
 behaviour of Sonic Pi. Have fun and happy live coding!
 
+On your system, these files are located in:
+- Linux, macOS: `~/.sonic-pi/config` (note that `~` means your home directory)
+- Windows: `<tbd>`
 
 ## init.rb
 


### PR DESCRIPTION
Maybe this documentation exists elsewhere, but I wasn't sure where to actually find the config directory when I was looking to change something.

I don't know what this ends up being on Windows—would someone mind filling that in?