### PR TITLE
prefs - give theme-selector pills room for descenders on Linux (#3542)

### DIFF
--- a/app/gui/widgets/settingswidget.cpp
+++ b/app/gui/widgets/settingswidget.cpp
@@ -637,9 +637,9 @@ QGroupBox* SettingsWidget::createEditorPrefsTab() {
         "#themeSegControl { background: rgba(127,127,127,70); border-radius: 7px; }"
         // color: explicit — the global QPushButton rule uses buttonTextColor,
         // which is white-on-light for the Light / High Contrast themes.
-        "#themeSegControl QPushButton { border: none; padding: 5px 16px; border-radius: 5px;"
+        "#themeSegControl QPushButton { border: none; padding: 6px 16px; border-radius: 5px;"
         " background: transparent; color: palette(window-text); text-align: left;"
-        " font-size: medium; min-height: 20px; }"
+        " font-size: medium; min-height: 26px; }"
         "#themeSegControl QPushButton:hover:!checked { background: rgba(127,127,127,70); }"
         "#themeSegControl QPushButton:checked { background: palette(highlight);"
         " color: palette(highlighted-text); }");


### PR DESCRIPTION
Follow-up to #3542 (2ad8bac / 327cc15). Those shrank the theme-selector labels so they nearly fit, but as @rbnpi notes the descenders still clip on Linux — the "g" in **High Contrast** is cut off at the bottom of the pill.

The `#themeSegControl QPushButton` rule in `settingswidget.cpp` uses `min-height: 20px`, which is a touch short for the full glyph box. This bumps it to `min-height: 26px` (and `padding: 5px -> 6px`) so descenders have room, without visibly enlarging the control.

Confirmed on a Linux/arm64 build (5.0b3+): full glyphs visible across all themes including High Contrast.
