### PR TITLE
GUI - Add a preference to prevent display sleep on macOS

### DIFF
--- a/app/gui/mainwindow.cpp
+++ b/app/gui/mainwindow.cpp
@@ -94,6 +94,7 @@ using namespace oscpkt; // OSC specific stuff
 #include <QtConcurrent/QtConcurrentRun>
 #elif defined(Q_OS_MAC)
 #include <QtConcurrent/QtConcurrentRun>
+#include "platform/macos.h"
 #else
 // assuming Raspberry Pi
 #include <QtConcurrentRun>
@@ -256,6 +257,9 @@ MainWindow::MainWindow(QApplication& app, QSplashScreen* splash)
         std::cout << "[GUI] - full screen" << std::endl;
 
         updateFullScreenMode();
+#ifdef Q_OS_MAC
+        updatePreventSleep((int)piSettings->prevent_sleep);
+#endif
 
         updateColourTheme();
         std::cout << "[GUI] - load workspaces" << std::endl;
@@ -471,6 +475,9 @@ void MainWindow::setupWindowStructure()
     connect(settingsWidget, SIGNAL(showMetroChanged()), this, SLOT(updateMetroVisibility()));
     connect(settingsWidget, SIGNAL(showButtonsChanged()), this, SLOT(updateButtonVisibility()));
     connect(settingsWidget, SIGNAL(showFullscreenChanged()), this, SLOT(updateFullScreenMode()));
+#ifdef Q_OS_MAC
+    connect(settingsWidget, SIGNAL(preventSleepChanged(int)), this, SLOT(updatePreventSleep(int)));
+#endif
     connect(settingsWidget, SIGNAL(showTabsChanged()), this, SLOT(updateTabsVisibility()));
     connect(settingsWidget, SIGNAL(logAutoScrollChanged()), this, SLOT(updateLogAutoScroll()));
     connect(settingsWidget, SIGNAL(themeChanged()), this, SLOT(updateColourTheme()));
@@ -926,6 +933,26 @@ void MainWindow::updateFullScreenMode()
     this->show();
 }
 
+#ifdef Q_OS_MAC
+void MainWindow::updatePreventSleep(int setting)
+{
+    piSettings->prevent_sleep = static_cast<SonicPiSettings::PreventSleepSetting>(setting);
+
+    if (piSettings->prevent_sleep == SonicPiSettings::PreventSleepDisabled)
+    {
+        SonicPi::preventMacosDisplaySleep(false);
+    }
+    else if (piSettings->prevent_sleep == SonicPiSettings::PreventSleepAlways)
+    {
+        SonicPi::preventMacosDisplaySleep(true);
+    }
+    else
+    {
+        SonicPi::preventMacosDisplaySleep(isRunningCode);
+    }
+}
+#endif
+
 void MainWindow::toggleFocusMode()
 {
     focusMode = !focusMode;
@@ -969,6 +996,14 @@ void MainWindow::allJobsCompleted()
     // re-enable log text selection
     incomingPane->setTextInteractionFlags(Qt::TextSelectableByMouse);
     outputPane->setTextInteractionFlags(Qt::TextSelectableByMouse);
+
+    isRunningCode = false;
+#ifdef Q_OS_MAC
+    if (piSettings->prevent_sleep == SonicPiSettings::PreventSleepWhilePlaying)
+    {
+        SonicPi::preventMacosDisplaySleep(false);
+    }
+#endif
 }
 
 void MainWindow::toggleLogVisibility()
@@ -2117,6 +2152,14 @@ void MainWindow::runCode()
         showBufferCapacityError();
         return;
     }
+
+    isRunningCode = true;
+#ifdef Q_OS_MAC
+    if (piSettings->prevent_sleep == SonicPiSettings::PreventSleepWhilePlaying)
+    {
+        SonicPi::preventMacosDisplaySleep(true);
+    }
+#endif
 
     statusBar()->showMessage(tr("Running Code..."), 1000);
 }
@@ -4593,6 +4636,11 @@ void MainWindow::readSettings()
     piSettings->audio_buffer_size   = gui_settings->value("prefs/audio-buffer-size", 0).toInt();
     piSettings->check_updates = gui_settings->value("prefs/rp/check-updates", true).toBool();
     piSettings->auto_indent_on_run = gui_settings->value("prefs/auto-indent-on-run", true).toBool();
+#ifdef Q_OS_MAC
+    piSettings->prevent_sleep = static_cast<SonicPiSettings::PreventSleepSetting>(
+        gui_settings->value("prefs/prevent-sleep",
+                            static_cast<int>(SonicPiSettings::PreventSleepDisabled)).toInt());
+#endif
     piSettings->gui_transparency = gui_settings->value("prefs/gui_transparency", 0).toInt();
     piSettings->show_scopes = gui_settings->value("prefs/scope/show-scopes", true).toBool();
     piSettings->show_scope_labels = gui_settings->value("prefs/scope/show-labels", false).toBool();
@@ -4670,6 +4718,9 @@ void MainWindow::writeSettings()
     gui_settings->setValue("prefs/system-vol", piSettings->main_volume);
     gui_settings->setValue("prefs/rp/check-updates", piSettings->check_updates);
     gui_settings->setValue("prefs/auto-indent-on-run", piSettings->auto_indent_on_run);
+#ifdef Q_OS_MAC
+    gui_settings->setValue("prefs/prevent-sleep", static_cast<int>(piSettings->prevent_sleep));
+#endif
     gui_settings->setValue("prefs/gui_transparency", piSettings->gui_transparency);
     gui_settings->setValue("prefs/scope/show-labels", piSettings->show_scope_labels);
     gui_settings->setValue("prefs/scope/show-scopes", piSettings->show_scopes);

--- a/app/gui/mainwindow.h
+++ b/app/gui/mainwindow.h
@@ -371,6 +371,9 @@ private slots:
     void updateButtonVisibility();
     void showButtonsMenuChanged();
     void toggleButtonVisibility();
+#ifdef Q_OS_MAC
+    void updatePreventSleep(int setting);
+#endif
 
     void requestVersion();
     void heartbeatOSC();
@@ -491,6 +494,8 @@ private:
     bool is_recording;
     bool show_rec_icon_a;
     QTimer* rec_flash_timer;
+
+    bool isRunningCode = false;
 
     QSplashScreen* splash;
 

--- a/app/gui/model/settings.h
+++ b/app/gui/model/settings.h
@@ -14,6 +14,15 @@ public:
         AudioAndVideo = 1
     };
 
+#ifdef Q_OS_MAC
+    enum PreventSleepSetting
+    {
+        PreventSleepDisabled = 0,
+        PreventSleepAlways = 1,
+        PreventSleepWhilePlaying = 2
+    };
+#endif
+
     // Audio Settings
     int main_volume;
     bool mixer_invert_stereo;
@@ -51,6 +60,9 @@ public:
     RecordingType recording_type;
     bool spout_show_cursor;
     bool full_screen;
+#ifdef Q_OS_MAC
+    PreventSleepSetting prevent_sleep;
+#endif
     bool goto_buffer_shortcuts;
     bool log_synths;
     bool clear_output_on_run;

--- a/app/gui/platform/macos.h
+++ b/app/gui/platform/macos.h
@@ -22,6 +22,9 @@ namespace SonicPi {
 
 void removeMacosSpecificMenuItems();
 
+// Prevent (or stop preventing) the display from going to sleep.
+void preventMacosDisplaySleep(bool prevent);
+
 // Request microphone access via AVCaptureDevice. Must be called from the
 // GUI/foreground app (not a background helper) or macOS will auto-deny.
 // Returns the current status string ("notDetermined" / "authorized" /

--- a/app/gui/platform/macos.mm
+++ b/app/gui/platform/macos.mm
@@ -15,6 +15,7 @@
 #import <AppKit/NSWindow.h>
 #import <AVFoundation/AVFoundation.h>
 #import <Foundation/Foundation.h>
+#import <IOKit/pwr_mgt/IOPMLib.h>
 #include <libproc.h>
 #include <unistd.h>
 #include <cstdio>
@@ -39,6 +40,43 @@ void removeMacosSpecificMenuItems()
   // menu
 
   [[NSUserDefaults standardUserDefaults] setBool:NO forKey:@"NSFullScreenMenuItemEverywhere"];
+}
+
+void preventMacosDisplaySleep(bool prevent)
+{
+    static IOPMAssertionID assertionID = kIOPMNullAssertionID;
+
+    if (prevent)
+    {
+        if (assertionID != kIOPMNullAssertionID) return;  // Nothing to do
+
+        IOReturn ret = IOPMAssertionCreateWithName(
+                          kIOPMAssertionTypeNoDisplaySleep,
+                          kIOPMAssertionLevelOn,
+                          CFSTR("SonicPi is active"),
+                          &assertionID);
+
+        if (ret != kIOReturnSuccess)
+        {
+            assertionID = kIOPMNullAssertionID;
+            NSLog(@"error creating power assertion: %x", ret);
+        }
+    }
+    else
+    {
+        if (assertionID == kIOPMNullAssertionID) return;  // Nothing to do
+
+        IOReturn ret = IOPMAssertionRelease(assertionID);
+        if (ret != kIOReturnSuccess)
+        {
+            NSLog(@"error releasing power assertion: %x", ret);
+        }
+
+        // It's very unlikely that the release would fail. We may as well null
+        // out the ID unconditionally so the next attempt to create an assertion
+        // will go through.
+        assertionID = kIOPMNullAssertionID;
+    }
 }
 
 std::string requestMicrophoneAccess()

--- a/app/gui/widgets/settingswidget.cpp
+++ b/app/gui/widgets/settingswidget.cpp
@@ -493,6 +493,25 @@ QGroupBox* SettingsWidget::createEditorPrefsTab() {
     auto_indent_on_run = new QCheckBox(tr("Auto-align"));
     auto_indent_on_run->setToolTip(tr("Automatically align code on Enter or Run "));
 
+#ifdef Q_OS_MAC
+    prevent_sleep_combo = new QComboBox();
+    prevent_sleep_combo->addItem(tr("Disabled"));
+    prevent_sleep_combo->addItem(tr("Always"));
+    prevent_sleep_combo->addItem(tr("When playing"));
+    prevent_sleep_combo->setMinimumContentsLength(2);
+    prevent_sleep_combo->setSizeAdjustPolicy(QComboBox::AdjustToMinimumContentsLengthWithIcon);
+    prevent_sleep_combo->setToolTip(tr("Prevent the computer from sleeping"));
+
+    QLabel *prevent_sleep_label = new QLabel;
+    prevent_sleep_label->setText(tr("Prevent sleep"));
+    prevent_sleep_label->setToolTip(tr("Prevent the computer from sleeping"));
+
+    QGridLayout *prevent_sleep_layout = new QGridLayout();
+
+    prevent_sleep_layout->addWidget(prevent_sleep_label, 0, 0);
+    prevent_sleep_layout->addWidget(prevent_sleep_combo, 0, 1);
+#endif
+
     show_line_numbers = new QCheckBox(tr("Show line numbers"));
     show_line_numbers->setToolTip(tr("Toggle line number visibility."));
 
@@ -578,6 +597,9 @@ QGroupBox* SettingsWidget::createEditorPrefsTab() {
 
     automation_box_layout->addWidget(auto_indent_on_run);
     automation_box_layout->addWidget(full_screen);
+#ifdef Q_OS_MAC
+    automation_box_layout->addLayout(prevent_sleep_layout);
+#endif
 
     automation_box->setLayout(automation_box_layout);
 
@@ -1390,6 +1412,12 @@ void SettingsWidget::toggleScope( QObject* qo ) {
   emit scopeChanged(name);
 }
 
+#ifdef Q_OS_MAC
+void SettingsWidget::changePreventSleep(int index) {
+  emit preventSleepChanged(index);
+}
+#endif
+
 
 
 // TODO: Implement real-time language switching
@@ -2102,6 +2130,10 @@ void SettingsWidget::updateSettings() {
     piSettings->show_buttons = show_buttons->isChecked();
     piSettings->show_tabs = show_tabs->isChecked();
     piSettings->full_screen = full_screen->isChecked();
+#ifdef Q_OS_MAC
+    piSettings->prevent_sleep = static_cast<SonicPiSettings::PreventSleepSetting>(
+        prevent_sleep_combo->currentIndex());
+#endif
     piSettings->log_synths = log_synths->isChecked();
     piSettings->clear_output_on_run = clear_output_on_run->isChecked();
     piSettings->log_cues = log_cues->isChecked();
@@ -2161,6 +2193,9 @@ void SettingsWidget::settingsChanged() {
     show_buttons->setChecked(piSettings->show_buttons);
     show_tabs->setChecked(piSettings->show_tabs);
     full_screen->setChecked(piSettings->full_screen);
+#ifdef Q_OS_MAC
+    prevent_sleep_combo->setCurrentIndex(static_cast<int>(piSettings->prevent_sleep));
+#endif
     log_synths->setChecked(piSettings->log_synths);
     clear_output_on_run->setChecked(piSettings->clear_output_on_run);
     log_cues->setChecked(piSettings->log_cues);
@@ -2224,6 +2259,9 @@ void SettingsWidget::connectAll() {
     connect(show_buttons, SIGNAL(clicked()), this, SLOT(updateSettings()));
     connect(show_tabs, SIGNAL(clicked()), this, SLOT(updateSettings()));
     connect(full_screen, SIGNAL(clicked()), this, SLOT(updateSettings()));
+#ifdef Q_OS_MAC
+    connect(prevent_sleep_combo, SIGNAL(currentIndexChanged(int)), this, SLOT(changePreventSleep(int)));
+#endif
     connect(log_synths, SIGNAL(clicked()), this, SLOT(updateSettings()));
     connect(clear_output_on_run, SIGNAL(clicked()), this, SLOT(updateSettings()));
     connect(log_cues, SIGNAL(clicked()), this, SLOT(updateSettings()));

--- a/app/gui/widgets/settingswidget.h
+++ b/app/gui/widgets/settingswidget.h
@@ -101,6 +101,9 @@ private slots:
     void logSynths();
     void clearOutputOnRun();
     void autoIndentOnRun();
+#ifdef Q_OS_MAC
+    void changePreventSleep(int index);
+#endif
     void showDebugLogPanel();
 #if defined(Q_OS_MAC) || defined(Q_OS_WIN)
     void recordingTypeChanged(int index);
@@ -148,6 +151,9 @@ signals:
     void logSynthsChanged();
     void clearOutputOnRunChanged();
     void autoIndentOnRunChanged();
+#ifdef Q_OS_MAC
+    void preventSleepChanged(int setting);
+#endif
     void showDebugLogPanelChanged();
 #if defined(Q_OS_MAC) || defined(Q_OS_WIN)
     // Recording → Type radio toggled. MainWindow::setRecordingMode
@@ -213,6 +219,9 @@ private:
     QCheckBox *show_line_numbers;
     QCheckBox *auto_indent_on_run;
     QCheckBox *full_screen;
+#ifdef Q_OS_MAC
+    QComboBox *prevent_sleep_combo;
+#endif
     QCheckBox* goto_buffer_shortcuts;
     QCheckBox *show_log;
     QCheckBox *show_cues;


### PR DESCRIPTION
I'm probably an outlier, but I often use Sonic Pi with a MIDI controller and don't actually touch my computer very often. I've been carrying this patch locally for a while.

It doesn't seem like it would be very difficult to implement this for Windows (see [this StackOverflow post for a method](https://stackoverflow.com/a/20996135)), and I assume it would involve dbus on Linux. I don't really have a Windows computer to test it though.