### PR TITLE
API - drop unused dependency: crossguid

### DIFF
--- a/app/api/CMakeLists.txt
+++ b/app/api/CMakeLists.txt
@@ -87,22 +87,18 @@ endif()
 
 # Windows
 if ("${CMAKE_SYSTEM_NAME}" STREQUAL "Windows")
-find_package(crossguid CONFIG REQUIRED)
 target_link_libraries(${PROJECT_NAME}
     PRIVATE
-        crossguid
     )
 endif()
 
 # Linux
 if("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux")
-find_package(crossguid CONFIG REQUIRED)
 target_link_libraries(${PROJECT_NAME}
     PUBLIC
         stdc++fs
         rt
     PRIVATE
-        crossguid
     )
 endif()
 

--- a/app/api/src/sonicpi_api.cpp
+++ b/app/api/src/sonicpi_api.cpp
@@ -27,10 +27,6 @@
 #include <api/scope_exit.h>
 #include <api/sonicpi_api.h>
 
-#ifndef __APPLE__
-#include <crossguid/guid.hpp>
-#endif
-
 using namespace std::chrono;
 using namespace oscpkt;
 

--- a/app/linux-pre-vcpkg.sh
+++ b/app/linux-pre-vcpkg.sh
@@ -51,9 +51,9 @@ fi
 cd vcpkg
 
 if [ "$no_imgui" == true ]; then
-    ./vcpkg install libsndfile[core,external-libs] kissfft crossguid platform-folders reproc catch2 --recurse
+    ./vcpkg install libsndfile[core,external-libs] kissfft platform-folders reproc catch2 --recurse
 else
-    ./vcpkg install libsndfile[core,external-libs] kissfft fmt crossguid sdl2[x11] gl3w reproc gsl-lite concurrentqueue platform-folders catch2 --recurse
+    ./vcpkg install libsndfile[core,external-libs] kissfft fmt sdl2[x11] gl3w reproc gsl-lite concurrentqueue platform-folders catch2 --recurse
 fi
 
 

--- a/app/mac-pre-vcpkg.sh
+++ b/app/mac-pre-vcpkg.sh
@@ -63,7 +63,7 @@ fi
 
 
 if [ "$no_imgui" == true ]; then
-    ./vcpkg install libsndfile[core,external-libs] kissfft crossguid platform-folders reproc catch2 --triplet ${triplet[0]} --recurse
+    ./vcpkg install libsndfile[core,external-libs] kissfft platform-folders reproc catch2 --triplet ${triplet[0]} --recurse
 else
     ./vcpkg install libsndfile[core,external-libs] kissfft fmt sdl2 gl3w reproc gsl-lite concurrentqueue platform-folders catch2 --triplet ${triplet[0]} --recurse
 fi

--- a/app/win-pre-vcpkg.bat
+++ b/app/win-pre-vcpkg.bat
@@ -19,6 +19,6 @@ if not exist "vcpkg\vcpkg.exe" (
 
 cd vcpkg
 @echo Installing Libraries
-vcpkg install libsndfile[core,external-libs] kissfft fmt crossguid sdl2 gl3w reproc gsl-lite concurrentqueue platform-folders catch2 --triplet x64-windows-static-md --recurse
+vcpkg install libsndfile[core,external-libs] kissfft fmt sdl2 gl3w reproc gsl-lite concurrentqueue platform-folders catch2 --triplet x64-windows-static-md --recurse
 
 cd %WORKING_DIR%


### PR DESCRIPTION
Seems like the library was linked but never called since commit 8793eaba8785018debf2eea274e8f196a9527c87: Daemon - evolve kill token into a more general comms token