### PR TITLE
TwentyWorkspaces  

### DIFF
--- a/TwentyWorkSpaces.md
+++ b/TwentyWorkSpaces.md
@@ -2,12 +2,20 @@
 
 Modifications to increase number of Workspaces from 10 to 20
 
+## Why ?
+
+I love live coding in Sonic-Pi but when experimenting with new ideas or having lots of elements to my composition I end up running out of Workspaces and have to use multiple
+COMMENT / UNCOMMENT blocks in Workspaces to control whats happening. 
+
+I thought it would be nice to have more than the default 10 Workspaces so I've made a few mods to have 20 Workspaces. 
+
+
 ## Changed files :
 
-.\app\gui\qt\mainwindow.h
-.\app\gui\qt\mainwindow.cpp
-.\app\api\src\sonicpi_api.cpp
-.\app\api\src\string_utils.cpp
+.\app\gui\qt\mainwindow.h  
+.\app\gui\qt\mainwindow.cpp  
+.\app\api\src\sonicpi_api.cpp  
+.\app\api\src\string_utils.cpp  
 
 ## Result
 
@@ -17,31 +25,37 @@ next/previous keyboard shortcuts  S-M-[ / S-M-]  work
 
 Each Workspace is saved to \~\\.sonic-pi\store\default\ and reloaded at startup
 
- \~\\.sonic-pi\store\default\workspace_4teen.spi 
- \~\\.sonic-pi\store\default\workspace_6teen.spi 
- \~\\.sonic-pi\store\default\workspace_7teen.spi 
- \~\\.sonic-pi\store\default\workspace_8teen.spi 
- \~\\.sonic-pi\store\default\workspace_9teen.spi 
- \~\\.sonic-pi\store\default\workspace_eight.spi 
- \~\\.sonic-pi\store\default\workspace_eleven.spi 
- \~\\.sonic-pi\store\default\workspace_fifteen.spi 
- \~\\.sonic-pi\store\default\workspace_five.spi 
- \~\\.sonic-pi\store\default\workspace_four.spi 
- \~\\.sonic-pi\store\default\workspace_nine.spi 
+ \~\\.sonic-pi\store\default\workspace_zero.spi   
  \~\\.sonic-pi\store\default\workspace_one.spi 
- \~\\.sonic-pi\store\default\workspace_seven.spi 
- \~\\.sonic-pi\store\default\workspace_six.spi 
- \~\\.sonic-pi\store\default\workspace_ten.spi 
- \~\\.sonic-pi\store\default\workspace_thirteen.spi 
- \~\\.sonic-pi\store\default\workspace_three.spi 
- \~\\.sonic-pi\store\default\workspace_twelve.spi 
- \~\\.sonic-pi\store\default\workspace_two.spi 
- \~\\.sonic-pi\store\default\workspace_zero.spi 
+ \~\\.sonic-pi\store\default\workspace_two.spi   
+ \~\\.sonic-pi\store\default\workspace_three.spi   
+ \~\\.sonic-pi\store\default\workspace_four.spi  
+ \~\\.sonic-pi\store\default\workspace_five.spi  
+ \~\\.sonic-pi\store\default\workspace_six.spi   
+ \~\\.sonic-pi\store\default\workspace_seven.spi  
+ \~\\.sonic-pi\store\default\workspace_eight.spi  
+ \~\\.sonic-pi\store\default\workspace_nine.spi  
+ \~\\.sonic-pi\store\default\workspace_ten.spi  
+ \~\\.sonic-pi\store\default\workspace_eleven.spi  
+ \~\\.sonic-pi\store\default\workspace_twelve.spi   
+ \~\\.sonic-pi\store\default\workspace_thirteen.spi   
+ \~\\.sonic-pi\store\default\workspace_4teen.spi  
+ \~\\.sonic-pi\store\default\workspace_fifteen.spi  
+ \~\\.sonic-pi\store\default\workspace_6teen.spi  
+ \~\\.sonic-pi\store\default\workspace_7teen.spi  
+ \~\\.sonic-pi\store\default\workspace_8teen.spi  
+ \~\\.sonic-pi\store\default\workspace_9teen.spi  
 
 * Note the names had to be chosen to avoid incorrect number/name matching
 * i.e. workspace 14 as fourteen, workspace 4 would match four and fourteen
 
 ## Future improvements : 
 
-1. change Workspace number/name conversion to work for any number creating a unique name match.
-2. make the number of Workspaces configurable in Preferences
+The way the number of Workspaces and their naming is implemented isn't ideal and could be improved by having the maximum number defined in one place in a single header file.  
+
+The functions/methods to generate the Workspace file name from the Workspace number and from name to number could be done in one place in one source file and be able to uniquely name the file for any sensible number.    
+
+### ToDo:
+  
+1. change Workspace number/name conversion to work for any number creating a unique name match.  
+2. make the number of Workspaces configurable in Preferences  

--- a/TwentyWorkSpaces.md
+++ b/TwentyWorkSpaces.md
@@ -1,0 +1,47 @@
+# TwentyWorkspaces 
+
+Modifications to increase number of Workspaces from 10 to 20
+
+## Changed files :
+
+.\app\gui\qt\mainwindow.h
+.\app\gui\qt\mainwindow.cpp
+.\app\api\src\sonicpi_api.cpp
+.\app\api\src\string_utils.cpp
+
+## Result
+
+20 Workspace tabs instead of 10
+
+next/previous keyboard shortcuts "S-M-[/S-M-]" work  
+
+Each Workspace is saved to "~\.sonic-pi\store\default\" and reloaded at startup
+
+"~\.sonic-pi\store\default\workspace_4teen.spi"
+"~\.sonic-pi\store\default\workspace_6teen.spi"
+"~\.sonic-pi\store\default\workspace_7teen.spi"
+"~\.sonic-pi\store\default\workspace_8teen.spi"
+"~\.sonic-pi\store\default\workspace_9teen.spi"
+"~\.sonic-pi\store\default\workspace_eight.spi"
+"~\.sonic-pi\store\default\workspace_eleven.spi"
+"~\.sonic-pi\store\default\workspace_fifteen.spi"
+"~\.sonic-pi\store\default\workspace_five.spi"
+"~\.sonic-pi\store\default\workspace_four.spi"
+"~\.sonic-pi\store\default\workspace_nine.spi"
+"~\.sonic-pi\store\default\workspace_one.spi"
+"~\.sonic-pi\store\default\workspace_seven.spi"
+"~\.sonic-pi\store\default\workspace_six.spi"
+"~\.sonic-pi\store\default\workspace_ten.spi"
+"~\.sonic-pi\store\default\workspace_thirteen.spi"
+"~\.sonic-pi\store\default\workspace_three.spi"
+"~\.sonic-pi\store\default\workspace_twelve.spi"
+"~\.sonic-pi\store\default\workspace_two.spi"
+"~\.sonic-pi\store\default\workspace_zero.spi"
+
+* Note the names had to be chosen to avoid incorrect number/name matching
+* i.e. workspace 14 as fourteen, workspace 4 would match four and fourteen
+
+## Future improvements : 
+
+1. change Workspace number/name conversion to work for any number creating a unique name match.
+2. make the number of Workspaces configurable in Preferences

--- a/TwentyWorkSpaces.md
+++ b/TwentyWorkSpaces.md
@@ -13,30 +13,30 @@ Modifications to increase number of Workspaces from 10 to 20
 
 20 Workspace tabs instead of 10
 
-next/previous keyboard shortcuts "S-M-[ / S-M-]" work  
+next/previous keyboard shortcuts  S-M-[ / S-M-]  work  
 
-Each Workspace is saved to "\~\\.sonic-pi\store\default\" and reloaded at startup
+Each Workspace is saved to \~\\.sonic-pi\store\default\ and reloaded at startup
 
-"\~\\.sonic-pi\store\default\workspace_4teen.spi"
-"\~\\.sonic-pi\store\default\workspace_6teen.spi"
-"\~\\.sonic-pi\store\default\workspace_7teen.spi"
-"~\.sonic-pi\store\default\workspace_8teen.spi"
-"~\.sonic-pi\store\default\workspace_9teen.spi"
-"~\.sonic-pi\store\default\workspace_eight.spi"
-"~\.sonic-pi\store\default\workspace_eleven.spi"
-"~\.sonic-pi\store\default\workspace_fifteen.spi"
-"~\.sonic-pi\store\default\workspace_five.spi"
-"~\.sonic-pi\store\default\workspace_four.spi"
-"~\.sonic-pi\store\default\workspace_nine.spi"
-"~\.sonic-pi\store\default\workspace_one.spi"
-"~\.sonic-pi\store\default\workspace_seven.spi"
-"~\.sonic-pi\store\default\workspace_six.spi"
-"~\.sonic-pi\store\default\workspace_ten.spi"
-"~\.sonic-pi\store\default\workspace_thirteen.spi"
-"~\.sonic-pi\store\default\workspace_three.spi"
-"~\.sonic-pi\store\default\workspace_twelve.spi"
-"~\.sonic-pi\store\default\workspace_two.spi"
-"~\.sonic-pi\store\default\workspace_zero.spi"
+ \~\\.sonic-pi\store\default\workspace_4teen.spi 
+ \~\\.sonic-pi\store\default\workspace_6teen.spi 
+ \~\\.sonic-pi\store\default\workspace_7teen.spi 
+ \~\\.sonic-pi\store\default\workspace_8teen.spi 
+ \~\\.sonic-pi\store\default\workspace_9teen.spi 
+ \~\\.sonic-pi\store\default\workspace_eight.spi 
+ \~\\.sonic-pi\store\default\workspace_eleven.spi 
+ \~\\.sonic-pi\store\default\workspace_fifteen.spi 
+ \~\\.sonic-pi\store\default\workspace_five.spi 
+ \~\\.sonic-pi\store\default\workspace_four.spi 
+ \~\\.sonic-pi\store\default\workspace_nine.spi 
+ \~\\.sonic-pi\store\default\workspace_one.spi 
+ \~\\.sonic-pi\store\default\workspace_seven.spi 
+ \~\\.sonic-pi\store\default\workspace_six.spi 
+ \~\\.sonic-pi\store\default\workspace_ten.spi 
+ \~\\.sonic-pi\store\default\workspace_thirteen.spi 
+ \~\\.sonic-pi\store\default\workspace_three.spi 
+ \~\\.sonic-pi\store\default\workspace_twelve.spi 
+ \~\\.sonic-pi\store\default\workspace_two.spi 
+ \~\\.sonic-pi\store\default\workspace_zero.spi 
 
 * Note the names had to be chosen to avoid incorrect number/name matching
 * i.e. workspace 14 as fourteen, workspace 4 would match four and fourteen

--- a/TwentyWorkSpaces.md
+++ b/TwentyWorkSpaces.md
@@ -13,13 +13,13 @@ Modifications to increase number of Workspaces from 10 to 20
 
 20 Workspace tabs instead of 10
 
-next/previous keyboard shortcuts "S-M-[/S-M-]" work  
+next/previous keyboard shortcuts "S-M-[ / S-M-]" work  
 
-Each Workspace is saved to "~\.sonic-pi\store\default\" and reloaded at startup
+Each Workspace is saved to "\~\\.sonic-pi\store\default\" and reloaded at startup
 
-"~\.sonic-pi\store\default\workspace_4teen.spi"
-"~\.sonic-pi\store\default\workspace_6teen.spi"
-"~\.sonic-pi\store\default\workspace_7teen.spi"
+"\~\\.sonic-pi\store\default\workspace_4teen.spi"
+"\~\\.sonic-pi\store\default\workspace_6teen.spi"
+"\~\\.sonic-pi\store\default\workspace_7teen.spi"
 "~\.sonic-pi\store\default\workspace_8teen.spi"
 "~\.sonic-pi\store\default\workspace_9teen.spi"
 "~\.sonic-pi\store\default\workspace_eight.spi"

--- a/TwentyWorkSpaces.md
+++ b/TwentyWorkSpaces.md
@@ -26,7 +26,7 @@ next/previous keyboard shortcuts  S-M-[ / S-M-]  work
 Each Workspace is saved to \~\\.sonic-pi\store\default\ and reloaded at startup
 
  \~\\.sonic-pi\store\default\workspace_zero.spi   
- \~\\.sonic-pi\store\default\workspace_one.spi 
+ \~\\.sonic-pi\store\default\workspace_one.spi   
  \~\\.sonic-pi\store\default\workspace_two.spi   
  \~\\.sonic-pi\store\default\workspace_three.spi   
  \~\\.sonic-pi\store\default\workspace_four.spi  

--- a/app/api/src/sonicpi_api.cpp
+++ b/app/api/src/sonicpi_api.cpp
@@ -982,7 +982,7 @@ void SonicPiAPI::Stop()
 
 uint32_t SonicPiAPI::MaxWorkspaces() const
 {
-    return 10;
+    return 20;  // was 10
 }
 
 void SonicPiAPI::LoadWorkspaces()

--- a/app/api/src/string_utils.cpp
+++ b/app/api/src/string_utils.cpp
@@ -101,6 +101,26 @@ std::string string_number_name(int i)
         return "eight";
     case 9:
         return "nine";
+    case 10:
+        return "ten";
+    case 11:
+        return "eleven";
+    case 12:
+        return "twelve";
+    case 13:
+        return "thirteen";
+    case 14:
+        return "4teen";
+    case 15:
+        return "fifteen";
+    case 16:
+        return "6teen";
+    case 17:
+        return "7teen";
+    case 18:
+        return "8teen";
+    case 19:
+        return "9teen";
     default:
         assert(false);
         return "";
@@ -148,6 +168,46 @@ uint32_t string_number_from_name(const std::string& name)
     else if (name.find("nine") != std::string::npos)
     {
         return 9;
+    }
+    if (name.find("ten") != std::string::npos)
+    {
+        return 10;
+    }
+    else if (name.find("eleven") != std::string::npos)
+    {
+        return 11;
+    }
+    else if (name.find("twelve") != std::string::npos)
+    {
+        return 12;
+    }
+    else if (name.find("thirteen") != std::string::npos)
+    {
+        return 13;
+    }
+    else if (name.find("4teen") != std::string::npos)
+    {
+        return 14;
+    }
+    else if (name.find("fifteen") != std::string::npos)
+    {
+        return 15;
+    }
+    else if (name.find("6teen") != std::string::npos)
+    {
+        return 16;
+    }
+    else if (name.find("7teen") != std::string::npos)
+    {
+        return 17;
+    }
+    else if (name.find("8teen") != std::string::npos)
+    {
+        return 18;
+    }
+    else if (name.find("9teen") != std::string::npos)
+    {
+        return 19;
     }
     return 0;
 }

--- a/app/gui/qt/mainwindow.cpp
+++ b/app/gui/qt/mainwindow.cpp
@@ -1656,6 +1656,26 @@ std::string MainWindow::number_name(int i)
         return "eight";
     case 9:
         return "nine";
+    case 10:
+        return "ten";
+    case 11:
+        return "eleven";
+    case 12:
+        return "twelve";
+    case 13:
+        return "thirteen";
+    case 14:
+        return "4teen";
+    case 15:
+        return "fifteen";
+    case 16:
+        return "6teen";
+    case 17:
+        return "7teen";
+    case 18:
+        return "8teen";
+    case 19:
+        return "9teen";
     default:
         assert(false);
         return "";

--- a/app/gui/qt/mainwindow.h
+++ b/app/gui/qt/mainwindow.h
@@ -418,7 +418,7 @@ private:
     QSplashScreen* splash;
 
     bool i18n;
-    static const int workspace_max = 10;
+    static const int workspace_max = 20;  // was 10
     SonicPiScintilla* workspaces[workspace_max];
     QTabWidget* docsNavTabs;
     QTabWidget* southTabs;


### PR DESCRIPTION
# TwentyWorkspaces 

Modifications to increase number of Workspaces from 10 to 20.

Sucessfully built and tested on Windows 11. 

## Why ?

I love live coding in Sonic-Pi but when experimenting with new ideas or having lots of elements to my composition I end up running out of Workspaces and have to use multiple
COMMENT / UNCOMMENT blocks in Workspaces to control whats happening. 

I thought it would be nice to have more than the default 10 Workspaces so I've made a few mods to have 20 Workspaces. 


## Changed files :

.\app\gui\qt\mainwindow.h  
.\app\gui\qt\mainwindow.cpp  
.\app\api\src\sonicpi_api.cpp  
.\app\api\src\string_utils.cpp  

## Result

20 Workspace tabs instead of 10

next/previous keyboard shortcuts  S-M-[ / S-M-]  work  

Each Workspace is saved to \~\\.sonic-pi\store\default\ and reloaded at startup

 \~\\.sonic-pi\store\default\workspace_zero.spi   
 \~\\.sonic-pi\store\default\workspace_one.spi   
 \~\\.sonic-pi\store\default\workspace_two.spi   
 \~\\.sonic-pi\store\default\workspace_three.spi   
 \~\\.sonic-pi\store\default\workspace_four.spi  
 \~\\.sonic-pi\store\default\workspace_five.spi  
 \~\\.sonic-pi\store\default\workspace_six.spi   
 \~\\.sonic-pi\store\default\workspace_seven.spi  
 \~\\.sonic-pi\store\default\workspace_eight.spi  
 \~\\.sonic-pi\store\default\workspace_nine.spi  
 \~\\.sonic-pi\store\default\workspace_ten.spi  
 \~\\.sonic-pi\store\default\workspace_eleven.spi  
 \~\\.sonic-pi\store\default\workspace_twelve.spi   
 \~\\.sonic-pi\store\default\workspace_thirteen.spi   
 \~\\.sonic-pi\store\default\workspace_4teen.spi  
 \~\\.sonic-pi\store\default\workspace_fifteen.spi  
 \~\\.sonic-pi\store\default\workspace_6teen.spi  
 \~\\.sonic-pi\store\default\workspace_7teen.spi  
 \~\\.sonic-pi\store\default\workspace_8teen.spi  
 \~\\.sonic-pi\store\default\workspace_9teen.spi  

* Note the names had to be chosen to avoid incorrect number/name matching
* i.e. workspace 14 as fourteen, workspace 4 would match four and fourteen

## Future improvements : 

The way the number of Workspaces and their naming is implemented isn't ideal and could be improved by having the maximum number defined in one place in a single header file.  

The functions/methods to generate the Workspace file name from the Workspace number and from name to number could be done in one place in one source file and be able to uniquely name the file for any sensible number.    

### ToDo:
  
1. change Workspace number/name conversion to work for any number creating a unique name match.  
2. make the number of Workspaces configurable in Preferences  
