### PR TITLE
Spider - Only remove one level of comments when uncommenting

### DIFF
--- a/app/server/ruby/lib/sonicpi/runtime.rb
+++ b/app/server/ruby/lib/sonicpi/runtime.rb
@@ -796,9 +796,9 @@ module SonicPi
       if(lines.all?{|el| el.match(/^\s*#.*?/) || el.match(/^\s*$/)})
         # need to uncomment ##| style comments
         lines = lines.map do |l|
-          m = l.match(/^(\s*)#[#\| ]*(.*)/)
+          m = l.match(/^(\s*)(#(#\|)?\s?)(.*)/)
           if m
-            m[1] + m[2] + "\n"
+            m[1] + m[4] + "\n"
           else
             l
           end


### PR DESCRIPTION
Perhaps this is undesirable, but I for one find it frustrating when the uncomment shortcut removes nested comments. E.g. code like this:

```ruby
##| live_loop :dummy do
##|   # play the best note 
##|   play :c3
##| end
```

If I uncomment that presently, the nested `#` in line 2 is also removed. This change will only remove the outermost level of comments (`##|` or `#`).