### PR TITLE
Allow range to return ints if all args are ints

### DIFF
--- a/app/server/ruby/lib/sonicpi/lang/core.rb
+++ b/app/server/ruby/lib/sonicpi/lang/core.rb
@@ -1772,8 +1772,6 @@ end"
 
 
       def range(start, finish, *args)
-        start = start.to_f
-        finish = finish.to_f
         if is_list_like?(args) && args.size == 1 && args.first.is_a?(Numeric)
           # Allow one optional arg for legacy reasons. Versions earlier
           # than v2.5 allowed: range(1, 10, 2)
@@ -1781,9 +1779,15 @@ end"
           inclusive = false
         else
           args_h = resolve_synth_opts_hash_or_array(args)
-          step_size = args_h[:step] || 1.0
-          step_size = step_size.to_f
+          step_size = args_h[:step] || 1
           inclusive = args_h[:inclusive]
+        end
+
+        # If all args are ints, return ints
+        unless start.is_a? Integer and finish.is_a? Integer and step_size.is_a? Integer then
+          start = start.to_f
+          finish = finish.to_f
+          step_size = step_size.to_f
         end
 
         return [].ring if start == finish


### PR DESCRIPTION
This change makes the `range` function return integers if all arguments are integers.

I don't think this should break anything, since the values returned should be unchanged,
and I think integers should be accepted anywhere floats are expected.

This would allow things like the following to work:
```ruby
live_loop :foo do
  sample "drum", range(2, 6).tick
  sleep 0.5
end
```
Currently that fails with an error like: `Unknown sample filter type: Float - got: 2.0 (RuntimeError)`,
which can cause confusion (see e.g. https://in-thread.sonic-pi.net/t/force-integer-from-a-range/8625/1).