### PR TITLE
Fix toolbar buttons rendering grey: TabColor → tabColor in app.qss

### DIFF
--- a/app/gui/theme/app.qss
+++ b/app/gui/theme/app.qss
@@ -617,7 +617,7 @@ QScrollBar::handle:hover {
 QPushButton
 {
     font-size: medium;
-    background-color: TabColor;
+    background-color: tabColor;
     color: buttonTextColor;
     padding: 5dx;
     border-radius: 3dx;


### PR DESCRIPTION
### Problem

In `app/gui/theme/app.qss`, the `QPushButton` rule sets:

```
background-color: TabColor;
```

with a capital `T`. The theme token substitution only fills the lowercase `tabColor`, so the capitalised token is never replaced — the result is invalid CSS and the toolbar buttons fall back to default grey on **every** theme, not just custom ones.

Confirmed still present on `dev` (line ~620) and in v4.6.0. Every other reference in the same file already uses lowercase `tabColor` (e.g. lines 123, 393, 399, 468), so this is clearly a typo.

### Fix

One-character change:

```diff
 QPushButton
 {
     font-size: medium;
-    background-color: TabColor;
+    background-color: tabColor;
     color: buttonTextColor;
```

The stylesheet is read at runtime, so the fix can be confirmed without a rebuild — toolbar buttons immediately pick up the theme's tab colour.

### Testing

Verified on Linux/arm64 (built from source). Toolbar buttons now render with the correct theme colour across light and dark themes.