### PR TITLE
REPL - fix daemon port parsing

### DIFF
--- a/app/server/ruby/bin/daemon.rb
+++ b/app/server/ruby/bin/daemon.rb
@@ -19,6 +19,11 @@ require 'fileutils'
 require 'time'
 require 'securerandom'
 
+# All dependencies are vendored. Unset gem environment variables that
+# may conflict and produce warnings on stdout, breaking port parsing.
+ENV.delete("GEM_PATH")
+ENV.delete("GEM_HOME")
+
 require_relative "../lib/sonicpi/osc/osc"
 require_relative "../lib/sonicpi/promise"
 

--- a/app/server/ruby/bin/repl.rb
+++ b/app/server/ruby/bin/repl.rb
@@ -19,7 +19,10 @@ module SonicPi
       @supercollider_started_prom = Promise.new
       @print_monitor = Monitor.new
 
-      daemon_stdin, daemon_stdout_and_err, daemon_wait_thr = Open3.popen2e Paths.ruby_path, Paths.daemon_path
+      # Clear gem environment for the daemon subprocess to prevent host
+      # gem warnings from polluting the stdout port protocol.
+      daemon_env = {"GEM_PATH" => nil, "GEM_HOME" => nil}
+      daemon_stdin, daemon_stdout_and_err, daemon_wait_thr = Open3.popen2e(daemon_env, Paths.ruby_path, Paths.daemon_path)
 
       force_puts "-- Sonic Pi Daemon started with PID: #{daemon_wait_thr.pid}"
       force_puts "-- Log files are located at: #{Paths.log_path}"


### PR DESCRIPTION
## Summary

- Clear `GEM_PATH` and `GEM_HOME` when spawning the daemon to prevent Ruby gem warnings from corrupting the stdout port protocol
- Also clear them at the top of `daemon.rb` to protect the GUI launch path (e.g. if set via `launchctl setenv`)

## Motivation

When a Ruby version manager (chruby, rbenv, rvm) or system-wide env config sets `GEM_PATH`/`GEM_HOME`, the daemon's Ruby process prints "Ignoring ... because its extensions are not built" warnings on startup. Since `popen2e` merges stdout and stderr, these warnings become the first line read by the port parser, causing all ports to resolve to 0 and crashing with `Errno::EADDRNOTAVAIL`.

This likely affects some of the reported "GUI unable to connect" issues as well (#3371, #3340, #3270).

## Before / After

**Before:** REPL crashes with `Can't assign requested address - connect(2) for "localhost" port 0` when any Ruby version manager is active.

**After:** Daemon and REPL boot cleanly regardless of host gem environment.

## Test plan

- Set `GEM_HOME` and `GEM_PATH` to a directory with gems built for a different Ruby version
- Run `repl.rb` — should boot and reach the `>>` prompt
- Unset the env vars and run again — should still boot (no regression)