### PR TITLE
Fix: Potential Vulnerability in Cloned Function

### DIFF
--- a/app/server/ruby/vendor/rugged-1.9.0/vendor/libgit2/src/libgit2/checkout.c
+++ b/app/server/ruby/vendor/rugged-1.9.0/vendor/libgit2/src/libgit2/checkout.c
@@ -1290,7 +1290,7 @@ static int checkout_verify_paths(
 	int action,
 	git_diff_delta *delta)
 {
-	unsigned int flags = GIT_PATH_REJECT_WORKDIR_DEFAULTS;
+	unsigned int flags = GIT_PATH_REJECT_WORKDIR_DEFAULTS | GIT_PATH_REJECT_DOT_GIT_NTFS;
 
 	if (action & CHECKOUT_ACTION__REMOVE) {
 		if (!git_path_is_valid(repo, delta->old_file.path, delta->old_file.mode, flags)) {


### PR DESCRIPTION
**Description**
This PR fixes a security vulnerability in checkout_verify_paths() that was cloned from libgit2 but did not receive the security patch. The original issue was reported and fixed under https://github.com/libgit2/libgit2/commit/64c612cc3e25eff5fb02c59ef5a66ba7a14751e4.
This PR applies the same patch to eliminate the vulnerability.

**References**
https://nvd.nist.gov/vuln/detail/CVE-2020-12279
https://github.com/libgit2/libgit2/commit/64c612cc3e25eff5fb02c59ef5a66ba7a14751e4
