### PR TITLE
introduced run_count var

### DIFF
--- a/app/server/ruby/lib/sonicpi/runtime.rb
+++ b/app/server/ruby/lib/sonicpi/runtime.rb
@@ -548,6 +548,7 @@ module SonicPi
 
     def __stop_jobs
       __info "Stopping all runs..."
+      @run_count = 0
       @user_jobs.each_id do |id|
         __stop_job id
       end
@@ -941,6 +942,10 @@ module SonicPi
           __set_default_user_thread_locals!
           __msg_queue.push({type: :job, jobid: id, action: :start, jobinfo: info})
           @life_hooks.init(id, {:thread => Thread.current})
+          # run_count is a counter showing how many runs have happened after last stop.
+          # it is available for user code and enables writing code that depends on it.
+          @run_count = @run_count ? @run_count + 1 : 0
+          run_count = @run_count
 
           ## fix this for link
           __init_spider_time_and_beat!


### PR DESCRIPTION
This PR introduces a `run_count` var that shows how many reruns (Alt+r) have happends after full stop (Alt+s). This var is available for user code which can use its value (distinguishing between run_count == 1 - first run and runt_count >1 - subsequent runs).

Example:

```ruby
live_loop :control_loop do
  print run_count
  sleep 1
end
```

One application of this is to be able to "control effects dynamically", as discussed in [this thread](https://in-thread.sonic-pi.net/t/help-needed-controllable-master-fx-in-sonic-pi/9922) and is based on the idea of a workaround proposed [here](https://in-thread.sonic-pi.net/t/question-about-control-keyword/357/2).

With `run_count` available, the problem of controlling FX is solved as follows

```ruby
#experimenting with changing cutoff using a single command line
#by Robin Newman

set :st,sample_duration(:loop_amen) #store duration of the sample

with_fx :rlpf, cutoff: 120 do |c|
  
  # This is the original workaround:
  # set :cv,c #comment after first run from stop, before re-run
  
  # This is how how we do it with `run_count`, no need to comment the code!
  set :cv,c if run_count == 1
  
  control get(:cv),cutoff: 120,cutoff_slide: get(:st)
  #                        ^^^
  #               change this number and hit Alt+r
  #                you will hear the changes
  
  live_loop :loop do
    print run_count
    st=get(:st)
    sample :loop_amen
    sleep st
  end
end
```

