### PR TITLE
Use Ruby 3.3 for Windows CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -97,7 +97,7 @@ jobs:
       - uses: ruby/setup-ruby@v1
         id: ruby-inst
         with:
-          ruby-version: 3.2
+          ruby-version: 3.3
         if: matrix.os == 'windows-latest'
 
       # Install gems Windows


### PR DESCRIPTION
Ruby 3.2 has issues with non-English entries in Registry.

Relates to #3371 and probably other crash reports mentioning `Error reading ports via Boot Daemon STDOUT`.

UPD: Was going to simply check if the project even builds with 3.3, but [GHA says](https://github.com/sonic-pi-net/sonic-pi/actions/runs/8635342255) `This workflow is awaiting approval from a maintainer` 😞 