### PR TITLE
Correct core.rb bug

### DIFF
--- a/app/server/ruby/lib/sonicpi/lang/core.rb
+++ b/app/server/ruby/lib/sonicpi/lang/core.rb
@@ -5115,7 +5115,7 @@ load_buffer \"~/sonic-pi-tracks/phat-beats.rb\" # will replace content of curren
         raise IOError, "Error - no example found with name: #{example_name.inspect}" unless path
         buf = __current_job_info[:workspace]
         __info "loading #{buf} with #{path}"
-        title = example_name.titleize
+        title = example_name.to_s.titleize
         __replace_buffer(buf, "# #{title}\n" + File.read(path))
       end
       doc name:           :load_example,


### PR DESCRIPTION
titleize method generates an error working on a symbol for the example_name. Checked on both Mac and Linux build. Solution insert .to_s Not sure why this error is occurring now, but it is there for builds at #916d4ea on both Linux (Pi) and Mac