### PR TITLE
Map preserves vector/ring/ramp type

### DIFF
--- a/app/server/ruby/core.rb
+++ b/app/server/ruby/core.rb
@@ -691,7 +691,7 @@ module SonicPi
       end
 
       def map(&block)
-        @vec.map(&block)
+        self.class.new(@vec.map(&block))
       end
 
       def max(n=nil, &block)


### PR DESCRIPTION
Code like this:
```ruby
ring(1, 2, 3).map do |x|
  2 ** x
end
```
Requires another invocation of ring function to restore the type. Other methods like flat_map or filter don't have that problem so this PR copies how they are implemented.