### PR TITLE
calculate_sustain now respects default attack, decay, and release

### DIFF
--- a/app/server/ruby/lib/sonicpi/lang/sound.rb
+++ b/app/server/ruby/lib/sonicpi/lang/sound.rb
@@ -3705,11 +3705,11 @@ If you wish your synth to work with Sonic Pi's automatic stereo sound infrastruc
         args_h["out_bus"] = out_bus.to_i
       end
 
-      def calculate_sustain!(args)
+      def calculate_sustain!(args, defaults)
         if args.has_key? :duration and not(args.has_key? :sustain)
-          attack = args.fetch(:attack, 0)
-          decay = args.fetch(:decay, 0)
-          release = args.fetch(:release, 0)
+          attack = args.fetch(:attack, defaults.fetch(:attack, 0))
+          decay = args.fetch(:decay, defaults.fetch(:decay, 0))
+          release = args.fetch(:release, defaults.fetch(:release, 0))
           duration = args[:duration]
 
           sustain = duration - (attack + decay + release)
@@ -3848,7 +3848,7 @@ If you wish your synth to work with Sonic Pi's automatic stereo sound infrastruc
         end
 
         normalise_args!(args_h, defaults)
-        calculate_sustain!(args_h)
+        calculate_sustain!(args_h, defaults)
         scale_time_args_to_bpm!(args_h, info, true) if info && __thread_locals.get(:sonic_pi_spider_arg_bpm_scaling)
 
         args_h

--- a/app/server/ruby/lib/sonicpi/lang/sound.rb
+++ b/app/server/ruby/lib/sonicpi/lang/sound.rb
@@ -1305,50 +1305,50 @@ play_pattern_timed [40, 42, 44], [1, 2, 3]
 
 # same as:
 
-play 40, sustain: 1
+play 40, duration: 1
 sleep 1
-play 42, sustain: 2
+play 42, duration: 2
 sleep 2
-play 44, sustain: 3
+play 44, duration: 3
 sleep 3",
 
         "play_pattern_timed [40, 42, 44, 46, 49], [1, 0.5]
 
 # same as:
 
-play 40, sustain: 1
+play 40, duration: 1
 sleep 1
-play 42, sustain: 0.5
+play 42, duration: 0.5
 sleep 0.5
-play 44, sustain: 1
+play 44, duration: 1
 sleep 1
-play 46, sustain: 0.5
+play 46, duration: 0.5
 sleep 0.5
-play 49, sustain: 1
+play 49, duration: 1
 sleep 1",
 
         "play_pattern_timed [40, 42, 44, 46], [0.5]
 
 # same as:
 
-play 40, sustain: 0.5
+play 40, duration: 0.5
 sleep 0.5
-play 42, sustain: 0.5
+play 42, duration: 0.5
 sleep 0.5
-play 44, sustain: 0.5
+play 44, duration: 0.5
 sleep 0.5
-play 46, sustain: 0.5
+play 46, duration: 0.5
 sleep 0.5",
 
         "play_pattern_timed [40, 42, 44], [1, 2, 3, 4, 5]
 
 # same as:
 
-play 40, sustain: 1
+play 40, duration: 1
 sleep 1
-play 42, sustain: 2
+play 42, duration: 2
 sleep 2
-play 44, sustain: 3
+play 44, duration: 3
 sleep 3",
 
         "play_pattern_timed [40, 42, 44], [1, 2, 3], sustain: 0


### PR DESCRIPTION
The following four notes should all be played with `attack: 0, decay: 0, sustain: 0, release: 1`.

```
play :c
sleep 1

play :c, attack: 0, decay: 0, sustain: 0, release: 1
sleep 1

play :c, attack: 0, decay: 0, duration: 1, release: 1
sleep 1

play :c, duration: 1
sleep 1
```

The first three correctly release over one beat, as expected, but the last one plays over two beats with `attack: 0, decay: 0, sustain: 1, release: 1`. This is because the `sustain` value calculated in `calculate_sustain!` only takes into account explicit arguments and thread-local defaults, ignoring the defaults for the underlying synth. After `calculate_sustain!` converts `duration: 1` into `sustain: 1` (incorrectly assuming `attack: 0, decay: 0, release: 0`), the default `release: 1` is applied, resulting in a note that lasts two beats.

This is easily fixed by passing the `defaults` variable into `calculate_sustain!`, where it can be queried for `attack`, `decay`, and `release` values that are not specified in the explicit arguments `args`. With this change, all four notes above sound the same, as expected. Note that this will result in a user-visible change to the way a piece plays, but only if they do not specify `release`, either using an explicit argument or something like the thread-local `use_synth_defaults`.

I noticed this as I was trying to understand why `play_pattern_timed` without a `release` argument produces so much overlap, so it's worth noting that this change carries through to something like

```
play_pattern_timed [:c, :c, :g, :g, :a, :a, :g], [1,1,1,1, 1,1,2]
```

With this change, there is no longer an extra beat of overlap between the notes, so it now sounds identical to the following, as expected:

```
play_pattern_timed [:c, :c, :g, :g, :a, :a, :g], [1,1,1,1, 1,1,2], release: 1
```

Finally, the examples in the documentation for `play_pattern_timed` should also say that it's equivalent to setting `duration` for each note played, not `sustain` directly. This was true before and after my change.

Thanks to all of you for your amazing work on this project!